### PR TITLE
[ledd] Exit with code 0 if we fail to find a platform-specific led_control module

### DIFF
--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -189,7 +189,7 @@ def main():
     # Load platform-specific LedControl module
     led_control = load_platform_led_control_module()
     if led_control is None:
-        sys.exit(1)
+        sys.exit(0)
 
     # Open a handle to the Application database
     appl_db = swsscommon.DBConnector(swsscommon.APPL_DB,


### PR DESCRIPTION
Not all platforms rely on ledd to control front-panel LEDs. These platforms purposefully do not provide a led_control.py plugin. Currently, ledd is started unconditionally, therefore it should not exit with a non-zero exit code if it fails to find a platform-specific led_control.py plugin.

However, ledd will log a message to syslog before exiting, thus we will be able to trace down an unexpected missing led_control.py file if the situation ever arises.