### PR TITLE
[ledd] Use select() with timeout for AppDB notifications

### DIFF
--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -50,6 +50,8 @@ REDIS_HOSTNAME = "localhost"
 REDIS_PORT = 6379
 REDIS_TIMEOUT_USECS = 0
 
+SELECT_TIMEOUT = 1000
+
 #========================== Syslog wrappers ==========================
 
 def log_info(msg):
@@ -204,9 +206,10 @@ def main():
 
     # Listen indefinitely for changes to the PORT table in the Application DB
     while True:
-        (state, c) = sel.select()
+        (state, c) = sel.select(SELECT_TIMEOUT)
         if state != swsscommon.Select.OBJECT:
-            log_warning("sel.select() did not return swsscommon.Select.OBJECT")
+            if state != swsscommon.Select.TIMEOUT:
+                log_warning("sel.select() did not return swsscommon.Select.OBJECT")
             continue
 
         (key, op, fvp) = sst.pop()


### PR DESCRIPTION
Overwise ledd ignores signals other than SIGKILL making impossible to
use __del__() destructors in LedClass implementations and delays pmon
docker container shutdown up to 10s.

Here is output from /var/log/supervisor/supervisord.log after
"systemctl stop pmon":

  2018-05-26 10:40:36,323 WARN received SIGTERM indicating exit request
  2018-05-26 10:40:36,323 INFO waiting for rsyslogd, ledd to die
  2018-05-26 10:40:39,327 INFO waiting for rsyslogd, ledd to die
  2018-05-26 10:40:42,330 INFO waiting for rsyslogd, ledd to die
  2018-05-26 10:40:45,335 INFO waiting for rsyslogd, ledd to die

Note that according to docker-stop(1) default time to wait before retry
with KILL signal is 10s.

Steps to reproduce:

  # docker exec -ti pmon bash

  # kill -TERM $(pgrep ledd)
  # kill -INT $(pgrep ledd)

  # kill -0 $(pgrep ledd) && echo 'alive'
  alive

  # kill -KILL $(pgrep ledd)

Process survives TERM and INT signals, and killed only in 5) by KILL.

Other C++ code already uses SELECT_TIMEOUT = 1000 to return control
into main loop and checks for state.

Signed-off-by: Sergey Popovich <sergey.popovich@ordnance.co>