### PR TITLE
[Event listener] Add a new supervisord event listener to pmon container

### DIFF
--- a/sonic-event-listener/scripts/event-listener
+++ b/sonic-event-listener/scripts/event-listener
@@ -1,0 +1,49 @@
+#!/usr/bin/env python2
+
+'''
+    event-listener
+    Supervisord event listener for SONiC pmon container
+    This event listener will monitor the 'SUPERVISOR_STATE_CHANGE_STOPPING' event of supervisord when it is shutting down.
+    On this event, event listener will call command 'post-syseeprom -c' to clear the state DB.
+'''
+
+try:
+    import sys
+    import subprocess
+    from supervisor.childutils import listener
+except ImportError, e:
+    raise ImportError (str(e) + " - required module not found")
+
+EVENT_TO_LISTEN = 'SUPERVISOR_STATE_CHANGE_STOPPING'
+COMMAND_ON_EVENT = 'post-syseeprom -c'
+
+def write_log(s):
+    sys.stderr.write(s)
+    sys.stderr.flush()
+
+class EventListener:
+    def __init__(self, event, command_string):
+        self.event = event
+        self.command = (command_string.strip()).split()
+
+    def run(self):
+        write_log("Event-listener start up...\n")
+
+        while True:
+            headers, body = listener.wait()
+            if headers["eventname"] == self.event:
+                subprocess.call(self.command)
+                write_log("Event-listener process docker stopping... \n")
+                listener.ok(sys.stdout)
+                break
+
+            listener.ok(sys.stdout)
+
+        write_log("Event-listener shutting down...\n")
+
+def main():
+    event_listener = EventListener(EVENT_TO_LISTEN, COMMAND_ON_EVENT)
+    event_listener.run()
+
+if __name__ == '__main__':
+    main()

--- a/sonic-event-listener/setup.py
+++ b/sonic-event-listener/setup.py
@@ -1,0 +1,29 @@
+from setuptools import setup
+
+setup(
+    name='sonic-event-listener',
+    version='1.0',
+    description='Sonic pmon supervisord event listener ',
+    license='Apache 2.0',
+    author='SONiC Team',
+    author_email='linuxnetdev@microsoft.com',
+    url='https://github.com/Azure/sonic-platform-daemons',
+    maintainer='Kebo Liu',
+    maintainer_email='kebol@mellanox.com',
+    scripts=[
+        'scripts/event-listener',
+    ],
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Environment :: No Input/Output (Daemon)',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Information Technology',
+        'Intended Audience :: System Administrators',
+        'License :: OSI Approved :: Apache Software License',
+        'Natural Language :: English',
+        'Operating System :: POSIX :: Linux',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: System :: Supervisord',
+    ],
+    keywords='sonic SONiC SUPERVISORD supervisord EVENT-LISTENER event-listener',
+)


### PR DESCRIPTION
Event-listener: Add a new supervisord event listener to pmon container to clear the state DB  when pmon was shut down.

* This event listener will monitor the 'SUPERVISOR_STATE_CHANGE_STOPPING' event of supervisord when it is shutting down.   On this event, the event listener will call command 'post-syseeprom -c' to clear the state DB.

Signed-off-by: Kebo Liu kebol@mellanox.com