### PR TITLE
sonic_xcvrd: Support for DOM Threshold values for EEPROM dump

### DIFF
--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -216,7 +216,7 @@ def post_port_dom_threshold_info_to_db(logical_port_name, table,
         ganged_member_num += 1
 
         try:
-            dom_info_dict = platform_sfputil.get_transceiver_dom_info_dict(physical_port)
+            dom_info_dict = platform_sfputil.get_transceiver_dom_threshold_info_dict(physical_port)
             if dom_info_dict is not None:
                 beautify_dom_threshold_info_dict(dom_info_dict)
                 fvs = swsscommon.FieldValuePairs(
@@ -276,7 +276,6 @@ def post_port_dom_info_to_db(logical_port_name, table, stop=threading.Event()):
             dom_info_dict = platform_sfputil.get_transceiver_dom_info_dict(physical_port)
             if dom_info_dict is not None:
                 beautify_dom_info_dict(dom_info_dict)
-                beautify_dom_threshold_info_dict(dom_info_dict)
                 fvs = swsscommon.FieldValuePairs(
                         [('temperature', dom_info_dict['temperature']),
                          ('voltage', dom_info_dict['voltage']),

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -291,23 +291,7 @@ def post_port_dom_info_to_db(logical_port_name, table, stop=threading.Event()):
                          ('tx1power', dom_info_dict['tx1power']),
                          ('tx2power', dom_info_dict['tx2power']),
                          ('tx3power', dom_info_dict['tx3power']),
-                         ('tx4power', dom_info_dict['tx4power']),
-                         ('temphighalarm', dom_info_dict['temphighalarm']),
-                         ('temphighwarning', dom_info_dict['temphighwarning']),
-                         ('templowalarm', dom_info_dict['templowalarm']),
-                         ('templowwarning', dom_info_dict['templowwarning']),
-                         ('vcchighalarm', dom_info_dict['vcchighalarm']),
-                         ('vcchighwarning', dom_info_dict['vcchighwarning']),
-                         ('vcclowalarm', dom_info_dict['vcclowalarm']),
-                         ('vcclowwarning', dom_info_dict['vcclowwarning']),
-                         ('rxpowerhighalarm', dom_info_dict['rxpowerhighalarm']),
-                         ('rxpowerlowalarm', dom_info_dict['rxpowerlowalarm']),
-                         ('rxpowerhighwarning', dom_info_dict['rxpowerhighwarning']),
-                         ('rxpowerlowwarning', dom_info_dict['rxpowerlowwarning']),
-                         ('txbiashighalarm', dom_info_dict['txbiashighalarm']),
-                         ('txbiaslowalarm', dom_info_dict['txbiaslowalarm']),
-                         ('txbiashighwarning', dom_info_dict['txbiashighwarning']),
-                         ('txbiaslowwarning', dom_info_dict['txbiaslowwarning'])
+                         ('tx4power', dom_info_dict['tx4power'])
                         ])
 
                 table.set(port_name, fvs)

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -107,6 +107,27 @@ def beautify_dom_info_dict(dom_info_dict):
     dom_info_dict['tx3power'] = strip_unit_and_beautify(dom_info_dict['tx3power'], POWER_UNIT)
     dom_info_dict['tx4power'] = strip_unit_and_beautify(dom_info_dict['tx4power'], POWER_UNIT)
 
+def beautify_dom_threshold_info_dict(dom_info_dict):
+    dom_info_dict['temphighalarm'] = strip_unit_and_beautify(dom_info_dict['temphighalarm'], TEMP_UNIT)
+    dom_info_dict['temphighwarning'] = strip_unit_and_beautify(dom_info_dict['temphighwarning'], TEMP_UNIT)
+    dom_info_dict['templowalarm'] = strip_unit_and_beautify(dom_info_dict['templowalarm'], TEMP_UNIT)
+    dom_info_dict['templowwarning'] = strip_unit_and_beautify(dom_info_dict['templowwarning'], TEMP_UNIT)
+
+    dom_info_dict['vcchighalarm'] = strip_unit_and_beautify(dom_info_dict['vcchighalarm'], VOLT_UNIT)
+    dom_info_dict['vcchighwarning'] = strip_unit_and_beautify(dom_info_dict['vcchighwarning'], VOLT_UNIT)
+    dom_info_dict['vcclowalarm'] = strip_unit_and_beautify(dom_info_dict['vcclowalarm'], VOLT_UNIT)
+    dom_info_dict['vcclowwarning'] = strip_unit_and_beautify(dom_info_dict['vcclowwarning'], VOLT_UNIT)
+
+    dom_info_dict['rxpowerhighalarm'] = strip_unit_and_beautify(dom_info_dict['rxpowerhighalarm'], POWER_UNIT)
+    dom_info_dict['rxpowerlowalarm'] = strip_unit_and_beautify(dom_info_dict['rxpowerlowalarm'], POWER_UNIT)
+    dom_info_dict['rxpowerhighwarning'] = strip_unit_and_beautify(dom_info_dict['rxpowerhighwarning'], POWER_UNIT)
+    dom_info_dict['rxpowerlowwarning'] = strip_unit_and_beautify(dom_info_dict['rxpowerlowwarning'], POWER_UNIT)
+
+    dom_info_dict['txbiashighalarm'] = strip_unit_and_beautify(dom_info_dict['txbiashighalarm'], BIAS_UNIT)
+    dom_info_dict['txbiaslowalarm'] = strip_unit_and_beautify(dom_info_dict['txbiaslowalarm'], BIAS_UNIT)
+    dom_info_dict['txbiashighwarning'] = strip_unit_and_beautify(dom_info_dict['txbiashighwarning'], BIAS_UNIT)
+    dom_info_dict['txbiaslowwarning'] = strip_unit_and_beautify(dom_info_dict['txbiaslowwarning'], BIAS_UNIT)
+
 # Update port sfp info in db
 def post_port_sfp_info_to_db(logical_port_name, table, stop=threading.Event()):
     ganged_port = False
@@ -183,21 +204,42 @@ def post_port_dom_info_to_db(logical_port_name, table, stop=threading.Event()):
             dom_info_dict = platform_sfputil.get_transceiver_dom_info_dict(physical_port)
             if dom_info_dict is not None:
                 beautify_dom_info_dict(dom_info_dict)
-                fvs = swsscommon.FieldValuePairs([('temperature', dom_info_dict['temperature']),
-                                                  ('voltage', dom_info_dict['voltage']),
-                                                  ('rx1power', dom_info_dict['rx1power']),
-                                                  ('rx2power', dom_info_dict['rx2power']),
-                                                  ('rx3power', dom_info_dict['rx3power']),
-                                                  ('rx4power', dom_info_dict['rx4power']),
-                                                  ('tx1bias', dom_info_dict['tx1bias']),
-                                                  ('tx2bias', dom_info_dict['tx2bias']),
-                                                  ('tx3bias', dom_info_dict['tx3bias']),
-                                                  ('tx4bias', dom_info_dict['tx4bias']),
-                                                  ('tx1power', dom_info_dict['tx1power']),
-                                                  ('tx2power', dom_info_dict['tx2power']),
-                                                  ('tx3power', dom_info_dict['tx3power']),
-                                                  ('tx4power', dom_info_dict['tx4power'])])
+                beautify_dom_threshold_info_dict(dom_info_dict)
+                fvs = swsscommon.FieldValuePairs(
+                        [('temperature', dom_info_dict['temperature']),
+                         ('voltage', dom_info_dict['voltage']),
+                         ('rx1power', dom_info_dict['rx1power']),
+                         ('rx2power', dom_info_dict['rx2power']),
+                         ('rx3power', dom_info_dict['rx3power']),
+                         ('rx4power', dom_info_dict['rx4power']),
+                         ('tx1bias', dom_info_dict['tx1bias']),
+                         ('tx2bias', dom_info_dict['tx2bias']),
+                         ('tx3bias', dom_info_dict['tx3bias']),
+                         ('tx4bias', dom_info_dict['tx4bias']),
+                         ('tx1power', dom_info_dict['tx1power']),
+                         ('tx2power', dom_info_dict['tx2power']),
+                         ('tx3power', dom_info_dict['tx3power']),
+                         ('tx4power', dom_info_dict['tx4power']),
+                         ('temphighalarm', dom_info_dict['temphighalarm']),
+                         ('temphighwarning', dom_info_dict['temphighwarning']),
+                         ('templowalarm', dom_info_dict['templowalarm']),
+                         ('templowwarning', dom_info_dict['templowwarning']),
+                         ('vcchighalarm', dom_info_dict['vcchighalarm']),
+                         ('vcchighwarning', dom_info_dict['vcchighwarning']),
+                         ('vcclowalarm', dom_info_dict['vcclowalarm']),
+                         ('vcclowwarning', dom_info_dict['vcclowwarning']),
+                         ('rxpowerhighalarm', dom_info_dict['rxpowerhighalarm']),
+                         ('rxpowerlowalarm', dom_info_dict['rxpowerlowalarm']),
+                         ('rxpowerhighwarning', dom_info_dict['rxpowerhighwarning']),
+                         ('rxpowerlowwarning', dom_info_dict['rxpowerlowwarning']),
+                         ('txbiashighalarm', dom_info_dict['txbiashighalarm']),
+                         ('txbiaslowalarm', dom_info_dict['txbiaslowalarm']),
+                         ('txbiashighwarning', dom_info_dict['txbiashighwarning']),
+                         ('txbiaslowwarning', dom_info_dict['txbiaslowwarning'])
+                        ])
+
                 table.set(port_name, fvs)
+
             else:
                 return SFP_EEPROM_NOT_READY
 

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -118,6 +118,11 @@ def beautify_dom_threshold_info_dict(dom_info_dict):
     dom_info_dict['vcclowalarm'] = strip_unit_and_beautify(dom_info_dict['vcclowalarm'], VOLT_UNIT)
     dom_info_dict['vcclowwarning'] = strip_unit_and_beautify(dom_info_dict['vcclowwarning'], VOLT_UNIT)
 
+    dom_info_dict['txpowerhighalarm'] = strip_unit_and_beautify(dom_info_dict['txpowerhighalarm'], POWER_UNIT)
+    dom_info_dict['txpowerlowalarm'] = strip_unit_and_beautify(dom_info_dict['txpowerlowalarm'], POWER_UNIT)
+    dom_info_dict['txpowerhighwarning'] = strip_unit_and_beautify(dom_info_dict['txpowerhighwarning'], POWER_UNIT)
+    dom_info_dict['txpowerlowwarning'] = strip_unit_and_beautify(dom_info_dict['txpowerlowwarning'], POWER_UNIT)
+
     dom_info_dict['rxpowerhighalarm'] = strip_unit_and_beautify(dom_info_dict['rxpowerhighalarm'], POWER_UNIT)
     dom_info_dict['rxpowerlowalarm'] = strip_unit_and_beautify(dom_info_dict['rxpowerlowalarm'], POWER_UNIT)
     dom_info_dict['rxpowerhighwarning'] = strip_unit_and_beautify(dom_info_dict['rxpowerhighwarning'], POWER_UNIT)
@@ -169,6 +174,66 @@ def post_port_sfp_info_to_db(logical_port_name, table, stop=threading.Event()):
                                                   ('cable_length',port_info_dict['cable_length']),
                                                   ('specification_compliance',port_info_dict['specification_compliance']),
                                                   ('nominal_bit_rate',port_info_dict['nominal_bit_rate'])])
+                table.set(port_name, fvs)
+            else:
+                return SFP_EEPROM_NOT_READY
+
+        except NotImplementedError:
+            logger.log_error("This functionality is currently not implemented for this platform")
+            sys.exit(NOT_IMPLEMENTED_ERROR)
+
+# Update port dom threshold info in db
+def post_port_dom_threshold_info_to_db(logical_port_name, table,
+                                       stop=threading.Event()):
+    ganged_port = False
+    ganged_member_num = 1
+
+    physical_port_list = logical_port_name_to_physical_port_list(logical_port_name)
+    if physical_port_list is None:
+        logger.log_error("No physical ports found for logical port '%s'"
+                                                           % logical_port_name)
+        return PHYSICAL_PORT_NOT_EXIST
+
+    if len(physical_port_list) > 1:
+        ganged_port = True
+
+    for physical_port in physical_port_list:
+        if stop.is_set():
+            break
+
+        if not platform_sfputil.get_presence(physical_port):
+            continue
+
+        port_name = get_physical_port_name(logical_port_name,
+                                           ganged_member_num, ganged_port)
+        ganged_member_num += 1
+
+        try:
+            dom_info_dict = platform_sfputil.get_transceiver_dom_info_dict(physical_port)
+            if dom_info_dict is not None:
+                beautify_dom_threshold_info_dict(dom_info_dict)
+                fvs = swsscommon.FieldValuePairs(
+                        [('temphighalarm', dom_info_dict['temphighalarm']),
+                         ('temphighwarning', dom_info_dict['temphighwarning']),
+                         ('templowalarm', dom_info_dict['templowalarm']),
+                         ('templowwarning', dom_info_dict['templowwarning']),
+                         ('vcchighalarm', dom_info_dict['vcchighalarm']),
+                         ('vcchighwarning', dom_info_dict['vcchighwarning']),
+                         ('vcclowalarm', dom_info_dict['vcclowalarm']),
+                         ('vcclowwarning', dom_info_dict['vcclowwarning']),
+                         ('txpowerhighalarm', dom_info_dict['txpowerhighalarm']),
+                         ('txpowerlowalarm', dom_info_dict['txpowerlowalarm']),
+                         ('txpowerhighwarning', dom_info_dict['txpowerhighwarning']),
+                         ('txpowerlowwarning', dom_info_dict['txpowerlowwarning']),
+                         ('rxpowerhighalarm', dom_info_dict['rxpowerhighalarm']),
+                         ('rxpowerlowalarm', dom_info_dict['rxpowerlowalarm']),
+                         ('rxpowerhighwarning', dom_info_dict['rxpowerhighwarning']),
+                         ('rxpowerlowwarning', dom_info_dict['rxpowerlowwarning']),
+                         ('txbiashighalarm', dom_info_dict['txbiashighalarm']),
+                         ('txbiaslowalarm', dom_info_dict['txbiaslowalarm']),
+                         ('txbiashighwarning', dom_info_dict['txbiashighwarning']),
+                         ('txbiaslowwarning', dom_info_dict['txbiaslowwarning'])
+                        ])
                 table.set(port_name, fvs)
             else:
                 return SFP_EEPROM_NOT_READY
@@ -262,6 +327,7 @@ def post_port_sfp_dom_info_to_db(stop=threading.Event()):
 
         post_port_sfp_info_to_db(logical_port_name, int_tbl, stop)
         post_port_dom_info_to_db(logical_port_name, dom_tbl, stop)
+        post_port_dom_threshold_info_to_db(logical_port_name, dom_tbl, stop)
 
 # Delete port dom/sfp info from db
 def del_port_sfp_dom_info_from_db(logical_port_name, int_tbl, dom_tbl):
@@ -354,6 +420,7 @@ class sfp_state_update_task:
                                 time.sleep(TIME_FOR_SFP_READY_SECS)
                                 post_port_sfp_info_to_db(logical_port, int_tbl)
                             post_port_dom_info_to_db(logical_port, dom_tbl)
+                            post_port_dom_threshold_info_to_db(logical_port, dom_tbl)
                         elif value == SFP_STATUS_REMOVED:
                             logger.log_info("Got SFP removed event")
                             del_port_sfp_dom_info_from_db(logical_port, int_tbl, dom_tbl)


### PR DESCRIPTION
This change is added to dump ChannelMonitor Threshold and Module Monitor Threshold values as part of DOM EEPROM dump output.

Added code change in sff8436.py,sfputilshow.py, xcvrd,  sfpshow .. etc

Verified the output in following optics

a) AVAGO
b) Finisar
c) DELL

Seeing the following issue of Values not getting dumped properly from day 1

Some channel monitor values are not displayed correctly.
Will raise a seperate issue for that.


Ethernet124: SFP EEPROM detected
        Connector: MPOx12
        Encoding: 64B66B
        Extended Identifier: Power Class 1(1.5W max)
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP+ or later
        Length OM3(2m): 50
        Nominal Bit Rate(100Mbs): 103
        Specification compliance:
                10/40G Ethernet Compliance Code: 40GBASE-SR4
        Vendor Date Code(YYYY-MM-DD Lot): 2010-09-01
        Vendor Name: AVAGO
        Vendor OUI: 00-17-6a
        Vendor PN: AFBR-79E4Z-D
        Vendor Rev: 01
        Vendor SN: QA340092
        ChannelMonitorValues:
                RX1Power: -16.3827dBm
                RX2Power: -infdBm     <<<<<<<<<<<<<<<<<<<<<<
                RX3Power: -15.5284dBm
                RX4Power: -infdBm     <<<<<<<<<<<<<<<<<<<<<<<
                TX1Bias: 5.9720mA
                TX2Bias: 5.3740mA
                TX3Bias: 5.3800mA
                TX4Bias: 6.0540mA
				