### PR TITLE
Add missing import statemet

### DIFF
--- a/sonic-syseepromd/scripts/syseepromd
+++ b/sonic-syseepromd/scripts/syseepromd
@@ -9,6 +9,7 @@
 '''
 
 try:
+    import sys
     import signal
     import threading
     from sonic_daemon_base.daemon_base import DaemonBase


### PR DESCRIPTION
In case of some fail "global name 'sys' is not defined" error logs are more visible then real error message
Example:
```
Jul 23 14:36:31.223795 cab18-2-switch2 INFO pmon#syseepromd: Starting up...
Jul 23 14:36:31.931699 cab18-2-switch2 ERR pmon#syseepromd: Failed to load eeprom utility: Failed to load platform module 'eeprom': [Errno 2] No such file or directory
Jul 23 14:36:31.931929 cab18-2-switch2 INFO pmon#supervisord: syseepromd Failed to load eeprom utility: Failed to load platform module 'eeprom': [Errno 2] No such file or directory
Jul 23 14:36:31.932004 cab18-2-switch2 INFO pmon#supervisord: syseepromd Traceback (most recent call last):
Jul 23 14:36:31.932004 cab18-2-switch2 INFO pmon#supervisord: syseepromd   File "/usr/bin/syseepromd", line 142, in <module>
Jul 23 14:36:31.932034 cab18-2-switch2 INFO pmon#supervisord: syseepromd     main()
Jul 23 14:36:31.932034 cab18-2-switch2 INFO pmon#supervisord: syseepromd   File "/usr/bin/syseepromd", line 139, in main
Jul 23 14:36:31.932048 cab18-2-switch2 INFO pmon#supervisord: syseepromd     syseepromd.run()
Jul 23 14:36:31.932059 cab18-2-switch2 INFO pmon#supervisord: syseepromd   File "/usr/bin/syseepromd", line 107, in run
Jul 23 14:36:31.932065 cab18-2-switch2 INFO pmon#supervisord: syseepromd     self.load_eeprom_util()
Jul 23 14:36:31.932092 cab18-2-switch2 INFO pmon#supervisord: syseepromd   File "/usr/bin/syseepromd", line 55, in load_eeprom_util
Jul 23 14:36:31.932092 cab18-2-switch2 INFO pmon#supervisord: syseepromd     sys.exit(ERR_EEPROMUTIL_LOAD)
Jul 23 14:36:31.932111 cab18-2-switch2 INFO pmon#supervisord: syseepromd NameError: global name 'sys' is not defined
```



Signed-off-by: Myron Sosyak <msosyak@barefootnetworks.com>