### PR TITLE
[xcvrd] Fix transceiver tuning issue

### DIFF
--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -400,7 +400,7 @@ def get_media_val_str_from_dict(media_dict):
             media_str += lane_separator
     return media_str
 
-def get_media_val_str(num_logical_ports, lane_dict):
+def get_media_val_str(num_logical_ports, lane_dict, logical_idx):
     lane_str = "lane"
     logical_media_dict = {}
     num_lanes_on_port = len(lane_dict)
@@ -409,7 +409,7 @@ def get_media_val_str(num_logical_ports, lane_dict):
     # in breakout mode. So fetch the corresponding lanes from the file
     media_val_str = ''
     if (num_logical_ports > 1) and \
-       (num_lanes_on_port > num_logical_ports):
+       (num_lanes_on_port >= num_logical_ports):
         num_lanes_per_logical_port = num_lanes_on_port/num_logical_ports
         start_lane = logical_idx * num_lanes_per_logical_port
 
@@ -470,7 +470,8 @@ def notify_media_setting(logical_port_name, transceiver_dict,
         for media_key in media_dict:
             if type(media_dict[media_key]) is dict:
                 media_val_str = get_media_val_str(num_logical_ports, \
-                                                  media_dict[media_key])
+                                                  media_dict[media_key],
+                                                  logical_idx)
             else:
                 media_val_str = media_dict[media_key]
             fvs[index] = (str(media_key), str(media_val_str))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixing transceiver tuning issue where number of lanes equal to number of logical ports in a port. (Example 40G port with 4 lanes is in 4x10G mode)
**- How I did it**

**- How to verify it**
Define a profile where number of lanes equal to number of logical ports and check if pre-emphasis gets programmed

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Handling transceiver tuning scenario when number of lanes in a port is equal to number of logical ports created
[preemp_ut.txt](https://github.com/Azure/sonic-platform-daemons/files/3478202/preemp_ut.txt)


**- A picture of a cute animal (not mandatory but encouraged)**
