### PR TITLE
[201811 xcvrd] state machine enhancement

### DIFF
--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -472,12 +472,14 @@ def main():
     # Start main loop to listen to the SFP change event.
     # The state migrating sequence:
     # 1. When the system starts, it is in "INIT" state, calling get_transceiver_change_event
-    #    with RETRY_PERIOD_FOR_SYSTEM_READY_MSECS as timeout for as many as RETRY_TIMES_FOR_SYSTEM_READY
-    #    times
+    #    with RETRY_PERIOD_FOR_SYSTEM_READY_MSECS as timeout for before reach RETRY_TIMES_FOR_SYSTEM_READY
+    #    times, otherwise it will transmit to "EXIT" state
     # 2. Once 'system_become_ready' returned, the system enters "SYSTEM_READY" state and starts to monitor
     #    the insertion/removal event of all the SFP modules.
-    #    In this state, receiving any system level event will be treated as an unrecoverable error and cause
-    #    the daemon exit
+    #    In this state, receiving any system level event will be treated as an error and cause transmit to
+    #    "INIT" state
+    # 3. When system back to "INIT" state, it will continue to handle system fail event, and retry until reach
+    #    RETRY_TIMES_FOR_SYSTEM_READY times, otherwise it will transmit to "EXIT" state
 
     # states definition
     # - Initial state: INIT, before received system ready or a normal event
@@ -499,9 +501,9 @@ def main():
     #       - retry < RETRY_TIMES_FOR_SYSTEM_READY
     #             retry ++
     #       - else
-    #             max retry reached, treat as fatal, exit
+    #             max retry reached, treat as fatal, transmit to EXIT
     #     - NORMAL
-    #         Treat as a fatal error, exit
+    #         Treat as an error, transmit to INIT
     # 2. SYSTEM_BECOME_READY
     #     - INIT
     #         transmit to NORMAL
@@ -515,15 +517,23 @@ def main():
     #     - NORMAL
     #         handle the event normally
     # 4. SYSTEM_FAIL
-    #     treat as a fatal error
-    
+    #     - INIT
+    #       - retry < RETRY_TIMES_FOR_SYSTEM_READY
+    #             retry ++
+    #       - else
+    #             max retry reached, treat as fatal, transmit to EXIT
+    #     - NORMAL
+    #         Treat as an error, transmit to INIT
+
+
     # State           event               next state
     # INIT            SYSTEM NOT READY    INIT / EXIT
+    # INIT            SYSTEM FAIL         INIT / EXIT
     # INIT            SYSTEM BECOME READY NORMAL
     # NORMAL          SYSTEM BECOME READY NORMAL
-    # INIT/NORMAL     SYSTEM FAIL         EXIT
+    # NORMAL          SYSTEM FAIL         INIT
     # INIT/NORMAL     NORMAL EVENT        NORMAL
-    # NORMAL          SYSTEM NOT READY    EXIT
+    # NORMAL          SYSTEM NOT READY    INIT
     # EXIT            -
 
     log_info("Start main loop")
@@ -541,7 +551,7 @@ def main():
             if state == STATE_INIT:
                 # system not ready, wait and retry
                 if retry >= RETRY_TIMES_FOR_SYSTEM_READY:
-                    log_error("System failed to get ready in {} secs or received system error. Exiting...".format((RETRY_PERIOD_FOR_SYSTEM_READY_MSECS/1000)*RETRY_TIMES_FOR_SYSTEM_READY))
+                    log_error("System failed to get ready in {} secs. Exiting...".format((RETRY_PERIOD_FOR_SYSTEM_READY_MSECS/1000)*RETRY_TIMES_FOR_SYSTEM_READY))
                     next_state = STATE_EXIT
                 else:
                     retry = retry + 1
@@ -556,8 +566,10 @@ def main():
                     if time_diff < RETRY_PERIOD_FOR_SYSTEM_READY_MSECS/1000:
                         time.sleep(RETRY_PERIOD_FOR_SYSTEM_READY_MSECS/1000 - time_diff)
             elif state == STATE_NORMAL:
-                log_error("Got system_not_ready in normal state, treat as fatal. Exiting...")
-                next_state = STATE_EXIT
+                log_error("Got system_not_ready in normal state, treat as error, transmit to INIT...")
+                next_state = STATE_INIT
+                timeout = RETRY_PERIOD_FOR_SYSTEM_READY_MSECS
+                retry = 0
             else:
                 next_state = STATE_EXIT
         elif event == SYSTEM_BECOME_READY:
@@ -610,10 +622,32 @@ def main():
                             continue
             else:
                 next_state = STATE_EXIT
+
         elif event == SYSTEM_FAIL:
-                # no matter which state current it is, it's fatal
+            if state == STATE_INIT:
+                # Treat as system not ready, wait and retry
+                if retry >= RETRY_TIMES_FOR_SYSTEM_READY:
+                    log_error("System failed to recover in {} secs. Exiting...".format((RETRY_PERIOD_FOR_SYSTEM_READY_MSECS/1000)*RETRY_TIMES_FOR_SYSTEM_READY))
+                    next_state = STATE_EXIT
+                else:
+                    retry = retry + 1
+
+                    # get_transceiver_change_event may return immediately,
+                    # we want the retry expired in expected time period,
+                    # So need to calc the time diff,
+                    # if time diff less that the pre-defined waiting time,
+                    # use sleep() to complete the time.
+                    time_now = time.time()
+                    time_diff = time_now - time_start
+                    if time_diff < RETRY_PERIOD_FOR_SYSTEM_READY_MSECS/1000:
+                        time.sleep(RETRY_PERIOD_FOR_SYSTEM_READY_MSECS/1000 - time_diff)
+            elif state == STATE_NORMAL:
+                log_error("Got system_fail in normal state, treat as error, transmit to INIT...")
+                next_state = STATE_INIT
+                timeout = RETRY_PERIOD_FOR_SYSTEM_READY_MSECS
+                retry = 0
+            else:
                 next_state = STATE_EXIT
-                log_error("Got system_fail event on state {}, exiting".format(state))
         else:
             log_warning("Got unknown event {} on state {}.".format(event, state))
         

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -55,6 +55,9 @@ XCVRD_MAIN_THREAD_SLEEP_MSECS = 60000
 RETRY_TIMES_FOR_SYSTEM_READY = 24
 RETRY_PERIOD_FOR_SYSTEM_READY_MSECS = 5000
 
+RETRY_TIMES_FOR_SYSTEM_FAIL = 24
+RETRY_PERIOD_FOR_SYSTEM_FAIL_MSECS = 5000
+
 SFP_STATUS_INSERTED = '1'
 SFP_STATUS_REMOVED = '0'
 
@@ -380,6 +383,13 @@ def mapping_event_from_change_event(status, port_dict):
 
     return event
 
+def waiting_time_compensation_with_sleep(time_start, time_to_wait):
+    time_now = time.time()
+    time_diff = time_now - time_start
+    if time_diff < time_to_wait:
+        time.sleep(time_to_wait - time_diff)
+
+
 # Timer thread wrapper class to update dom info to DB periodically
 class dom_info_update_task:
     def __init__(self, table):
@@ -561,10 +571,7 @@ def main():
                     # So need to calc the time diff, 
                     # if time diff less that the pre-defined waiting time, 
                     # use sleep() to complete the time.
-                    time_now = time.time()
-                    time_diff = time_now - time_start
-                    if time_diff < RETRY_PERIOD_FOR_SYSTEM_READY_MSECS/1000:
-                        time.sleep(RETRY_PERIOD_FOR_SYSTEM_READY_MSECS/1000 - time_diff)
+                    waiting_time_compensation_with_sleep(time_start, RETRY_PERIOD_FOR_SYSTEM_READY_MSECS/1000)
             elif state == STATE_NORMAL:
                 log_error("Got system_not_ready in normal state, treat as error, transmit to INIT...")
                 next_state = STATE_INIT
@@ -625,26 +632,20 @@ def main():
 
         elif event == SYSTEM_FAIL:
             if state == STATE_INIT:
-                # Treat as system not ready, wait and retry
-                if retry >= RETRY_TIMES_FOR_SYSTEM_READY:
-                    log_error("System failed to recover in {} secs. Exiting...".format((RETRY_PERIOD_FOR_SYSTEM_READY_MSECS/1000)*RETRY_TIMES_FOR_SYSTEM_READY))
+                # To overcome a case that system is only temporarily not available,
+                # when get system fail event will wait and retry for a certain period,  
+                # if system recovered in this period xcvrd will transit to INIT state
+                # and continue run, if can not recover then exit.
+                if retry >= RETRY_TIMES_FOR_SYSTEM_FAIL:
+                    log_error("System failed to recover in {} secs. Exiting...".format((RETRY_PERIOD_FOR_SYSTEM_FAIL_MSECS/1000)*RETRY_TIMES_FOR_SYSTEM_FAIL))
                     next_state = STATE_EXIT
                 else:
-                    retry = retry + 1
-
-                    # get_transceiver_change_event may return immediately,
-                    # we want the retry expired in expected time period,
-                    # So need to calc the time diff,
-                    # if time diff less that the pre-defined waiting time,
-                    # use sleep() to complete the time.
-                    time_now = time.time()
-                    time_diff = time_now - time_start
-                    if time_diff < RETRY_PERIOD_FOR_SYSTEM_READY_MSECS/1000:
-                        time.sleep(RETRY_PERIOD_FOR_SYSTEM_READY_MSECS/1000 - time_diff)
+                    retry = retry + 1                   
+                    waiting_time_compensation_with_sleep(time_start, RETRY_PERIOD_FOR_SYSTEM_FAIL_MSECS/1000)
             elif state == STATE_NORMAL:
                 log_error("Got system_fail in normal state, treat as error, transmit to INIT...")
                 next_state = STATE_INIT
-                timeout = RETRY_PERIOD_FOR_SYSTEM_READY_MSECS
+                timeout = RETRY_PERIOD_FOR_SYSTEM_FAIL_MSECS
                 retry = 0
             else:
                 next_state = STATE_EXIT

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -483,13 +483,13 @@ def main():
     # The state migrating sequence:
     # 1. When the system starts, it is in "INIT" state, calling get_transceiver_change_event
     #    with RETRY_PERIOD_FOR_SYSTEM_READY_MSECS as timeout for before reach RETRY_TIMES_FOR_SYSTEM_READY
-    #    times, otherwise it will transmit to "EXIT" state
+    #    times, otherwise it will transition to "EXIT" state
     # 2. Once 'system_become_ready' returned, the system enters "SYSTEM_READY" state and starts to monitor
     #    the insertion/removal event of all the SFP modules.
-    #    In this state, receiving any system level event will be treated as an error and cause transmit to
+    #    In this state, receiving any system level event will be treated as an error and cause transition to
     #    "INIT" state
     # 3. When system back to "INIT" state, it will continue to handle system fail event, and retry until reach
-    #    RETRY_TIMES_FOR_SYSTEM_READY times, otherwise it will transmit to "EXIT" state
+    #    RETRY_TIMES_FOR_SYSTEM_READY times, otherwise it will transition to "EXIT" state
 
     # states definition
     # - Initial state: INIT, before received system ready or a normal event
@@ -505,24 +505,24 @@ def main():
     #   - timeout returned by sfputil.get_change_event with status = true
     # - SYSTEM_FAIL
     
-    # State transmit:
+    # State transition:
     # 1. SYSTEM_NOT_READY
     #     - INIT
     #       - retry < RETRY_TIMES_FOR_SYSTEM_READY
     #             retry ++
     #       - else
-    #             max retry reached, treat as fatal, transmit to EXIT
+    #             max retry reached, treat as fatal, transition to EXIT
     #     - NORMAL
-    #         Treat as an error, transmit to INIT
+    #         Treat as an error, transition to INIT
     # 2. SYSTEM_BECOME_READY
     #     - INIT
-    #         transmit to NORMAL
+    #         transition to NORMAL
     #     - NORMAL
     #         log the event
     #         nop
     # 3. NORMAL_EVENT
     #     - INIT (for the vendors who don't implement SYSTEM_BECOME_READY)
-    #         transmit to NORMAL
+    #         transition to NORMAL
     #         handle the event normally
     #     - NORMAL
     #         handle the event normally
@@ -531,9 +531,9 @@ def main():
     #       - retry < RETRY_TIMES_FOR_SYSTEM_READY
     #             retry ++
     #       - else
-    #             max retry reached, treat as fatal, transmit to EXIT
+    #             max retry reached, treat as fatal, transition to EXIT
     #     - NORMAL
-    #         Treat as an error, transmit to INIT
+    #         Treat as an error, transition to INIT
 
 
     # State           event               next state
@@ -573,7 +573,7 @@ def main():
                     # use sleep() to complete the time.
                     waiting_time_compensation_with_sleep(time_start, RETRY_PERIOD_FOR_SYSTEM_READY_MSECS/1000)
             elif state == STATE_NORMAL:
-                log_error("Got system_not_ready in normal state, treat as error, transmit to INIT...")
+                log_error("Got system_not_ready in normal state, treat as error, transition to INIT...")
                 next_state = STATE_INIT
                 timeout = RETRY_PERIOD_FOR_SYSTEM_READY_MSECS
                 retry = 0
@@ -582,7 +582,7 @@ def main():
         elif event == SYSTEM_BECOME_READY:
             if state == STATE_INIT:
                 next_state = STATE_NORMAL
-                log_info("Got system_become_ready in init state, transmit to normal state")
+                log_info("Got system_become_ready in init state, transition to normal state")
             elif state == STATE_NORMAL:
                 next_state = STATE_NORMAL
             else:
@@ -596,7 +596,7 @@ def main():
                 # this is the originally logic that handled the transceiver change event
                 # this can be reached in two cases:
                 #   1. the state has been normal before got the event
-                #   2. the state was init and is transmitted to normal after got the event.
+                #   2. the state was init and is transition to normal after got the event.
                 #      this is for the vendors who don't implement "system_not_ready/system_becom_ready" logic
                 for key, value in port_dict.iteritems():
                     logical_port_list = platform_sfputil.get_physical_to_logical(int(key))
@@ -643,7 +643,7 @@ def main():
                     retry = retry + 1                   
                     waiting_time_compensation_with_sleep(time_start, RETRY_PERIOD_FOR_SYSTEM_FAIL_MSECS/1000)
             elif state == STATE_NORMAL:
-                log_error("Got system_fail in normal state, treat as error, transmit to INIT...")
+                log_error("Got system_fail in normal state, treat as error, transition to INIT...")
                 next_state = STATE_INIT
                 timeout = RETRY_PERIOD_FOR_SYSTEM_FAIL_MSECS
                 retry = 0
@@ -653,7 +653,7 @@ def main():
             log_warning("Got unknown event {} on state {}.".format(event, state))
         
         if next_state != state:
-            log_info("State transmitted from {} to {}".format(state, next_state))
+            log_info("State transition from {} to {}".format(state, next_state))
             state = next_state
 
         if next_state == STATE_EXIT:


### PR DESCRIPTION
backport PR https://github.com/Azure/sonic-platform-daemons/pull/44 from master to 201811 branch

Enhance the state machine in order to overcome a possible platform temporarily fail/unavailable case
    
   1. When receiving system_fail event under NORMAL state, it will transmit to INIT instead of exit directly
   2. In INIT state will handle system_fail event as the same as system_not_ready event, try certain times,
       if the system recovered then transmit to NORMAL state again, if not recovered in a certain period, then exit.
    
 the benefit of this change is that when the system has error/failed temporarily,  xcvrd can survive and recover instead of exit directly, make to more tolerance to errors.