### PR TITLE
Update psud

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -40,6 +40,7 @@ PSU_INFO_PRESENCE_FIELD = 'presence'
 PSU_INFO_STATUS_FIELD = 'status'
 
 PSU_INFO_UPDATE_PERIOD_SECS = 3
+PSU_MAX = 10
 
 PSUUTIL_LOAD_ERROR = 1
 
@@ -79,11 +80,25 @@ def _wrapper_get_psus_status(psu_index):
 
 def psu_db_update(psu_tbl, psu_num):
     for psu_index in range(1, psu_num + 1):
+        psu_presence_state = psuutil.get_psu_presence(psu_index)
+        psu_status_state = psuutil.get_psu_status(psu_index)
+        if psu_db_update.psu_presence[psu_index] != psu_presence_state:
+            msg = " present" if psu_presence_state else " not present"
+            logger.log_info("PSU " + str(psu_index) + msg)
+            psu_db_update.psu_presence[psu_index] = psu_presence_state
+            
+        if psu_db_update.psu_status[psu_index] != psu_status_state:
+            msg = " inserted" if psu_status_state else " removed"
+            logger.log_info("PSU " + str(psu_index) + msg)
+            psu_db_update.psu_status[psu_index] = psu_status_state
+            
         fvs = swsscommon.FieldValuePairs([(PSU_INFO_PRESENCE_FIELD,
-                                           'true' if _wrapper_get_psus_presence(psu_index) else 'false'),
+                                           'true' if psu_presence_state else 'false'),
                                           (PSU_INFO_STATUS_FIELD,
-                                           'true' if _wrapper_get_psus_status(psu_index) else 'false')])
+                                           'true' if psu_status_state else 'false')])
         psu_tbl.set(PSU_INFO_KEY_TEMPLATE.format(psu_index), fvs)
+psu_db_update.psu_presence=[-1] * PSU_MAX
+psu_db_update.psu_status=[-1] * PSU_MAX
 
 #
 # Daemon =======================================================================


### PR DESCRIPTION
Fix: PSU(power supply unit) event logs are not generated when plug-in/plug-out the PSUs of DUT

What I did
Generate sys-log events when insert/remove PSUs

How I did it
Store psu presence and status information in db. Generating a syslog event if there is a psu presence/status update. 

How I verify it
insert/remove PSU and check syslog
root@sonic:/var/log# grep PSU syslog
Jul 26 18:04:38.827329 sonic INFO pmon#psud: PSU 1: present
Jul 26 18:04:38.827329 sonic INFO pmon#psud: PSU 1: inserted
Jul 26 18:04:38.832794 sonic INFO pmon#psud: PSU 2: present
Jul 26 18:04:38.832794 sonic INFO pmon#psud: PSU 2: removed
Jul 26 18:07:54.330588 sonic INFO pmon#psud: PSU 2: inserted
Jul 26 18:07:57.333925 sonic INFO pmon#psud: PSU 1: removed
Jul 26 18:08:00.340598 sonic INFO pmon#psud: PSU 1: inserted
Jul 26 18:08:03.350434 sonic INFO pmon#psud: PSU 2: removed