### PR TITLE
[xcvrd] Fixed SFP state update in case port is not in port_config.ini

### DIFF
--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -837,6 +837,8 @@ class sfp_state_update_task:
                     #      this is for the vendors who don't implement "system_not_ready/system_becom_ready" logic
                     for key, value in port_dict.iteritems():
                         logical_port_list = platform_sfputil.get_physical_to_logical(int(key))
+                        if logical_port_list is None:
+                            continue
                         for logical_port in logical_port_list:
                             if value == SFP_STATUS_INSERTED:
                                 logger.log_info("Got SFP inserted event")

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -838,6 +838,7 @@ class sfp_state_update_task:
                     for key, value in port_dict.iteritems():
                         logical_port_list = platform_sfputil.get_physical_to_logical(int(key))
                         if logical_port_list is None:
+                            logger.log_warning("Got unknown FP port index {}, ignored".format(key))
                             continue
                         for logical_port in logical_port_list:
                             if value == SFP_STATUS_INSERTED:


### PR DESCRIPTION
In case some FP port is not in port_config.ini but platform plugin still iterates through all FP ports including this one, there will be an exception as follows:

INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 840, in task_worker
INFO pmon#supervisord: xcvrd     for logical_port in logical_port_list:
INFO pmon#supervisord: xcvrd TypeError: 'NoneType' object is not iterable

Signed-off-by: Andriy Kokhan <akokhan@barefootnetworks.com>