### PR TITLE
[xcvrd] Retrieve DOM info using platform API 2.0 if implemented

### DIFF
--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -143,8 +143,10 @@ def _wrapper_get_transceiver_dom_info(physical_port):
 
 def _wrapper_get_transceiver_dom_threshold_info(physical_port):
     if platform_chassis is not None:
-        return platform_chassis.get_sfp(physical_port).get_transceiver_threshold_info()
-
+	try:
+            return platform_chassis.get_sfp(physical_port).get_transceiver_threshold_info()
+	except NotImplementedError:
+	    pass
     return platform_sfputil.get_transceiver_dom_threshold_info_dict(physical_port)
 
 def _wrapper_get_transceiver_change_event(timeout):

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -143,7 +143,7 @@ def _wrapper_get_transceiver_dom_info(physical_port):
 
 def _wrapper_get_transceiver_dom_threshold_info(physical_port):
     if platform_chassis is not None:
-        return None
+        return platform_chassis.get_sfp(physical_port).get_transceiver_threshold_info()
 
     return platform_sfputil.get_transceiver_dom_threshold_info_dict(physical_port)
 

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -143,10 +143,10 @@ def _wrapper_get_transceiver_dom_info(physical_port):
 
 def _wrapper_get_transceiver_dom_threshold_info(physical_port):
     if platform_chassis is not None:
-	try:
+        try:
             return platform_chassis.get_sfp(physical_port).get_transceiver_threshold_info()
-	except NotImplementedError:
-	    pass
+        except NotImplementedError:
+            pass
     return platform_sfputil.get_transceiver_dom_threshold_info_dict(physical_port)
 
 def _wrapper_get_transceiver_change_event(timeout):


### PR DESCRIPTION
**What I did:**
DOM related informations are not displayed in 2.0 supported platforms and returns the following error.

root@sonic:/home/admin# sfpshow -eeprom -d
…
…
File "/usr/bin/sfpshow", line 146, in format_dict_value_to_string
if dom_info_dict is not None and dom_info_dict[key] != 'N/A':
KeyError: 'rxpowerhighalarm'

**How I did:**
Used 2.0 DOM API in xcvrd to  fetch DOM related information.

**How to verify:**
Check "sfpshow eeprom -d" output after making the changes.