### PR TITLE
Fix missing DOM threshold info from DB

### DIFF
--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -663,6 +663,7 @@ class dom_info_update_task:
             logical_port_list = platform_sfputil.logical
             for logical_port_name in logical_port_list:
                 post_port_dom_info_to_db(logical_port_name, dom_tbl, self.task_stopping_event)
+                post_port_dom_threshold_info_to_db(logical_port_name, dom_tbl, self.task_stopping_event)
 
         logger.log_info("Stop DOM monitoring loop")
 


### PR DESCRIPTION
DOM threshold info is missing from DB because of function to fetch DOM threshold info "post_port_dom_threshold_info_to_db" is not called in "dom_info_update_task", and which will break CLI "show interface transceiver eeprom -d".
The fix is to add call to "post_port_dom_threshold_info_to_db" in "dom_info_update_task".

This fix should be included in the 201911 and bmtor branch.