### PR TITLE
[xcvrd] Don't log unnecessary messages upon empty transceiver change event

### DIFF
--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -796,6 +796,8 @@ class sfp_state_update_task:
             next_state = state
             time_start = time.time()
             status, port_dict = _wrapper_get_transceiver_change_event(timeout)
+            if not port_dict:
+                continue
             logger.log_debug("Got event {} {} in state {}".format(status, port_dict, state))
             event = self._mapping_event_from_change_event(status, port_dict)
             if event == SYSTEM_NOT_READY:


### PR DESCRIPTION
Eliminates unnecessary logs of the form:
```
xcvrd: Got event True {} in state 1
xcvrd: mapping from True {'-1': 'system_become_ready'} to system_become_ready
xcvrd: Got system_become_ready in normal state, ignored
```

What I did:
    Don't need to do anything when the port_dict of transceiver_change is empty

How to verify:
    Run on DUT to make sure xcvrd can detect tranceiver eeprom correctly and
    there is no unmeaning logs anymore.

Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>