### PR TITLE
Platform daemon changes for multi asic platform

### DIFF
--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -73,12 +73,12 @@ class DaemonLedd(daemon_base.DaemonBase):
         sel = swsscommon.Select()
 
         for namespace in namespaces:
-            # Open a handle to the Application database
+            # Open a handle to the Application database, in all namespaces
             appl_db[namespace] = daemon_base.db_connect("APPL_DB", namespace=namespace)
             sst[namespace] = swsscommon.SubscriberStateTable(appl_db[namespace], swsscommon.APP_PORT_TABLE_NAME)
             sel.addSelectable(sst[namespace])
 
-        # Listen indefinitely for changes to the PORT table in the Application DB
+        # Listen indefinitely for changes to the PORT table in the Application DB's
         while True:
             # Use timeout to prevent ignoring the signals we want to handle
             # in signal_handler() (e.g. SIGTERM for graceful shutdown)
@@ -102,7 +102,7 @@ class DaemonLedd(daemon_base.DaemonBase):
                     fvp_dict = dict(fvp)
 
                     if op == "SET" and "oper_status" in fvp_dict:
-                        if not key.startswith(INTERNAL_INTERFACE_PREFIX):
+                        if not key.startswith(daemon_base.get_internal_interface_prefix()):
                             led_control.port_link_state_change(key, fvp_dict["oper_status"])
 
         return 1

--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -65,13 +65,18 @@ class DaemonLedd(daemon_base.DaemonBase):
             self.log_error("Failed to load ledutil: %s" % (str(e)), True)
             sys.exit(LEDUTIL_LOAD_ERROR)
 
-        # Open a handle to the Application database
-        appl_db = daemon_base.db_connect("APPL_DB")
+        # Get the namespaces in the platform
+        namespaces = multi_asic.get_namespaces()
 
         # Subscribe to PORT table notifications in the Application DB
+        appl_db, sst = {}, {}
         sel = swsscommon.Select()
-        sst = swsscommon.SubscriberStateTable(appl_db, swsscommon.APP_PORT_TABLE_NAME)
-        sel.addSelectable(sst)
+
+        for namespace in namespaces:
+            # Open a handle to the Application database
+            appl_db[namespace] = daemon_base.db_connect("APPL_DB", namespace=namespace)
+            sst[namespace] = swsscommon.SubscriberStateTable(appl_db[namespace], swsscommon.APP_PORT_TABLE_NAME)
+            sel.addSelectable(sst[namespace])
 
         # Listen indefinitely for changes to the PORT table in the Application DB
         while True:
@@ -86,17 +91,19 @@ class DaemonLedd(daemon_base.DaemonBase):
                 self.log_warning("sel.select() did not  return swsscommon.Select.OBJECT")
                 continue
 
-            (key, op, fvp) = sst.pop()
+            for namespace in namespaces:
+                (key, op, fvp) = sst[namespace].pop()
+                if fvp:
+                    # TODO: Once these flag entries have been removed from the DB,
+                    # we can remove this check
+                    if key in ["PortConfigDone", "PortInitDone"]:
+                        continue
 
-            # TODO: Once these flag entries have been removed from the DB,
-            # we can remove this check
-            if key in ["PortConfigDone", "PortInitDone"]:
-                continue
+                    fvp_dict = dict(fvp)
 
-            fvp_dict = dict(fvp)
-
-            if op == "SET" and "oper_status" in fvp_dict:
-                led_control.port_link_state_change(key, fvp_dict["oper_status"])
+                    if op == "SET" and "oper_status" in fvp_dict:
+                        if not key.startswith(INTERNAL_INTERFACE_PREFIX):
+                            led_control.port_link_state_change(key, fvp_dict["oper_status"])
 
         return 1
 

--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -10,6 +10,8 @@ try:
     import sys
 
     from sonic_py_common import daemon_base
+    from sonic_py_common import multi_asic
+    from sonic_py_common.interface import backplane_prefix
     from swsscommon import swsscommon
 except ImportError as e:
     raise ImportError (str(e) + " - required module not found")
@@ -34,6 +36,9 @@ LED_CLASS_NAME = "LedControl"
 SELECT_TIMEOUT = 1000
 
 LEDUTIL_LOAD_ERROR = 1
+
+# The empty namespace refers to linux host namespace.
+EMPTY_NAMESPACE = ''
 
 class DaemonLedd(daemon_base.DaemonBase):
 
@@ -65,8 +70,15 @@ class DaemonLedd(daemon_base.DaemonBase):
             self.log_error("Failed to load ledutil: %s" % (str(e)), True)
             sys.exit(LEDUTIL_LOAD_ERROR)
 
-        # Get the namespaces in the platform
-        namespaces = multi_asic.get_namespaces()
+        # Load the namespace details first from the database_global.json file.
+        swsscommon.SonicDBConfig.initializeGlobalConfig()
+
+        # Get the namespaces in the platform. For multi-asic devices we get the namespaces
+        # of front-end ascis which have front-panel interfaces.
+        namespaces = [EMPTY_NAMESPACE]
+        if multi_asic.is_multi_asic():
+            ns_list = multi_asic.get_all_namespaces()
+            namespaces = ns_list['front_ns']
 
         # Subscribe to PORT table notifications in the Application DB
         appl_db, sst = {}, {}
@@ -103,7 +115,7 @@ class DaemonLedd(daemon_base.DaemonBase):
                 fvp_dict = dict(fvp)
 
                 if op == "SET" and "oper_status" in fvp_dict:
-                    if not key.startswith(daemon_base.get_internal_interface_prefix()):
+                    if not key.startswith(backplane_prefix()):
                         led_control.port_link_state_change(key, fvp_dict["oper_status"])
 
         return 1

--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -91,19 +91,20 @@ class DaemonLedd(daemon_base.DaemonBase):
                 self.log_warning("sel.select() did not  return swsscommon.Select.OBJECT")
                 continue
 
-            for namespace in namespaces:
-                (key, op, fvp) = sst[namespace].pop()
-                if fvp:
-                    # TODO: Once these flag entries have been removed from the DB,
-                    # we can remove this check
-                    if key in ["PortConfigDone", "PortInitDone"]:
-                        continue
+            # Get the namespace from the selectable object and use it to index the SubscriberStateTable handle.
+            ns=c.getDbNamespace()
+            (key, op, fvp) = sst[ns].pop()
+            if fvp:
+                # TODO: Once these flag entries have been removed from the DB,
+                # we can remove this check
+                if key in ["PortConfigDone", "PortInitDone"]:
+                    continue
 
-                    fvp_dict = dict(fvp)
+                fvp_dict = dict(fvp)
 
-                    if op == "SET" and "oper_status" in fvp_dict:
-                        if not key.startswith(daemon_base.get_internal_interface_prefix()):
-                            led_control.port_link_state_change(key, fvp_dict["oper_status"])
+                if op == "SET" and "oper_status" in fvp_dict:
+                    if not key.startswith(daemon_base.get_internal_interface_prefix()):
+                        led_control.port_link_state_change(key, fvp_dict["oper_status"])
 
         return 1
 

--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -75,10 +75,7 @@ class DaemonLedd(daemon_base.DaemonBase):
 
         # Get the namespaces in the platform. For multi-asic devices we get the namespaces
         # of front-end ascis which have front-panel interfaces.
-        namespaces = [EMPTY_NAMESPACE]
-        if multi_asic.is_multi_asic():
-            ns_list = multi_asic.get_all_namespaces()
-            namespaces = ns_list['front_ns']
+        namespaces = multi_asic.get_front_end_namespaces()
 
         # Subscribe to PORT table notifications in the Application DB
         appl_db, sst = {}, {}

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -802,6 +802,9 @@ class DomInfoUpdateTask(object):
         self.task_thread = None
         self.task_stopping_event = threading.Event()
 
+        # Load the namespace details first from the database_global.json file.
+        swsscommon.SonicDBConfig.initializeGlobalConfig()
+
     def task_worker(self):
         helper_logger.log_info("Start DOM monitoring loop")
 
@@ -848,6 +851,9 @@ class SfpStateUpdateTask(object):
     def __init__(self):
         self.task_process = None
         self.task_stopping_event = multiprocessing.Event()
+
+        # Load the namespace details first from the database_global.json file.
+        swsscommon.SonicDBConfig.initializeGlobalConfig()
 
     def _mapping_event_from_change_event(self, status, port_dict):
         """

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -738,7 +738,7 @@ def detect_port_in_error_status(logical_port_name, status_tbl):
 # Init TRANSCEIVER_STATUS table
 def init_port_sfp_status_tbl(stop_event=threading.Event()):
     # Connect to STATE_DB and create transceiver status table
-    state_db, status_tbl = {},{}
+    state_db, status_tbl = {}, {}
 
     # Get the namespaces in the platform
     namespaces = multi_asic.get_front_end_namespaces()

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -95,6 +95,9 @@ platform_chassis = None
 # by DaemonXcvrd
 helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 
+# MultiAsic class instance
+multi_asic = multiAsic()
+
 #
 # Helper functions =============================================================
 #
@@ -421,14 +424,19 @@ def post_port_dom_info_to_db(logical_port_name, table, stop_event=threading.Even
 # Update port dom/sfp info in db
 def post_port_sfp_dom_info_to_db(is_warm_start, stop_event=threading.Event()):
     # Connect to STATE_DB and create transceiver dom/sfp info tables
-    transceiver_dict = {}
-    state_db = daemon_base.db_connect("STATE_DB")
-    int_tbl = swsscommon.Table(state_db, TRANSCEIVER_INFO_TABLE)
-    dom_tbl = swsscommon.Table(state_db, TRANSCEIVER_DOM_SENSOR_TABLE)
+    transceiver_dict, state_db, appl_db, int_tbl, dom_tbl, app_port_tbl = {}, {}, {}, {}, {}, {}
 
-    appl_db = daemon_base.db_connect("APPL_DB")
-    app_port_tbl = swsscommon.ProducerStateTable(appl_db,
-                                                 swsscommon.APP_PORT_TABLE_NAME)
+    # Get the namespaces in the platform
+    namespaces = multi_asic.get_namespaces()
+    namespaceIDs = multi_asic.get_namespaceIDs()
+
+    for namespace in namespaces:
+        asic_id = multi_asic.get_asic_id_from_namespace(namespace)
+        state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+        appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
+        int_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_INFO_TABLE)
+        dom_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_DOM_SENSOR_TABLE)
+        app_port_tbl[asic_id] = swsscommon.ProducerStateTable(appl_db[asic_id], swsscommon.APP_PORT_TABLE_NAME)
 
     # Post all the current interface dom/sfp info to STATE_DB
     logical_port_list = platform_sfputil.logical
@@ -436,13 +444,18 @@ def post_port_sfp_dom_info_to_db(is_warm_start, stop_event=threading.Event()):
         if stop_event.is_set():
             break
 
-        post_port_sfp_info_to_db(logical_port_name, int_tbl, transceiver_dict, stop_event)
-        post_port_dom_info_to_db(logical_port_name, dom_tbl, stop_event)
-        post_port_dom_threshold_info_to_db(logical_port_name, dom_tbl, stop_event)
+        # Get the asic to which this port belongs
+        asic_index = platform_sfputil.get_asicId_for_logical_port(logical_port_name)
+        if asic_index is None or asic_index not in namespaceIDs:
+            continue
+
+        post_port_sfp_info_to_db(logical_port_name, int_tbl[asic_index], transceiver_dict, stop_event)
+        post_port_dom_info_to_db(logical_port_name, dom_tbl[asic_index], stop_event)
+        post_port_dom_threshold_info_to_db(logical_port_name, dom_tbl[asic_index], stop_event)
 
         ## Do not notify media settings during warm reboot to avoid dataplane traffic impact
         if is_warm_start == False:
-            notify_media_setting(logical_port_name, transceiver_dict, app_port_tbl)
+            notify_media_setting(logical_port_name, transceiver_dict, app_port_tbl[asic_index])
             transceiver_dict.clear()
 
 # Delete port dom/sfp info from db
@@ -473,16 +486,22 @@ def del_port_sfp_dom_info_from_db(logical_port_name, int_tbl, dom_tbl):
             sys.exit(NOT_IMPLEMENTED_ERROR)
 
 # recover missing sfp table entries if any
-def recover_missing_sfp_table_entries(sfp_util, int_tbl, status_tbl, stop_event):
+def recover_missing_sfp_table_entries(self, sfp_util, stop_event):
     transceiver_dict = {}
     
-    keys = int_tbl.getKeys()
+    keys = self.int_tbl.getKeys()
     logical_port_list = sfp_util.logical
     for logical_port_name in logical_port_list:
         if stop_event.is_set():
             break
-        if logical_port_name not in keys and not detect_port_in_error_status(logical_port_name, status_tbl):
-            post_port_sfp_info_to_db(logical_port_name, int_tbl, transceiver_dict, stop_event)
+
+        # Get the asic to which this port belongs
+        asic_index = sfp_util.get_asicId_for_logical_port(logical_port_name)
+        if asic_index is None or asic_index not in namespaceIDs:
+            continue
+
+        if logical_port_name not in keys and not detect_port_in_error_status(logical_port_name, self.status_tbl[asic_index]):
+            post_port_sfp_info_to_db(logical_port_name, self.int_tbl[asic_index], transceiver_dict, stop_event)
     
 
 def check_port_in_range(range_str, physical_port):
@@ -719,28 +738,41 @@ def detect_port_in_error_status(logical_port_name, status_tbl):
 # Init TRANSCEIVER_STATUS table
 def init_port_sfp_status_tbl(stop_event=threading.Event()):
     # Connect to STATE_DB and create transceiver status table
-    state_db = daemon_base.db_connect("STATE_DB")
-    status_tbl = swsscommon.Table(state_db, TRANSCEIVER_STATUS_TABLE)
+    state_db, status_tbl = {},{}
+
+    # Get the namespaces in the platform
+    namespaces = multi_asic.get_namespaces()
+    namespaceIDs = multi_asic.get_namespaceIDs()
+
+    for namespace in namespaces:
+        asic_id = multi_asic.get_asic_id_from_namespace(namespace)
+        state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+        status_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
 
     # Init TRANSCEIVER_STATUS table
     logical_port_list = platform_sfputil.logical
     for logical_port_name in logical_port_list:
         if stop_event.is_set():
             break
+
+        # Get the asic to which this port belongs
+        asic_index = platform_sfputil.get_asicId_for_logical_port(logical_port_name)
+        if asic_index is None or asic_index not in namespaceIDs:
+            continue
+
         physical_port_list = logical_port_name_to_physical_port_list(logical_port_name)
         if physical_port_list is None:
             helper_logger.log_error("No physical ports found for logical port '%s'" % logical_port_name)
-            update_port_transceiver_status_table(logical_port_name, status_tbl, SFP_STATUS_REMOVED)
+            update_port_transceiver_status_table(logical_port_name, status_tbl[asic_index], SFP_STATUS_REMOVED)
 
         for physical_port in physical_port_list:
             if stop_event.is_set():
                 break
 
             if not _wrapper_get_presence(physical_port):
-                update_port_transceiver_status_table(logical_port_name, status_tbl, SFP_STATUS_REMOVED)
+                update_port_transceiver_status_table(logical_port_name, status_tbl[asic_index], SFP_STATUS_REMOVED)
             else:
-                update_port_transceiver_status_table(logical_port_name, status_tbl, SFP_STATUS_INSERTED)
-
+                update_port_transceiver_status_table(logical_port_name, status_tbl[asic_index], SFP_STATUS_INSERTED)
 
 #
 # Helper classes ===============================================================
@@ -756,17 +788,30 @@ class DomInfoUpdateTask(object):
         helper_logger.log_info("Start DOM monitoring loop")
 
         # Connect to STATE_DB and create transceiver dom info table
-        state_db = daemon_base.db_connect("STATE_DB")
-        dom_tbl = swsscommon.Table(state_db, TRANSCEIVER_DOM_SENSOR_TABLE)
-        status_tbl = swsscommon.Table(state_db, TRANSCEIVER_STATUS_TABLE)
+        state_db, dom_tbl, status_tbl = {}, {}, {}
+
+        # Get the namespaces in the platform
+        namespaces = multi_asic.get_namespaces()
+        namespaceIDs = multi_asic.get_namespaceIDs()
+
+        for namespace in namespaces:
+            asic_id = multi_asic.get_asic_id_from_namespace(namespace)
+            state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            dom_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_DOM_SENSOR_TABLE)
+            status_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
 
         # Start loop to update dom info in DB periodically
         while not self.task_stopping_event.wait(DOM_INFO_UPDATE_PERIOD_SECS):
             logical_port_list = platform_sfputil.logical
             for logical_port_name in logical_port_list:
-                if not detect_port_in_error_status(logical_port_name, status_tbl):
-                    post_port_dom_info_to_db(logical_port_name, dom_tbl, self.task_stopping_event)
-                    post_port_dom_threshold_info_to_db(logical_port_name, dom_tbl, self.task_stopping_event)
+                # Get the asic to which this port belongs
+                asic_index = platform_sfputil.get_asicId_for_logical_port(logical_port_name)
+                if asic_index is None or asic_index not in namespaceIDs:
+                    continue
+
+                if not detect_port_in_error_status(logical_port_name, status_tbl[asic_index]):
+                    post_port_dom_info_to_db(logical_port_name, dom_tbl[asic_index], self.task_stopping_event)
+                    post_port_dom_threshold_info_to_db(logical_port_name, dom_tbl[asic_index], self.task_stopping_event)
 
         helper_logger.log_info("Stop DOM monitoring loop")
 
@@ -816,15 +861,22 @@ class SfpStateUpdateTask(object):
 
         transceiver_dict = {}
         # Connect to STATE_DB and create transceiver dom/sfp info tables
-        state_db = daemon_base.db_connect("STATE_DB")
-        int_tbl = swsscommon.Table(state_db, TRANSCEIVER_INFO_TABLE)
-        dom_tbl = swsscommon.Table(state_db, TRANSCEIVER_DOM_SENSOR_TABLE)
-        status_tbl = swsscommon.Table(state_db, TRANSCEIVER_STATUS_TABLE)
+        state_db, appl_db, int_tbl, dom_tbl, status_tbl, app_port_tbl = {}, {}, {}, {}, {}, {}
 
-        # Connect to APPL_DB to notify Media notifications
-        appl_db = daemon_base.db_connect("APPL_DB")
-        app_port_tbl = swsscommon.ProducerStateTable(appl_db,
-                                                     swsscommon.APP_PORT_TABLE_NAME)
+        # Get the namespaces in the platform
+        namespaces = multi_asic.get_namespaces()
+        namespaceIDs = multi_asic.get_namespaceIDs()
+
+        for namespace in namespaces:
+            asic_id = multi_asic.get_asic_id_from_namespace(namespace)
+            state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            int_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_INFO_TABLE)
+            dom_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_DOM_SENSOR_TABLE)
+            status_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
+
+            # Connect to APPL_DB to notify Media notifications
+            appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
+            app_port_tbl[asic_id] = swsscommon.ProducerStateTable(appl_db[asic_id], swsscommon.APP_PORT_TABLE_NAME)
 
         # Start main loop to listen to the SFP change event.
         # The state migrating sequence:
@@ -949,37 +1001,43 @@ class SfpStateUpdateTask(object):
                             helper_logger.log_warning("Got unknown FP port index {}, ignored".format(key))
                             continue
                         for logical_port in logical_port_list:
+
+                            # Get the asic to which this port belongs
+                            asic_index = platform_sfputil.get_asicId_for_logical_port(logical_port)
+                            if asic_index is None or asic_index not in namespaceIDs:
+                                continue
+
                             if value == SFP_STATUS_INSERTED:
                                 helper_logger.log_info("Got SFP inserted event")
                                 # A plugin event will clear the error state.
-                                update_port_transceiver_status_table(logical_port, status_tbl, SFP_STATUS_INSERTED)
+                                update_port_transceiver_status_table(logical_port, status_tbl[asic_index], SFP_STATUS_INSERTED)
                                 helper_logger.log_info("receive plug in and update port sfp status table.")
-                                rc = post_port_sfp_info_to_db(logical_port, int_tbl, transceiver_dict)
+                                rc = post_port_sfp_info_to_db(logical_port, int_tbl[asic_index], transceiver_dict)
                                 # If we didn't get the sfp info, assuming the eeprom is not ready, give a try again.
                                 if rc == SFP_EEPROM_NOT_READY:
                                     helper_logger.log_warning("SFP EEPROM is not ready. One more try...")
                                     time.sleep(TIME_FOR_SFP_READY_SECS)
-                                    post_port_sfp_info_to_db(logical_port, int_tbl, transceiver_dict)
-                                post_port_dom_info_to_db(logical_port, dom_tbl)
-                                post_port_dom_threshold_info_to_db(logical_port, dom_tbl)
-                                notify_media_setting(logical_port, transceiver_dict, app_port_tbl)
+                                    post_port_sfp_info_to_db(logical_port, int_tbl[asic_index], transceiver_dict)
+                                post_port_dom_info_to_db(logical_port, dom_tbl[asic_index])
+                                post_port_dom_threshold_info_to_db(logical_port, dom_tbl[asic_index])
+                                notify_media_setting(logical_port, transceiver_dict, app_port_tbl[asic_index])
                                 transceiver_dict.clear()
                             elif value == SFP_STATUS_REMOVED:
                                 helper_logger.log_info("Got SFP removed event")
-                                update_port_transceiver_status_table(logical_port, status_tbl, SFP_STATUS_REMOVED)
+                                update_port_transceiver_status_table(logical_port, status_tbl[asic_index], SFP_STATUS_REMOVED)
                                 helper_logger.log_info("receive plug out and pdate port sfp status table.")
-                                del_port_sfp_dom_info_from_db(logical_port, int_tbl, dom_tbl)
+                                del_port_sfp_dom_info_from_db(logical_port, int_tbl[asic_index], dom_tbl[asic_index])
                             elif value in errors_block_eeprom_reading:
                                 helper_logger.log_info("Got SFP Error event")
                                 # Add port to error table to stop accessing eeprom of it
                                 # If the port already in the error table, the stored error code will
                                 # be updated to the new one.
-                                update_port_transceiver_status_table(logical_port, status_tbl, value)
+                                update_port_transceiver_status_table(logical_port, status_tbl[asic_index], value)
                                 helper_logger.log_info("receive error update port sfp status table.")
                                 # In this case EEPROM is not accessible, so remove the DOM info
                                 # since it will be outdated if long time no update.
                                 # but will keep the interface info in the DB since it static.
-                                del_port_sfp_dom_info_from_db(logical_port, None, dom_tbl)
+                                del_port_sfp_dom_info_from_db(logical_port, None, dom_tbl[asic_index])
 
                             else:
                                 # SFP return unkown event, just ignore for now.
@@ -1042,6 +1100,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         super(DaemonXcvrd, self).__init__(log_identifier)
 
         self.timeout = XCVRD_MAIN_THREAD_SLEEP_SECS
+        self.num_asics = multi_asic.get_num_asics()
         self.stop_event = threading.Event()
         self.sfp_error_event = multiprocessing.Event()
 
@@ -1059,9 +1118,9 @@ class DaemonXcvrd(daemon_base.DaemonBase):
             self.log_warning("Caught unhandled signal '" + sig + "'")
 
     # Wait for port config is done
-    def wait_for_port_config_done(self):
+    def wait_for_port_config_done(self, namespace):
         # Connect to APPL_DB and subscribe to PORT table notifications
-        appl_db = daemon_base.db_connect("APPL_DB")
+        appl_db = daemon_base.db_connect("APPL_DB", namespace=namespace)
 
         sel = swsscommon.Select()
         sst = swsscommon.SubscriberStateTable(appl_db, swsscommon.APP_PORT_TABLE_NAME)
@@ -1126,17 +1185,31 @@ class DaemonXcvrd(daemon_base.DaemonBase):
 
         # Load port info
         try:
-            port_config_file_path = device_info.get_path_to_port_config_file()
-            platform_sfputil.read_porttab_mappings(port_config_file_path)
-        except Exception as e:
+            if multi_asic.is_multi_asic():
+                # For multi ASIC platforms we pass DIR of port_config_file_path and the number of asics
+                (platform_path, hwsku_path) = device_info.get_path_to_platform_and_hwsku()
+                platform_sfputil.read_all_porttab_mappings(hwsku_path, self.num_asics)
+            else:
+                # For single ASIC platforms we pass port_config_file_path and the asic_inst as 0
+                port_config_file_path = device_info.get_path_to_port_config_file()
+                platform_sfputil.read_porttab_mappings(port_config_file_path, 0)
+        except Exception, e:
             self.log_error("Failed to read port info: %s" % (str(e)), True)
             sys.exit(PORT_CONFIG_LOAD_ERROR)
 
         # Connect to STATE_DB and create transceiver dom/sfp info tables
-        state_db = daemon_base.db_connect("STATE_DB")
-        self.int_tbl = swsscommon.Table(state_db, TRANSCEIVER_INFO_TABLE)
-        self.dom_tbl = swsscommon.Table(state_db, TRANSCEIVER_DOM_SENSOR_TABLE)
-        self.status_tbl = swsscommon.Table(state_db, TRANSCEIVER_STATUS_TABLE)
+        state_db, self.int_tbl, self.dom_tbl, self.status_tbl = {}, {}, {}, {}
+
+        # Get the namespaces in the platform
+        namespaces = multi_asic.get_namespaces()
+        namespaceIDs = multi_asic.get_namespaceIDs()
+
+        for namespace in namespaces:
+            asic_id = multi_asic.get_asic_id_from_namespace(namespace)
+            state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            self.int_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_INFO_TABLE)
+            self.dom_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_DOM_SENSOR_TABLE)
+            self.status_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
 
         self.load_media_settings()
         warmstart = swsscommon.WarmStart()
@@ -1146,7 +1219,8 @@ class DaemonXcvrd(daemon_base.DaemonBase):
 
         # Make sure this daemon started after all port configured
         self.log_info("Wait for port config is done")
-        self.wait_for_port_config_done()
+        for namespace in namespaces:
+            self.wait_for_port_config_done(namespace)
 
         # Post all the current interface dom/sfp info to STATE_DB
         self.log_info("Post all port DOM/SFP info to DB")
@@ -1163,8 +1237,13 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         # Delete all the information from DB and then exit
         logical_port_list = platform_sfputil.logical
         for logical_port_name in logical_port_list:
-            del_port_sfp_dom_info_from_db(logical_port_name, self.int_tbl, self.dom_tbl)
-            delete_port_from_status_table(logical_port_name, self.status_tbl)
+            # Get the asic to which this port belongs
+            asic_index = platform_sfputil.get_asicId_for_logical_port(logical_port_name)
+            if asic_index is None:
+                continue
+
+            del_port_sfp_dom_info_from_db(logical_port_name, self.int_tbl[asic_index], self.dom_tbl[asic_index])
+            delete_port_from_status_table(logical_port_name, self.status_tbl[asic_index])
 
     # Run daemon
     def run(self):
@@ -1186,7 +1265,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
 
         while not self.stop_event.wait(self.timeout):
             # Check the integrity of the sfp info table and recover the missing entries if any
-            recover_missing_sfp_table_entries(platform_sfputil, self.int_tbl, self.status_tbl, self.stop_event)
+            recover_missing_sfp_table_entries(self, platform_sfputil, self.stop_event)
 
         self.log_info("Stop daemon main loop")
 

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -117,10 +117,13 @@ def get_front_end_namesapces():
 # Get asic index from the namespace name
 # With single ASIC platform, namespace is EMPTY_NAMESPACE, return index 0
 def get_asic_id_from_namespace(namespace):
-    if namespace == EMPTY_NAMESPACE:
-        return 0 
-    else:
-        return multi_asic.get_asic_id_from_name(namespace)
+    asic_id_string = multi_asic.get_asic_id_from_name(namespace)
+    if asic_id_string is not None:
+        return int(asic_id_string)
+
+    # Default we return back 0, handles single asic platform and check when the func
+    # get_asic_id_from_name() returns back None.
+    return 0
 
 # Find out the underneath physical port list by logical name
 def logical_port_name_to_physical_port_list(port_name):
@@ -1212,7 +1215,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         try:
             if multi_asic.is_multi_asic():
                 # For multi ASIC platforms we pass DIR of port_config_file_path and the number of asics
-                (platform_path, hwsku_path) = device_info.get_path_to_platform_and_hwsku()
+                (platform_path, hwsku_path) = device_info.get_paths_to_platform_and_hwsku_dirs()
                 platform_sfputil.read_all_porttab_mappings(hwsku_path, self.num_asics)
             else:
                 # For single ASIC platforms we pass port_config_file_path and the asic_inst as 0

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -19,7 +19,8 @@ try:
     from enum import Enum
     from sonic_py_common import daemon_base, device_info, logger
     from swsscommon import swsscommon
-except ImportError as e:
+    from sonic_py_common import multi_asic
+except ImportError, e:
     raise ImportError (str(e) + " - required module not found")
 
 #
@@ -95,12 +96,31 @@ platform_chassis = None
 # by DaemonXcvrd
 helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 
-# MultiAsic class instance
-multi_asic = MultiAsic()
+# The empty namespace refers to linux host namespace.
+EMPTY_NAMESPACE = ''
 
 #
 # Helper functions =============================================================
 #
+
+# Get namespaces, for single ASIC platform namespace is EMPTY_NAMESPACE
+def get_front_end_namesapces():
+    # Get the namespaces in the platform. For multi-asic devices we get the namespaces
+    # of front-end ascis which have front-panel interfaces.
+    namespaces = [EMPTY_NAMESPACE]
+    if multi_asic.is_multi_asic():
+        ns_list = multi_asic.get_all_namespaces()
+        namespaces = ns_list['front_ns']
+
+    return namespaces
+
+# Get asic index from the namespace name
+# With single ASIC platform, namespace is EMPTY_NAMESPACE, return index 0
+def get_asic_id_from_namespace(namespace):
+    if namespace == EMPTY_NAMESPACE:
+        return 0 
+    else:
+        return multi_asic.get_asic_id_from_name(namespace)
 
 # Find out the underneath physical port list by logical name
 def logical_port_name_to_physical_port_list(port_name):
@@ -427,9 +447,9 @@ def post_port_sfp_dom_info_to_db(is_warm_start, stop_event=threading.Event()):
     transceiver_dict, state_db, appl_db, int_tbl, dom_tbl, app_port_tbl = {}, {}, {}, {}, {}, {}
 
     # Get the namespaces in the platform
-    namespaces = multi_asic.get_namespaces()
+    namespaces = get_front_end_namesapces()
     for namespace in namespaces:
-        asic_id = multi_asic.get_asic_id_from_namespace(namespace)
+        asic_id = get_asic_id_from_namespace(namespace)
         state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
         appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
         int_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_INFO_TABLE)
@@ -740,9 +760,9 @@ def init_port_sfp_status_tbl(stop_event=threading.Event()):
     state_db, status_tbl = {},{}
 
     # Get the namespaces in the platform
-    namespaces = multi_asic.get_namespaces()
+    namespaces = get_front_end_namesapces()
     for namespace in namespaces:
-        asic_id = multi_asic.get_asic_id_from_namespace(namespace)
+        asic_id = get_asic_id_from_namespace(namespace)
         state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
         status_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
 
@@ -789,9 +809,9 @@ class DomInfoUpdateTask(object):
         state_db, dom_tbl, status_tbl = {}, {}, {}
 
         # Get the namespaces in the platform
-        namespaces = multi_asic.get_namespaces()
+        namespaces = get_front_end_namesapces()
         for namespace in namespaces:
-            asic_id = multi_asic.get_asic_id_from_namespace(namespace)
+            asic_id = get_asic_id_from_namespace(namespace)
             state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
             dom_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_DOM_SENSOR_TABLE)
             status_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
@@ -861,9 +881,9 @@ class SfpStateUpdateTask(object):
         state_db, appl_db, int_tbl, dom_tbl, status_tbl, app_port_tbl = {}, {}, {}, {}, {}, {}
 
         # Get the namespaces in the platform
-        namespaces = multi_asic.get_namespaces()
+        namespaces = get_front_end_namesapces()
         for namespace in namespaces:
-            asic_id = multi_asic.get_asic_id_from_namespace(namespace)
+            asic_id = get_asic_id_from_namespace(namespace)
             state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
             int_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_INFO_TABLE)
             dom_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_DOM_SENSOR_TABLE)
@@ -1179,6 +1199,9 @@ class DaemonXcvrd(daemon_base.DaemonBase):
                 self.log_error("Failed to load sfputil: %s" % (str(e)), True)
                 sys.exit(SFPUTIL_LOAD_ERROR)
 
+        # Load the namespace details first from the database_global.json file.
+        swsscommon.SonicDBConfig.initializeGlobalConfig()
+
         # Load port info
         try:
             if multi_asic.is_multi_asic():
@@ -1197,9 +1220,9 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         state_db, self.int_tbl, self.dom_tbl, self.status_tbl = {}, {}, {}, {}
 
         # Get the namespaces in the platform
-        namespaces = multi_asic.get_namespaces()
+        namespaces = get_front_end_namesapces()
         for namespace in namespaces:
-            asic_id = multi_asic.get_asic_id_from_namespace(namespace)
+            asic_id = get_asic_id_from_namespace(namespace)
             state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
             self.int_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_INFO_TABLE)
             self.dom_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_DOM_SENSOR_TABLE)

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -96,7 +96,7 @@ platform_chassis = None
 helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 
 # MultiAsic class instance
-multi_asic = multiAsic()
+multi_asic = MultiAsic()
 
 #
 # Helper functions =============================================================
@@ -443,7 +443,7 @@ def post_port_sfp_dom_info_to_db(is_warm_start, stop_event=threading.Event()):
             break
 
         # Get the asic to which this port belongs
-        asic_index = platform_sfputil.get_asicId_for_logical_port(logical_port_name)
+        asic_index = platform_sfputil.get_asic_id_for_logical_port(logical_port_name)
         if asic_index is None:
             logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
             continue
@@ -484,23 +484,23 @@ def del_port_sfp_dom_info_from_db(logical_port_name, int_tbl, dom_tbl):
             sys.exit(NOT_IMPLEMENTED_ERROR)
 
 # recover missing sfp table entries if any
-def recover_missing_sfp_table_entries(self, sfp_util, stop_event):
+def recover_missing_sfp_table_entries(sfp_util, int_tbl, status_tbl, stop_event):
     transceiver_dict = {}
     
-    keys = self.int_tbl.getKeys()
+    keys = int_tbl.getKeys()
     logical_port_list = sfp_util.logical
     for logical_port_name in logical_port_list:
         if stop_event.is_set():
             break
 
         # Get the asic to which this port belongs
-        asic_index = sfp_util.get_asicId_for_logical_port(logical_port_name)
+        asic_index = sfp_util.get_asic_id_for_logical_port(logical_port_name)
         if asic_index is None:
             logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
             continue
 
-        if logical_port_name not in keys and not detect_port_in_error_status(logical_port_name, self.status_tbl[asic_index]):
-            post_port_sfp_info_to_db(logical_port_name, self.int_tbl[asic_index], transceiver_dict, stop_event)
+        if logical_port_name not in keys and not detect_port_in_error_status(logical_port_name, status_tbl[asic_index]):
+            post_port_sfp_info_to_db(logical_port_name, int_tbl[asic_index], transceiver_dict, stop_event)
     
 
 def check_port_in_range(range_str, physical_port):
@@ -753,7 +753,7 @@ def init_port_sfp_status_tbl(stop_event=threading.Event()):
             break
 
         # Get the asic to which this port belongs
-        asic_index = platform_sfputil.get_asicId_for_logical_port(logical_port_name)
+        asic_index = platform_sfputil.get_asic_id_for_logical_port(logical_port_name)
         if asic_index is None:
             logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
             continue
@@ -801,7 +801,7 @@ class DomInfoUpdateTask(object):
             logical_port_list = platform_sfputil.logical
             for logical_port_name in logical_port_list:
                 # Get the asic to which this port belongs
-                asic_index = platform_sfputil.get_asicId_for_logical_port(logical_port_name)
+                asic_index = platform_sfputil.get_asic_id_for_logical_port(logical_port_name)
                 if asic_index is None:
                     logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
                     continue
@@ -998,7 +998,7 @@ class SfpStateUpdateTask(object):
                         for logical_port in logical_port_list:
 
                             # Get the asic to which this port belongs
-                            asic_index = platform_sfputil.get_asicId_for_logical_port(logical_port)
+                            asic_index = platform_sfputil.get_asic_id_for_logical_port(logical_port)
                             if asic_index is None:
                                 logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port))
                                 continue
@@ -1232,7 +1232,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         logical_port_list = platform_sfputil.logical
         for logical_port_name in logical_port_list:
             # Get the asic to which this port belongs
-            asic_index = platform_sfputil.get_asicId_for_logical_port(logical_port_name)
+            asic_index = platform_sfputil.get_asic_id_for_logical_port(logical_port_name)
             if asic_index is None:
                 logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
                 continue
@@ -1260,7 +1260,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
 
         while not self.stop_event.wait(self.timeout):
             # Check the integrity of the sfp info table and recover the missing entries if any
-            recover_missing_sfp_table_entries(self, platform_sfputil, self.stop_event)
+            recover_missing_sfp_table_entries(platform_sfputil, self.int_tbl, self.status_tbl, self.stop_event)
 
         self.log_info("Stop daemon main loop")
 

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -428,8 +428,6 @@ def post_port_sfp_dom_info_to_db(is_warm_start, stop_event=threading.Event()):
 
     # Get the namespaces in the platform
     namespaces = multi_asic.get_namespaces()
-    namespaceIDs = multi_asic.get_namespaceIDs()
-
     for namespace in namespaces:
         asic_id = multi_asic.get_asic_id_from_namespace(namespace)
         state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
@@ -446,9 +444,9 @@ def post_port_sfp_dom_info_to_db(is_warm_start, stop_event=threading.Event()):
 
         # Get the asic to which this port belongs
         asic_index = platform_sfputil.get_asicId_for_logical_port(logical_port_name)
-        if asic_index is None or asic_index not in namespaceIDs:
+        if asic_index is None:
+            logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
             continue
-
         post_port_sfp_info_to_db(logical_port_name, int_tbl[asic_index], transceiver_dict, stop_event)
         post_port_dom_info_to_db(logical_port_name, dom_tbl[asic_index], stop_event)
         post_port_dom_threshold_info_to_db(logical_port_name, dom_tbl[asic_index], stop_event)
@@ -497,7 +495,8 @@ def recover_missing_sfp_table_entries(self, sfp_util, stop_event):
 
         # Get the asic to which this port belongs
         asic_index = sfp_util.get_asicId_for_logical_port(logical_port_name)
-        if asic_index is None or asic_index not in namespaceIDs:
+        if asic_index is None:
+            logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
             continue
 
         if logical_port_name not in keys and not detect_port_in_error_status(logical_port_name, self.status_tbl[asic_index]):
@@ -742,8 +741,6 @@ def init_port_sfp_status_tbl(stop_event=threading.Event()):
 
     # Get the namespaces in the platform
     namespaces = multi_asic.get_namespaces()
-    namespaceIDs = multi_asic.get_namespaceIDs()
-
     for namespace in namespaces:
         asic_id = multi_asic.get_asic_id_from_namespace(namespace)
         state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
@@ -757,7 +754,8 @@ def init_port_sfp_status_tbl(stop_event=threading.Event()):
 
         # Get the asic to which this port belongs
         asic_index = platform_sfputil.get_asicId_for_logical_port(logical_port_name)
-        if asic_index is None or asic_index not in namespaceIDs:
+        if asic_index is None:
+            logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
             continue
 
         physical_port_list = logical_port_name_to_physical_port_list(logical_port_name)
@@ -792,8 +790,6 @@ class DomInfoUpdateTask(object):
 
         # Get the namespaces in the platform
         namespaces = multi_asic.get_namespaces()
-        namespaceIDs = multi_asic.get_namespaceIDs()
-
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_id_from_namespace(namespace)
             state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
@@ -806,7 +802,8 @@ class DomInfoUpdateTask(object):
             for logical_port_name in logical_port_list:
                 # Get the asic to which this port belongs
                 asic_index = platform_sfputil.get_asicId_for_logical_port(logical_port_name)
-                if asic_index is None or asic_index not in namespaceIDs:
+                if asic_index is None:
+                    logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
                     continue
 
                 if not detect_port_in_error_status(logical_port_name, status_tbl[asic_index]):
@@ -865,8 +862,6 @@ class SfpStateUpdateTask(object):
 
         # Get the namespaces in the platform
         namespaces = multi_asic.get_namespaces()
-        namespaceIDs = multi_asic.get_namespaceIDs()
-
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_id_from_namespace(namespace)
             state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
@@ -1004,7 +999,8 @@ class SfpStateUpdateTask(object):
 
                             # Get the asic to which this port belongs
                             asic_index = platform_sfputil.get_asicId_for_logical_port(logical_port)
-                            if asic_index is None or asic_index not in namespaceIDs:
+                            if asic_index is None:
+                                logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port))
                                 continue
 
                             if value == SFP_STATUS_INSERTED:
@@ -1202,8 +1198,6 @@ class DaemonXcvrd(daemon_base.DaemonBase):
 
         # Get the namespaces in the platform
         namespaces = multi_asic.get_namespaces()
-        namespaceIDs = multi_asic.get_namespaceIDs()
-
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_id_from_namespace(namespace)
             state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
@@ -1240,6 +1234,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
             # Get the asic to which this port belongs
             asic_index = platform_sfputil.get_asicId_for_logical_port(logical_port_name)
             if asic_index is None:
+                logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
                 continue
 
             del_port_sfp_dom_info_from_db(logical_port_name, self.int_tbl[asic_index], self.dom_tbl[asic_index])

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -103,28 +103,6 @@ EMPTY_NAMESPACE = ''
 # Helper functions =============================================================
 #
 
-# Get namespaces, for single ASIC platform namespace is EMPTY_NAMESPACE
-def get_front_end_namesapces():
-    # Get the namespaces in the platform. For multi-asic devices we get the namespaces
-    # of front-end ascis which have front-panel interfaces.
-    namespaces = [EMPTY_NAMESPACE]
-    if multi_asic.is_multi_asic():
-        ns_list = multi_asic.get_all_namespaces()
-        namespaces = ns_list['front_ns']
-
-    return namespaces
-
-# Get asic index from the namespace name
-# With single ASIC platform, namespace is EMPTY_NAMESPACE, return index 0
-def get_asic_id_from_namespace(namespace):
-    asic_id_string = multi_asic.get_asic_id_from_name(namespace)
-    if asic_id_string is not None:
-        return int(asic_id_string)
-
-    # Default we return back 0, handles single asic platform and check when the func
-    # get_asic_id_from_name() returns back None.
-    return 0
-
 # Find out the underneath physical port list by logical name
 def logical_port_name_to_physical_port_list(port_name):
     if port_name.startswith("Ethernet"):
@@ -450,9 +428,9 @@ def post_port_sfp_dom_info_to_db(is_warm_start, stop_event=threading.Event()):
     transceiver_dict, state_db, appl_db, int_tbl, dom_tbl, app_port_tbl = {}, {}, {}, {}, {}, {}
 
     # Get the namespaces in the platform
-    namespaces = get_front_end_namesapces()
+    namespaces = multi_asic.get_front_end_namespaces()
     for namespace in namespaces:
-        asic_id = get_asic_id_from_namespace(namespace)
+        asic_id = multi_asic.get_asic_index_from_namespace(namespace)
         state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
         appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
         int_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_INFO_TABLE)
@@ -763,9 +741,9 @@ def init_port_sfp_status_tbl(stop_event=threading.Event()):
     state_db, status_tbl = {},{}
 
     # Get the namespaces in the platform
-    namespaces = get_front_end_namesapces()
+    namespaces = multi_asic.get_front_end_namespaces()
     for namespace in namespaces:
-        asic_id = get_asic_id_from_namespace(namespace)
+        asic_id = multi_asic.get_asic_index_from_namespace(namespace)
         state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
         status_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
 
@@ -815,9 +793,9 @@ class DomInfoUpdateTask(object):
         state_db, dom_tbl, status_tbl = {}, {}, {}
 
         # Get the namespaces in the platform
-        namespaces = get_front_end_namesapces()
+        namespaces = multi_asic.get_front_end_namespaces()
         for namespace in namespaces:
-            asic_id = get_asic_id_from_namespace(namespace)
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
             state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
             dom_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_DOM_SENSOR_TABLE)
             status_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
@@ -890,9 +868,9 @@ class SfpStateUpdateTask(object):
         state_db, appl_db, int_tbl, dom_tbl, status_tbl, app_port_tbl = {}, {}, {}, {}, {}, {}
 
         # Get the namespaces in the platform
-        namespaces = get_front_end_namesapces()
+        namespaces = multi_asic.get_front_end_namespaces()
         for namespace in namespaces:
-            asic_id = get_asic_id_from_namespace(namespace)
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
             state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
             int_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_INFO_TABLE)
             dom_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_DOM_SENSOR_TABLE)
@@ -1229,9 +1207,9 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         state_db, self.int_tbl, self.dom_tbl, self.status_tbl = {}, {}, {}, {}
 
         # Get the namespaces in the platform
-        namespaces = get_front_end_namesapces()
+        namespaces = multi_asic.get_front_end_namespaces()
         for namespace in namespaces:
-            asic_id = get_asic_id_from_namespace(namespace)
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
             state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
             self.int_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_INFO_TABLE)
             self.dom_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_DOM_SENSOR_TABLE)


### PR DESCRIPTION
The changes done here are for supporting ledd and xcvr for multi-asic platforms 
(i) In the ledd process, select now looks for events from the APP_DB in different namespaces.
(ii) In the xcvr process, the parent process and the sub processes connect to databases in all namespaces. The table in which namespace to be updated, is decided by the logical port ( we use the logical_port to asic_id mapping which is stored in the sfp_helper utility classes while parsing the port_config.ini files )

Related PR's

https://github.com/Azure/sonic-swss-common/pull/364
https://github.com/Azure/sonic-buildimage/pull/4932
https://github.com/Azure/sonic-platform-common/pull/100

Update with test results in Single ASIC and Multi-ASIC 
-------------------------------------------------------------

**SINGLE ASIC**

```
admin@str-s6000-acs-8:~$ show interface transceiver eeprom
Ethernet0: SFP EEPROM detected
        Connector: No separable connector
        Encoding: Unspecified
        Extended Identifier: Power Class 1(1.5W max)
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP+ or later
        Length Cable Assembly(m): 1
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: 
                10/40G Ethernet Compliance Code: 40GBASE-CR4
                Fibre Channel Speed: 1200 Mbytes/Sec
                Fibre Channel link length/Transmitter Technology: Electrical inter-enclosure (EL)
                Fibre Channel transmission media: Twin Axial Pair (TW)
        Vendor Date Code(YYYY-MM-DD Lot): 2016-05-07 
        Vendor Name: Molex Inc.
        Vendor OUI: 00-09-3a
        Vendor PN: 1110401054
        Vendor Rev: 
        Vendor SN: 612833363

Ethernet4: SFP EEPROM detected
.....
admin@str-s6000-acs-8:~$ show interface transceiver presence 
Port         Presence
-----------  ----------
Ethernet0    Present
Ethernet4    Present
Ethernet8    Present
Ethernet12   Present
Ethernet16   Present
Ethernet20   Present
Ethernet24   Present
Ethernet28   Present
Ethernet32   Present
Ethernet36   Present
Ethernet40   Present
Ethernet44   Present
Ethernet48   Present
Ethernet52   Present
Ethernet56   Present
Ethernet60   Present
Ethernet64   Present
Ethernet68   Present
Ethernet72   Present
Ethernet76   Present
Ethernet80   Present
Ethernet84   Present
Ethernet88   Present
Ethernet92   Present
Ethernet96   Present
Ethernet100  Present
Ethernet104  Present
Ethernet108  Present
Ethernet112  Present
Ethernet116  Present
Ethernet120  Present
Ethernet124  Present

admin@str-s6000-acs-8:~$ sudo config interface transceiver lpmode Ethernet84 enable
Enabling low-power mode for port Ethernet84...  OK

admin@str-s6000-acs-8:~$ sudo config interface transceiver lpmode Ethernet0 disable
Disabling low-power mode for port Ethernet0...  OK

admin@str-s6000-acs-8:~$ show interface transceiver lpmode
Port         Low-power Mode
-----------  ----------------
Ethernet0    Off
Ethernet4    Off
Ethernet8    Off
Ethernet12   Off
Ethernet16   Off
Ethernet20   Off
Ethernet24   Off
Ethernet28   Off
Ethernet32   Off
Ethernet36   Off
Ethernet40   Off
Ethernet44   Off
Ethernet48   Off
Ethernet52   Off
Ethernet56   Off
Ethernet60   Off
Ethernet64   Off
Ethernet68   Off
Ethernet72   Off
Ethernet76   Off
Ethernet80   Off
Ethernet84   On
Ethernet88   Off
Ethernet92   Off
Ethernet96   Off
Ethernet100  Off
Ethernet104  Off
Ethernet108  Off
Ethernet112  Off
Ethernet116  Off
Ethernet120  Off
Ethernet124  Off
```

**Multi-ASIC**

```
root@str-n3164-acs-1:/# ps -ef 
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  2 22:03 pts/0    00:00:01 /usr/bin/python2 /usr/bin/supervisord
root        15     1  0 22:03 pts/0    00:00:00 python /usr/bin/supervisor-proc-exit-listener --container-name pmon
root        19     1  0 22:03 pts/0    00:00:00 /usr/sbin/rsyslogd -n -iNONE
root        27     1  0 22:03 pts/0    00:00:00 /usr/bin/python /usr/local/bin/ledd
root        29     1 18 22:03 pts/0    00:00:08 /usr/bin/python /usr/local/bin/xcvrd
root        31     1  1 22:03 pts/0    00:00:00 /usr/bin/python /usr/local/bin/psud
root        40     1  0 22:03 ?        00:00:00 /usr/sbin/sensord -f daemon
root        79    29  0 22:04 pts/0    00:00:00 /usr/bin/python /usr/local/bin/xcvrd
root        83     0  0 22:04 pts/1    00:00:00 bash
root        92    83  0 22:04 pts/1    00:00:00 ps -ef


database0
127.0.0.1:6379[6]> keys *TRAN*
 1) "TRANSCEIVER_DOM_SENSOR|Ethernet12"
 2) "TRANSCEIVER_INFO|Ethernet12"
 3) "TRANSCEIVER_STATUS|Ethernet28"
 4) "TRANSCEIVER_INFO|Ethernet28"
 5) "TRANSCEIVER_DOM_SENSOR|Ethernet20"
 6) "TRANSCEIVER_INFO|Ethernet16"
 7) "TRANSCEIVER_INFO|Ethernet36"
 8) "TRANSCEIVER_STATUS|Ethernet32"
 9) "TRANSCEIVER_STATUS|Ethernet0"
10) "TRANSCEIVER_DOM_SENSOR|Ethernet56"
11) "TRANSCEIVER_DOM_SENSOR|Ethernet16"
12) "TRANSCEIVER_INFO|Ethernet60"
13) "TRANSCEIVER_DOM_SENSOR|Ethernet8"
14) "TRANSCEIVER_STATUS|Ethernet24"
15) "TRANSCEIVER_DOM_SENSOR|Ethernet0"
16) "TRANSCEIVER_DOM_SENSOR|Ethernet36"
17) "TRANSCEIVER_STATUS|Ethernet52"
18) "TRANSCEIVER_STATUS|Ethernet56"
19) "TRANSCEIVER_STATUS|Ethernet36"
20) "TRANSCEIVER_INFO|Ethernet48"
21) "TRANSCEIVER_INFO|Ethernet20"
22) "TRANSCEIVER_INFO|Ethernet8"
23) "TRANSCEIVER_INFO|Ethernet4"
24) "TRANSCEIVER_STATUS|Ethernet12"
25) "TRANSCEIVER_DOM_SENSOR|Ethernet48"
26) "TRANSCEIVER_INFO|Ethernet44"
27) "TRANSCEIVER_DOM_SENSOR|Ethernet32"
28) "TRANSCEIVER_STATUS|Ethernet8"
29) "TRANSCEIVER_INFO|Ethernet52"
30) "TRANSCEIVER_DOM_SENSOR|Ethernet40"
31) "TRANSCEIVER_DOM_SENSOR|Ethernet28"
32) "TRANSCEIVER_INFO|Ethernet56"
33) "TRANSCEIVER_DOM_SENSOR|Ethernet52"
34) "TRANSCEIVER_STATUS|Ethernet48"
35) "TRANSCEIVER_INFO|Ethernet24"
36) "TRANSCEIVER_DOM_SENSOR|Ethernet24"
37) "TRANSCEIVER_INFO|Ethernet32"
38) "TRANSCEIVER_DOM_SENSOR|Ethernet4"
39) "TRANSCEIVER_STATUS|Ethernet16"
40) "TRANSCEIVER_INFO|Ethernet40"
41) "TRANSCEIVER_STATUS|Ethernet20"
42) "TRANSCEIVER_INFO|Ethernet0"
43) "TRANSCEIVER_STATUS|Ethernet4"
44) "TRANSCEIVER_DOM_SENSOR|Ethernet60"
45) "TRANSCEIVER_STATUS|Ethernet60"
46) "TRANSCEIVER_STATUS|Ethernet44"
47) "TRANSCEIVER_STATUS|Ethernet40"
48) "TRANSCEIVER_DOM_SENSOR|Ethernet44"

database1

root@str--acs-1:/# redis-cli -n 6
127.0.0.1:6379[6]> keys *TRANS*
 1) "TRANSCEIVER_STATUS|Ethernet124"
 2) "TRANSCEIVER_DOM_SENSOR|Ethernet68"
 3) "TRANSCEIVER_DOM_SENSOR|Ethernet76"
 4) "TRANSCEIVER_STATUS|Ethernet112"
 5) "TRANSCEIVER_STATUS|Ethernet108"
 6) "TRANSCEIVER_DOM_SENSOR|Ethernet64"
 7) "TRANSCEIVER_DOM_SENSOR|Ethernet108"
 8) "TRANSCEIVER_DOM_SENSOR|Ethernet80"
 9) "TRANSCEIVER_STATUS|Ethernet120"
10) "TRANSCEIVER_STATUS|Ethernet88"
11) "TRANSCEIVER_DOM_SENSOR|Ethernet84"
12) "TRANSCEIVER_INFO|Ethernet72"
13) "TRANSCEIVER_INFO|Ethernet88"
14) "TRANSCEIVER_DOM_SENSOR|Ethernet72"
15) "TRANSCEIVER_STATUS|Ethernet76"
16) "TRANSCEIVER_DOM_SENSOR|Ethernet120"
17) "TRANSCEIVER_STATUS|Ethernet68"
18) "TRANSCEIVER_DOM_SENSOR|Ethernet124"
19) "TRANSCEIVER_INFO|Ethernet120"
20) "TRANSCEIVER_DOM_SENSOR|Ethernet92"
21) "TRANSCEIVER_INFO|Ethernet76"
22) "TRANSCEIVER_DOM_SENSOR|Ethernet88"
23) "TRANSCEIVER_STATUS|Ethernet72"
24) "TRANSCEIVER_INFO|Ethernet80"
25) "TRANSCEIVER_STATUS|Ethernet116"
26) "TRANSCEIVER_INFO|Ethernet108"
27) "TRANSCEIVER_DOM_SENSOR|Ethernet100"
28) "TRANSCEIVER_STATUS|Ethernet104"
29) "TRANSCEIVER_DOM_SENSOR|Ethernet112"
30) "TRANSCEIVER_STATUS|Ethernet64"
31) "TRANSCEIVER_INFO|Ethernet112"
32) "TRANSCEIVER_INFO|Ethernet92"
33) "TRANSCEIVER_INFO|Ethernet104"
34) "TRANSCEIVER_DOM_SENSOR|Ethernet104"
35) "TRANSCEIVER_INFO|Ethernet64"
36) "TRANSCEIVER_STATUS|Ethernet92"
37) "TRANSCEIVER_STATUS|Ethernet84"
38) "TRANSCEIVER_INFO|Ethernet100"
39) "TRANSCEIVER_INFO|Ethernet96"
40) "TRANSCEIVER_DOM_SENSOR|Ethernet96"
41) "TRANSCEIVER_STATUS|Ethernet80"
42) "TRANSCEIVER_INFO|Ethernet124"
43) "TRANSCEIVER_INFO|Ethernet84"
44) "TRANSCEIVER_STATUS|Ethernet96"
45) "TRANSCEIVER_STATUS|Ethernet100"
46) "TRANSCEIVER_INFO|Ethernet68"


admin@str--acs-1:~$ cat /sys/class/leds/port17:green/brightness
255
admin@str--acs-1:~$ sudo ip netns exec asic1 config interface shutdown Ethernet64 
admin@str--acs-1:~$ cat /sys/class/leds/port17:green/brightness
0
admin@str--acs-1:~$ sudo ip netns exec asic1 config interface startup  Ethernet64 
admin@str--acs-1:~$ cat /sys/class/leds/port17:green/brightness
255
```
