### PR TITLE
Modify the import python libary module name.

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -624,8 +624,8 @@ class ThermalControlDaemon(DaemonBase):
         """
         logger.log_info("Starting up...")
 
-        import sonic_platform.platform
-        chassis = sonic_platform.platform.Platform().get_chassis()
+        import sonic_platform_base.platform_base
+        chassis = sonic_platform_base.platform_base.PlatformBase().get_chassis()
 
         thermal_monitor = ThermalMonitor(chassis)
         thermal_monitor.task_run()


### PR DESCRIPTION
Origin module name is import with incorrect name.
It will lets python error appeared as bellowing.
INFO pmon#supervisord: thermalctld   File "/usr/bin/thermalctld", line 586, in main
INFO pmon#supervisord: thermalctld     thermal_control.run()
INFO pmon#supervisord: thermalctld   File "/usr/bin/thermalctld", line 547, in run
INFO pmon#supervisord: thermalctld     import sonic_platform.platform
INFO pmon#supervisord: thermalctld ImportError: No module named sonic_platform.platform
INFO pmon#thermalctld: Starting up...