### PR TITLE
[201811][xcvrd] Return value of main() is returned as process exit code

### DIFF
--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -680,4 +680,4 @@ def main():
     return 1
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())


### PR DESCRIPTION
In Python, the return value of `main()` is not automatically the exit code which gets presented to the OS. This patch will pass the  return value of `main()` to the OS as the exit code.