### PR TITLE
[xcvrd] Save the dom_capability of transceiver into db

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -128,7 +128,8 @@ class TestXcvrdScript(object):
                                                                                 'specification_compliance': '0.7',
                                                                                 'nominal_bit_rate': '0.7',
                                                                                 'application_advertisement': '0.7',
-                                                                                'is_replaceable': '0.7', }))
+                                                                                'is_replaceable': '0.7',
+                                                                                'dom_capability': '0.7', }))
     def test_post_port_sfp_info_to_db(self):
         logical_port_name = "Ethernet0"
         stop_event = threading.Event()
@@ -156,7 +157,8 @@ class TestXcvrdScript(object):
                                                                                 'specification_compliance': '0.7',
                                                                                 'nominal_bit_rate': '0.7',
                                                                                 'application_advertisement': '0.7',
-                                                                                'is_replaceable': '0.7', }))
+                                                                                'is_replaceable': '0.7',
+                                                                                'dom_capability': '0.7', }))
     @patch('xcvrd.xcvrd._wrapper_get_transceiver_dom_threshold_info', MagicMock(return_value={'temphighalarm': '22.75',
                                                                                               'temphighwarning': '0.5',
                                                                                               'templowalarm': '0.7',

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -299,6 +299,7 @@ def post_port_sfp_info_to_db(logical_port_name, table, transceiver_dict,
                      ('application_advertisement', port_info_dict['application_advertisement']
                       if 'application_advertisement' in port_info_dict else 'N/A'),
                      ('is_replaceable', str(is_replaceable)),
+                     ('dom_capability',port_info_dict['dom_capability']),
                      ])
                 table.set(port_name, fvs)
             else:


### PR DESCRIPTION
- What I did
Save the dom_capability gotten from transceiver into db

- How I did it
Add a field-value pair when it try to set the table inside "post_port_sfp_info_to_db" function

- How to verify it
Compare one transceiver which support diagnostic monitoring function to another transceiver which doesn't support it.
Check the db data of the transceiver
Run 'show interfaces transceiver eeprom' command.