### PR TITLE
[xcvrd] Continue legacy platform API support

### DIFF
--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -171,6 +171,14 @@ def _wrapper_get_transceiver_change_event(timeout):
             pass
     return platform_sfputil.get_transceiver_change_event(timeout)
 
+def _wrapper_get_sfp_type(physical_port):
+    if platform_chassis:
+        try:
+            return platform_chassis.get_sfp(physical_port).sfp_type
+        except NotImplementedError:
+            pass
+    return None
+
 # Remove unnecessary unit from the raw data
 def beautify_dom_info_dict(dom_info_dict):
     dom_info_dict['temperature'] = strip_unit_and_beautify(dom_info_dict['temperature'], TEMP_UNIT)
@@ -353,7 +361,7 @@ def post_port_dom_info_to_db(logical_port_name, table, stop_event=threading.Even
             dom_info_dict = _wrapper_get_transceiver_dom_info(physical_port)
             if dom_info_dict is not None:
                 beautify_dom_info_dict(dom_info_dict)
-                if platform_chassis.get_sfp(physical_port).sfp_type == 'QSFP_DD':
+                if _wrapper_get_sfp_type(physical_port) == 'QSFP_DD':
                     fvs = swsscommon.FieldValuePairs(
                         [('temperature', dom_info_dict['temperature']),
                          ('voltage', dom_info_dict['voltage']),


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

At the moment not all platforms migrated to the new platform API.
Fixes following exception in xcvrd:

```
INFO pmon#supervisord: xcvrd Traceback (most recent call last):
INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1212, in <module>
INFO pmon#supervisord: xcvrd     main()
INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1209, in main
INFO pmon#supervisord: xcvrd     xcvrd.run()
INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1170, in run
INFO pmon#supervisord: xcvrd     self.init()
INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1149, in init
INFO pmon#supervisord: xcvrd     post_port_sfp_dom_info_to_db(is_warm_start, self.stop_event)
INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 436, in post_port_sfp_dom_info_to_db
INFO pmon#supervisord: xcvrd     post_port_dom_info_to_db(logical_port_name, dom_tbl, stop_event)
INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 361, in post_port_dom_info_to_db
INFO pmon#supervisord: xcvrd     if platform_chassis.get_sfp(physical_port).sfp_type == 'QSFP_DD':
INFO pmon#supervisord: xcvrd AttributeError: 'NoneType' object has no attribute 'get_sfp'

```