### PR TITLE
[xcvrd] Fix bailing out on platforms that do not support QSFP-DD

### DIFF
--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -171,6 +171,14 @@ def _wrapper_get_transceiver_change_event(timeout):
             pass
     return platform_sfputil.get_transceiver_change_event(timeout)
 
+def _wrapper_get_sfp_type(physical_port):
+    if platform_chassis:
+        try:
+            return platform_chassis.get_sfp(physical_port).sfp_type
+        except (NotImplementedError, AttributeError):
+            pass
+    return None
+
 # Remove unnecessary unit from the raw data
 def beautify_dom_info_dict(dom_info_dict):
     dom_info_dict['temperature'] = strip_unit_and_beautify(dom_info_dict['temperature'], TEMP_UNIT)
@@ -353,7 +361,7 @@ def post_port_dom_info_to_db(logical_port_name, table, stop_event=threading.Even
             dom_info_dict = _wrapper_get_transceiver_dom_info(physical_port)
             if dom_info_dict is not None:
                 beautify_dom_info_dict(dom_info_dict)
-                if hasattr(platform_chassis.get_sfp(physical_port), 'sfp_type') and platform_chassis.get_sfp(physical_port).sfp_type == 'QSFP_DD':
+                if _wrapper_get_sfp_type(physical_port) == 'QSFP_DD':
                     fvs = swsscommon.FieldValuePairs(
                         [('temperature', dom_info_dict['temperature']),
                          ('voltage', dom_info_dict['voltage']),

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -257,7 +257,7 @@ def post_port_sfp_info_to_db(logical_port_name, table, transceiver_dict,
                                                   ('cable_length',port_info_dict['cable_length']),
                                                   ('specification_compliance',port_info_dict['specification_compliance']),
                                                   ('nominal_bit_rate',port_info_dict['nominal_bit_rate']),
-                                                  ('application_advertisement',port_info_dict['application_advertisement'])])
+                                                  ('application_advertisement',port_info_dict['application_advertisement'] if 'application_advertisement' in port_info_dict else 'N/A')])
                 table.set(port_name, fvs)
             else:
                 return SFP_EEPROM_NOT_READY
@@ -353,7 +353,7 @@ def post_port_dom_info_to_db(logical_port_name, table, stop_event=threading.Even
             dom_info_dict = _wrapper_get_transceiver_dom_info(physical_port)
             if dom_info_dict is not None:
                 beautify_dom_info_dict(dom_info_dict)
-                if platform_chassis.get_sfp(physical_port).sfp_type == 'QSFP_DD':
+                if hasattr(platform_chassis.get_sfp(physical_port), 'sfp_type') and platform_chassis.get_sfp(physical_port).sfp_type == 'QSFP_DD':
                     fvs = swsscommon.FieldValuePairs(
                         [('temperature', dom_info_dict['temperature']),
                          ('voltage', dom_info_dict['voltage']),


### PR DESCRIPTION
Merge of QSFP-DD support via PR# https://github.com/Azure/sonic-platform-daemons/pull/66
is making xcvrd to bail out on platforms that do not support
new key/attribute. 

Fix is to ignore new key/attribute if not present/supported yet.

Fix takes changes done as part of PR#https://github.com/Azure/sonic-platform-daemons/pull/76 which can be closed
once this gets merged

Verified manually xcvrd running fine after above changes.
also command  show interface transceiver is showing correct o/p