### PR TITLE
Fix thermalctld tests which were broken by the transition to sonic-py-common

### DIFF
--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -22,13 +22,13 @@ from thermalctld import *
 
 
 def setup_function():
-    logger.log_notice = MagicMock()
-    logger.log_warning = MagicMock()
+    thermal_control.log_notice = MagicMock()
+    thermal_control.log_warning = MagicMock()
 
 
 def teardown_function():
-    logger.log_notice.reset()
-    logger.log_warning.reset()
+    thermal_control.log_notice.reset()
+    thermal_control.log_warning.reset()
 
 
 def test_fanstatus_set_presence():
@@ -99,12 +99,12 @@ def test_fanupdater_fan_absence():
     fan_updater.update()
     fan_list = chassis.get_all_fans()
     assert fan_list[0].get_status_led() == MockFan.STATUS_LED_COLOR_RED
-    logger.log_warning.assert_called()
+    thermal_control.log_warning.assert_called()
 
     fan_list[0].presence = True
     fan_updater.update()
     assert fan_list[0].get_status_led() == MockFan.STATUS_LED_COLOR_GREEN
-    logger.log_notice.assert_called()
+    thermal_control.log_notice.assert_called()
 
 
 def test_fanupdater_fan_fault():
@@ -114,12 +114,12 @@ def test_fanupdater_fan_fault():
     fan_updater.update()
     fan_list = chassis.get_all_fans()
     assert fan_list[0].get_status_led() == MockFan.STATUS_LED_COLOR_RED
-    logger.log_warning.assert_called()
+    thermal_control.log_warning.assert_called()
 
     fan_list[0].status = True
     fan_updater.update()
     assert fan_list[0].get_status_led() == MockFan.STATUS_LED_COLOR_GREEN
-    logger.log_notice.assert_called()
+    thermal_control.log_notice.assert_called()
 
 
 def test_fanupdater_fan_under_speed():
@@ -129,12 +129,12 @@ def test_fanupdater_fan_under_speed():
     fan_updater.update()
     fan_list = chassis.get_all_fans()
     assert fan_list[0].get_status_led() == MockFan.STATUS_LED_COLOR_RED
-    logger.log_warning.assert_called_once()
+    thermal_control.log_warning.assert_called_once()
 
     fan_list[0].make_normal_speed()
     fan_updater.update()
     assert fan_list[0].get_status_led() == MockFan.STATUS_LED_COLOR_GREEN
-    logger.log_notice.assert_called_once()
+    thermal_control.log_notice.assert_called_once()
 
 
 def test_fanupdater_fan_over_speed():
@@ -144,12 +144,12 @@ def test_fanupdater_fan_over_speed():
     fan_updater.update()
     fan_list = chassis.get_all_fans()
     assert fan_list[0].get_status_led() == MockFan.STATUS_LED_COLOR_RED
-    logger.log_warning.assert_called_once()
+    thermal_control.log_warning.assert_called_once()
 
     fan_list[0].make_normal_speed()
     fan_updater.update()
     assert fan_list[0].get_status_led() == MockFan.STATUS_LED_COLOR_GREEN
-    logger.log_notice.assert_called_once()
+    thermal_control.log_notice.assert_called_once()
 
 
 def test_insufficient_fan_number():
@@ -166,19 +166,19 @@ def test_insufficient_fan_number():
     chassis.make_fault_fan()
     fan_updater = FanUpdater(chassis)
     fan_updater.update()
-    assert logger.log_warning.call_count == 3
-    logger.log_warning.assert_called_with('Insufficient number of working fans warning: 2 fans are not working.')
+    assert thermal_control.log_warning.call_count == 3
+    thermal_control.log_warning.assert_called_with('Insufficient number of working fans warning: 2 fans are not working.')
 
     fan_list = chassis.get_all_fans()
     fan_list[0].presence = True
     fan_updater.update()
-    assert logger.log_notice.call_count == 1
-    logger.log_warning.assert_called_with('Insufficient number of working fans warning: 1 fans are not working.')
+    assert thermal_control.log_notice.call_count == 1
+    thermal_control.log_warning.assert_called_with('Insufficient number of working fans warning: 1 fans are not working.')
     
     fan_list[1].status = True
     fan_updater.update()
-    assert logger.log_notice.call_count == 3
-    logger.log_notice.assert_called_with('Insufficient number of working fans warning cleared: all fans are back to normal.')
+    assert thermal_control.log_notice.call_count == 3
+    thermal_control.log_notice.assert_called_with('Insufficient number of working fans warning cleared: all fans are back to normal.')
 
 
 def test_temperature_status_set_over_temper():
@@ -227,11 +227,11 @@ def test_temperupdater_over_temper():
     temperature_updater = TemperatureUpdater(chassis)
     temperature_updater.update()
     thermal_list = chassis.get_all_thermals()
-    logger.log_warning.assert_called_once()
+    thermal_control.log_warning.assert_called_once()
 
     thermal_list[0].make_normal_temper()
     temperature_updater.update()
-    logger.log_notice.assert_called_once()
+    thermal_control.log_notice.assert_called_once()
 
 
 def test_temperupdater_under_temper():
@@ -240,11 +240,11 @@ def test_temperupdater_under_temper():
     temperature_updater = TemperatureUpdater(chassis)
     temperature_updater.update()
     thermal_list = chassis.get_all_thermals()
-    logger.log_warning.assert_called_once()
+    thermal_control.log_warning.assert_called_once()
 
     thermal_list[0].make_normal_temper()
     temperature_updater.update()
-    logger.log_notice.assert_called_once()
+    thermal_control.log_notice.assert_called_once()
 
 
 def test_update_fan_with_exception():
@@ -257,7 +257,7 @@ def test_update_fan_with_exception():
     fan_updater = FanUpdater(chassis)
     fan_updater.update()
     assert fan.get_status_led() == MockFan.STATUS_LED_COLOR_RED
-    logger.log_warning.assert_called()
+    thermal_control.log_warning.assert_called()
 
 
 def test_update_thermal_with_exception():
@@ -269,4 +269,4 @@ def test_update_thermal_with_exception():
 
     temperature_updater = TemperatureUpdater(chassis)
     temperature_updater.update()
-    logger.log_warning.assert_called()
+    thermal_control.log_warning.assert_called()


### PR DESCRIPTION
Fix thermalctld tests which were broken by the transition to sonic-py-common. Logger class is now a superclass of the daemon itself.