### PR TITLE
Python 3 compliance

### DIFF
--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -11,7 +11,7 @@ try:
 
     from sonic_py_common import daemon_base
     from swsscommon import swsscommon
-except ImportError, e:
+except ImportError as e:
     raise ImportError (str(e) + " - required module not found")
 
 #============================= Constants =============================
@@ -45,17 +45,17 @@ class DaemonLedd(daemon_base.DaemonBase):
                 (options, remainder) = getopt.getopt(sys.argv[1:],
                                                    'hv',
                                                    ['help', 'version'])
-            except getopt.GetoptError, e:
-                print e
-                print USAGE_HELP
+            except getopt.GetoptError as e:
+                print(e)
+                print(USAGE_HELP)
                 sys.exit(2)
 
             for opt, arg in options:
                 if opt == '--help' or opt == '-h':
-                    print USAGE_HELP
+                    print(USAGE_HELP)
                     sys.exit(0)
                 elif opt == '--version' or opt == '-v':
-                    print 'ledd version ' + VERSION
+                    print('ledd version ' + VERSION)
                     sys.exit(0)
 
         # Load platform-specific LedControl module

--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -15,7 +15,7 @@ try:
     import swsssdk
     from sonic_py_common.daemon_base import DaemonBase
     from sonic_py_common.device_info import get_platform
-except ImportError, e:
+except ImportError as e:
     raise ImportError(str(e) + " - required module not found")
 
 #

--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -16,7 +16,7 @@ try:
 
     from sonic_py_common import daemon_base
     from swsscommon import swsscommon
-except ImportError, e:
+except ImportError as e:
     raise ImportError (str(e) + " - required module not found")
 
 #

--- a/sonic-syseepromd/scripts/syseepromd
+++ b/sonic-syseepromd/scripts/syseepromd
@@ -15,7 +15,7 @@ try:
 
     from sonic_py_common import daemon_base
     from swsscommon import swsscommon
-except ImportError, e:
+except ImportError as e:
     raise ImportError (str(e) + " - required module not found")
 
 PLATFORM_SPECIFIC_MODULE_NAME = 'eeprom'

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -19,7 +19,7 @@ try:
     from enum import Enum
     from sonic_py_common import daemon_base, device_info, logger
     from swsscommon import swsscommon
-except ImportError, e:
+except ImportError as e:
     raise ImportError (str(e) + " - required module not found")
 
 #
@@ -1128,7 +1128,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         try:
             port_config_file_path = device_info.get_path_to_port_config_file()
             platform_sfputil.read_porttab_mappings(port_config_file_path)
-        except Exception, e:
+        except Exception as e:
             self.log_error("Failed to read port info: %s" % (str(e)), True)
             sys.exit(PORT_CONFIG_LOAD_ERROR)
 


### PR DESCRIPTION
As part of the migration from Python 2 to Python 3, this PR ensures that all Python files in sonic-platform-daemons are Python 3-compliant, and work with both Python 2 and Python 3.

Once this is merged, we can begin building Python 3-based versions of the sonic-platform-daemons packages.