### PR TITLE
Update .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
+*.pyc
+*/*.egg-info/
+*/*.tar.gz
+*/.cache/
+*/.eggs/
+*/__pycache__/
+*/build/
 */deb_dist/
 */dist/
-*/*.tar.gz
-*/*.egg-info
-*/.cache/
-*.pyc
-*/__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 */build/
 */deb_dist/
 */dist/
+
+# Compiled code which doesn't end in '.pyc'
+sonic-thermalctld/scripts/thermalctldc


### PR DESCRIPTION
- Add entries to ignore files generated when building Python 2 and 3 wheel packages of the daemons
- Ignore 'thermalctldc' file
- Organize alphabetically