### PR TITLE
Fix pcied daemon failure

### DIFF
--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -70,6 +70,7 @@ class DaemonPcied(DaemonBase):
                 raise e
 
         resultInfo = platform_pcieutil.get_pcie_check()
+        err = 0
 
         for item in resultInfo:
             if item["result"] == "Failed":


### PR DESCRIPTION
Signed-off-by: Petro Bratash <petrox.bratash@intel.com>

Fix pcied daemon error:
```
Traceback (most recent call last):
  File "/usr/local/bin/pcied", line 144, in <module>
    main()
  File "/usr/local/bin/pcied", line 141, in main
    pcied.run()
  File "/usr/local/bin/pcied", line 125, in run
    self.check_pcie_devices()
  File "/usr/local/bin/pcied", line 79, in check_pcie_devices
    if err:
UnboundLocalError: local variable 'err' referenced before assignment
```