### PR TITLE
[thermalctld] Fix issue: fan status should not be True when fan is absent

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -311,12 +311,15 @@ class FanUpdater(logger.Logger):
             if not is_psu_fan:
                 self._set_fan_led(fan_drawer, fan, fan_name, fan_status)
 
+        if fan_fault_status != NOT_AVAILABLE:
+            fan_fault_status = fan_status.is_ok()
+
         fvs = swsscommon.FieldValuePairs(
             [('presence', str(presence)),
              ('drawer_name', drawer_name),
              ('model', str(try_get(fan.get_model))),
              ('serial', str(try_get(fan.get_serial))),
-             ('status', str(fan_fault_status and not(fan_status.under_speed or fan_status.over_speed))),
+             ('status', str(fan_fault_status)),
              ('direction', str(fan_direction)),
              ('speed', str(speed)),
              ('speed_tolerance', str(speed_tolerance)),


### PR DESCRIPTION
Why I did this?

Fan status displays OK when a fan is removed from system, the expect value should be "N/A"

How I did?

If fan is not present, keep fan status value as "N/A".