### PR TITLE
[pcied] Change STATE_DB key (PCIE_STATUS|PCIE_DEVICES -> PCIE_DEVICES)

### DIFF
--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -78,10 +78,10 @@ class DaemonPcied(DaemonBase):
                 err += 1
 
         if err:
-            self.update_state_db("PCIE_STATUS|", "PCIE_DEVICES", "FAILED")
+            self.update_state_db("PCIE_DEVICES", "status", "FAILED")
             self.log_error("PCIe device status check : FAILED")
         else:
-            self.update_state_db("PCIE_STATUS|", "PCIE_DEVICES", "PASSED")
+            self.update_state_db("PCIE_DEVICES", "status", "PASSED")
             self.log_info("PCIe device status check : PASSED")
 
     def read_state_db(self, key1, key2):


### PR DESCRIPTION
Signed-off-by: Petro Bratash <petrox.bratash@intel.com>

**- Why I did it**
pci-check.service and pcied daemon set different variables in STATE_DB.

- **_pci-check.service_** set "PCIE_STATUS|PCIE_DEVICES" variable with type string,
- **_pcied daemon_**  set "PCIE_STATUS|" -> "PCIE_DEVICES" variable with type hash.


**- How I did it**
Change name for variable with PCI devices status.
"PCIE_STATUS|" : "PCIE_DEVICES" --------------> "PCIE_DEVICES" : "status")

Related PR: https://github.com/Azure/sonic-buildimage/pull/5368
Fix the bug: https://github.com/Azure/sonic-buildimage/issues/5349