### PR TITLE
[thermalctld] Fix issue: thermalctld should be auto restarted when being killed

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -632,7 +632,7 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
             self.log_info("Caught SIGHUP - ignoring...")
         elif sig == signal.SIGINT or sig == signal.SIGTERM:
             self.log_info("Caught signal {} - exiting...".format(sig))
-            self.exit_code = sig
+            self.exit_code = sig + 128
             self.stop_event.set()
         else:
             self.log_warning("Caught unhandled signal '" + sig + "'")

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -618,7 +618,11 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
         """
         super(ThermalControlDaemon, self).__init__(log_identifier)
         self.stop_event = threading.Event()
-        self.exit_code = -1
+
+        # Thermal control daemon is designed to never exit, it must always
+        # return non zero exit code when exiting and so that supervisord will 
+        # restart it automatically.
+        self.exit_code = 1
 
     # Signal handler
     def signal_handler(self, sig, frame):

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -618,6 +618,7 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
         """
         super(ThermalControlDaemon, self).__init__(log_identifier)
         self.stop_event = threading.Event()
+        self.exit_code = -1
 
     # Signal handler
     def signal_handler(self, sig, frame):
@@ -629,11 +630,9 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
         """
         if sig == signal.SIGHUP:
             self.log_info("Caught SIGHUP - ignoring...")
-        elif sig == signal.SIGINT:
-            self.log_info("Caught SIGINT - exiting...")
-            self.stop_event.set()
-        elif sig == signal.SIGTERM:
-            self.log_info("Caught SIGTERM - exiting...")
+        elif sig == signal.SIGINT or sig == signal.SIGTERM:
+            self.log_info("Caught signal {} - exiting...".format(sig))
+            self.exit_code = sig
             self.stop_event.set()
         else:
             self.log_warning("Caught unhandled signal '" + sig + "'")
@@ -687,7 +686,8 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
 
         thermal_monitor.task_stop()
 
-        self.log_info("Shutdown...")
+        self.log_info("Shutdown with exit code {}...".format(self.exit_code))
+        exit(self.exit_code)
 
 
 #


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

Part of thermalctld function is to handle user space thermal policies for events like fan/PSU removing, it works together with kernel thermal algorithm to make sure the switch won't be overheat.

Recently, we found that commit https://github.com/Azure/sonic-buildimage/commit/cbc75fe4c85fd01aded0bacb283c8bbf62adf2f8 changes its autorestart configuration in supervisord, and it won't be auto restarted after being killed. This PR is to make sure that thermalctld will be always restarted when it is killed.

**- How I did it**

1. Catch signal and assign it to a exit_code member data
2. Add a line "exit(self.exit_code)" to make sure it won't always exit with code 0

**- How to verify it**

Manual test

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

Depends on where https://github.com/Azure/sonic-buildimage/commit/cbc75fe4c85fd01aded0bacb283c8bbf62adf2f8 is going to merge to. 

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
