### PR TITLE
Add 'wheel' package to 'setup_requires' list in all setup.py files

### DIFF
--- a/sonic-ledd/setup.py
+++ b/sonic-ledd/setup.py
@@ -13,6 +13,9 @@ setup(
     scripts=[
         'scripts/ledd',
     ],
+    setup_requires= [
+        'wheel'
+    ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: No Input/Output (Daemon)',

--- a/sonic-pcied/setup.py
+++ b/sonic-pcied/setup.py
@@ -13,6 +13,9 @@ setup(
     scripts=[
         'scripts/pcied',
     ],
+    setup_requires= [
+        'wheel'
+    ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: No Input/Output (Daemon)',

--- a/sonic-psud/setup.py
+++ b/sonic-psud/setup.py
@@ -13,6 +13,9 @@ setup(
     scripts=[
         'scripts/psud',
     ],
+    setup_requires= [
+        'wheel'
+    ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: No Input/Output (Daemon)',

--- a/sonic-syseepromd/setup.py
+++ b/sonic-syseepromd/setup.py
@@ -13,6 +13,9 @@ setup(
     scripts=[
         'scripts/syseepromd',
     ],
+    setup_requires= [
+        'wheel'
+    ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: No Input/Output (Daemon)',

--- a/sonic-thermalctld/setup.py
+++ b/sonic-thermalctld/setup.py
@@ -17,7 +17,8 @@ setup(
         'scripts/thermalctld',
     ],
     setup_requires= [
-        'pytest-runner'
+        'pytest-runner',
+        'wheel'
     ],
     tests_require = [
         'pytest',

--- a/sonic-xcvrd/setup.py
+++ b/sonic-xcvrd/setup.py
@@ -13,6 +13,9 @@ setup(
     scripts=[
         'scripts/xcvrd',
     ],
+    setup_requires= [
+        'wheel'
+    ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: No Input/Output (Daemon)',


### PR DESCRIPTION
Add 'wheel' to the list of packages required for building the package. This way it will be implicitly installed at build time, preventing the need to install the 'wheel' package explicitly in our build environment.