### PR TITLE
[Thermalctld] Update thermal info to CHASSIS_STATE_DB

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -463,6 +463,13 @@ class TemperatureUpdater(logger.Logger):
         state_db = daemon_base.db_connect("STATE_DB")
         self.table = swsscommon.Table(state_db, TemperatureUpdater.TEMPER_INFO_TABLE_NAME)
 
+        self.is_chassis_system = chassis.is_modular_chassis()
+        if self.is_chassis_system:
+            my_slot = chassis.get_my_slot()
+            table_name = TemperatureUpdater.TEMPER_INFO_TABLE_NAME+'_'+str(my_slot)
+            global_state_db = daemon_base.db_connect("GLOBAL_STATE_DB")
+            self.global_table = swsscommon.Table(global_state_db, table_name)
+
     def deinit(self):
         """
         Destructor of TemperatureUpdater 
@@ -470,6 +477,8 @@ class TemperatureUpdater(logger.Logger):
         """
         for name in self.temperature_status_dict.keys():
             self.table._del(name)
+            if self.is_chassis_system:
+                self.global_table._del(name)
 
     def _log_on_status_changed(self, normal_status, normal_log, abnormal_log):
         """
@@ -515,9 +524,13 @@ class TemperatureUpdater(logger.Logger):
         low_threshold = NOT_AVAILABLE
         high_critical_threshold = NOT_AVAILABLE
         low_critical_threshold = NOT_AVAILABLE
+        maximum_temperature = NOT_AVAILABLE
+        minimum_temperature = NOT_AVAILABLE
         temperature = try_get(thermal.get_temperature)
         if temperature != NOT_AVAILABLE:
             temperature_status.set_temperature(name, temperature)
+            minimum_temperature = try_get(thermal.get_minimum_recorded)
+            maximum_temperature = try_get(thermal.get_maximum_recorded)
             high_threshold = try_get(thermal.get_high_threshold)
             low_threshold = try_get(thermal.get_low_threshold)
             high_critical_threshold = try_get(thermal.get_high_critical_threshold)
@@ -544,6 +557,8 @@ class TemperatureUpdater(logger.Logger):
 
         fvs = swsscommon.FieldValuePairs(
             [('temperature', str(temperature)),
+             ('minimum_temperature', str(minimum_temperature)),
+             ('maximum_temperature', str(maximum_temperature)),
              ('high_threshold', str(high_threshold)),
              ('low_threshold', str(low_threshold)),
              ('warning_status', str(warning)),
@@ -553,6 +568,8 @@ class TemperatureUpdater(logger.Logger):
              ])
 
         self.table.set(name, fvs)
+        if self.is_chassis_system:
+            self.global_table.set(name, fvs)
 
 
 class ThermalMonitor(ProcessTaskBase):

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -23,6 +23,7 @@ except ImportError as e:
 
 SYSLOG_IDENTIFIER = 'thermalctld'
 NOT_AVAILABLE = 'N/A'
+INVALID_SLOT = -1
 
 # utility functions
 
@@ -462,13 +463,15 @@ class TemperatureUpdater(logger.Logger):
         self.temperature_status_dict = {}
         state_db = daemon_base.db_connect("STATE_DB")
         self.table = swsscommon.Table(state_db, TemperatureUpdater.TEMPER_INFO_TABLE_NAME)
+        self.chassis_table = None
 
         self.is_chassis_system = chassis.is_modular_chassis()
         if self.is_chassis_system:
-            my_slot = chassis.get_my_slot()
-            table_name = TemperatureUpdater.TEMPER_INFO_TABLE_NAME+'_'+str(my_slot)
-            global_state_db = daemon_base.db_connect("GLOBAL_STATE_DB")
-            self.global_table = swsscommon.Table(global_state_db, table_name)
+            my_slot = try_get(chassis.get_my_slot, INVALID_SLOT)
+            if my_slot != INVALID_SLOT:
+                table_name = TemperatureUpdater.TEMPER_INFO_TABLE_NAME+'_'+str(my_slot)
+                chassis_state_db = daemon_base.db_connect("CHASSIS_STATE_DB")
+                self.chassis_table = swsscommon.Table(chassis_state_db, table_name)
 
     def deinit(self):
         """
@@ -477,8 +480,8 @@ class TemperatureUpdater(logger.Logger):
         """
         for name in self.temperature_status_dict.keys():
             self.table._del(name)
-            if self.is_chassis_system:
-                self.global_table._del(name)
+            if self.is_chassis_system and self.chassis_table is not None:
+                self.chassis_table._del(name)
 
     def _log_on_status_changed(self, normal_status, normal_log, abnormal_log):
         """
@@ -568,8 +571,8 @@ class TemperatureUpdater(logger.Logger):
              ])
 
         self.table.set(name, fvs)
-        if self.is_chassis_system:
-            self.global_table.set(name, fvs)
+        if self.is_chassis_system and self.chassis_table is not None:
+            self.chassis_table.set(name, fvs)
 
 
 class ThermalMonitor(ProcessTaskBase):

--- a/sonic-thermalctld/tests/mock_platform.py
+++ b/sonic-thermalctld/tests/mock_platform.py
@@ -104,6 +104,8 @@ class MockThermal:
     def __init__(self):
         self.name = None
         self.temperature = 2
+        self.minimum_temperature = 1
+        self.maximum_temperature = 5
         self.high_threshold = 3
         self.low_threshold = 1
         self.high_critical_threshold = 4
@@ -114,6 +116,12 @@ class MockThermal:
 
     def get_temperature(self):
         return self.temperature
+
+    def get_minimum_recorded(self):
+        return self.minimum_temperature
+
+    def get_maximum_recorded(self):
+        return self.maximum_temperature
 
     def get_high_threshold(self):
         return self.high_threshold
@@ -154,6 +162,9 @@ class MockChassis:
         self.psu_list = []
         self.thermal_list = []
         self.fan_drawer_list = []
+
+    def is_modular_chassis(self):
+        return False
 
     def get_all_fans(self):
         return self.fan_list

--- a/sonic-thermalctld/tests/mock_platform.py
+++ b/sonic-thermalctld/tests/mock_platform.py
@@ -162,9 +162,7 @@ class MockChassis:
         self.psu_list = []
         self.thermal_list = []
         self.fan_drawer_list = []
-
-    def is_modular_chassis(self):
-        return False
+        self.is_chassis_system = False
 
     def get_all_fans(self):
         return self.fan_list
@@ -177,6 +175,9 @@ class MockChassis:
 
     def get_all_fan_drawers(self):
         return self.fan_drawer_list
+
+    def get_num_thermals(self):
+        return len(self.thermal_list)
 
     def make_absence_fan(self):
         fan = MockFan()
@@ -231,3 +232,14 @@ class MockChassis:
         thermal = MockErrorThermal()
         self.thermal_list.append(thermal)
 
+    def is_modular_chassis(self):
+        return self.is_chassis_system
+
+    def set_modular_chassis(self, is_true):
+        self.is_chassis_system = is_true
+
+    def set_my_slot(self, my_slot):
+        self.my_slot = my_slot
+
+    def get_my_slot(self):
+        return self.my_slot

--- a/sonic-thermalctld/tests/mock_swsscommon.py
+++ b/sonic-thermalctld/tests/mock_swsscommon.py
@@ -1,17 +1,28 @@
 STATE_DB = ''
-GLOBAL_STATE_DB = ''
+CHASSIS_STATE_DB = ''
 
 class Table:
     def __init__(self, db, table_name):
       self.table_name = table_name
+      self.mock_dict = {}
 
     def _del(self, key):
+        del self.mock_dict[key]
         pass
 
     def set(self, key, fvs):
+        self.mock_dict[key] = fvs.fv_dict
         pass
 
+    def get(self, key):
+        if key in self.mock_dict:
+            return self.mock_dict[key]
+        return None
+
+    def get_size(self):
+        return (len(self.mock_dict))
 
 class FieldValuePairs:
-  def __init__(self, fvs):
-    pass
+    def __init__(self, fvs):
+        self.fv_dict = dict(fvs)
+        pass

--- a/sonic-thermalctld/tests/mock_swsscommon.py
+++ b/sonic-thermalctld/tests/mock_swsscommon.py
@@ -1,5 +1,5 @@
 STATE_DB = ''
-
+GLOBAL_STATE_DB = ''
 
 class Table:
     def __init__(self, db, table_name):


### PR DESCRIPTION
Enhance thermalctld to write to chassis state-DB on a modular chassis

HLD: Azure/SONiC#646

In a modular chassis, the thermal information from all line-cards
will be updated to the chassis state-DB in the control-card.

Additionally, minimum and maximum temperatures will be recorded.
The fan control algorithm used by certain vendors will require
this information.