### PR TITLE
[xcvrd] Add enum dependence back; Install 'enum34' conditionally based on Python version

### DIFF
--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -18,8 +18,8 @@ try:
 
     from enum import Enum
     from sonic_py_common import daemon_base, device_info, logger
-    from swsscommon import swsscommon
     from sonic_py_common import multi_asic
+    from swsscommon import swsscommon
 except ImportError, e:
     raise ImportError (str(e) + " - required module not found")
 

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -16,9 +16,10 @@ try:
     import threading
     import time
 
+    from enum import Enum
     from sonic_py_common import daemon_base, device_info, logger
-    from sonic_py_common import multi_asic
     from swsscommon import swsscommon
+    from sonic_py_common import multi_asic
 except ImportError, e:
     raise ImportError (str(e) + " - required module not found")
 
@@ -45,21 +46,13 @@ XCVRD_MAIN_THREAD_SLEEP_SECS = 60
 SFP_STATUS_REMOVED = '0'
 SFP_STATUS_INSERTED = '1'
 
-# SFP error codes, stored as strings. Can add more as needed.
-SFP_STATUS_ERR_I2C_STUCK = '2'
-SFP_STATUS_ERR_BAD_EEPROM = '3'
-SFP_STATUS_ERR_UNSUPPORTED_CABLE = '4'
-SFP_STATUS_ERR_HIGH_TEMP = '5'
-SFP_STATUS_ERR_BAD_CABLE = '6'
+# SFP error code enum, new elements can be added to the enum if new errors need to be supported.
+SFP_STATUS_ERR_ENUM = Enum('SFP_STATUS_ERR_ENUM', ['SFP_STATUS_ERR_I2C_STUCK', 'SFP_STATUS_ERR_BAD_EEPROM', 
+                                                  'SFP_STATUS_ERR_UNSUPPORTED_CABLE', 'SFP_STATUS_ERR_HIGH_TEMP',
+                                                  'SFP_STATUS_ERR_BAD_CABLE'], start=2)
 
-# Store the error codes in a set for convenience
-errors_block_eeprom_reading = {
-    SFP_STATUS_ERR_I2C_STUCK,
-    SFP_STATUS_ERR_BAD_EEPROM,
-    SFP_STATUS_ERR_UNSUPPORTED_CABLE,
-    SFP_STATUS_ERR_HIGH_TEMP,
-    SFP_STATUS_ERR_BAD_CABLE
-}
+# Convert the error code to string and store them in a set for convenience
+errors_block_eeprom_reading = set(str(error_code.value) for error_code in SFP_STATUS_ERR_ENUM)
 
 EVENT_ON_ALL_SFP = '-1'
 # events definition

--- a/sonic-xcvrd/setup.py
+++ b/sonic-xcvrd/setup.py
@@ -1,26 +1,22 @@
 from setuptools import setup
 
 setup(
-    name = 'sonic-xcvrd',
-    version = '1.0',
-    description = 'Transceiver monitoring daemon for SONiC',
-    license = 'Apache 2.0',
-    author = 'SONiC Team',
-    author_email = 'linuxnetdev@microsoft.com',
-    url = 'https://github.com/Azure/sonic-platform-daemons',
-    maintainer = 'Kebo Liu',
-    maintainer_email = 'kebol@mellanox.com',
-    scripts = [
+    name='sonic-xcvrd',
+    version='1.0',
+    description='Transceiver monitoring daemon for SONiC',
+    license='Apache 2.0',
+    author='SONiC Team',
+    author_email='linuxnetdev@microsoft.com',
+    url='https://github.com/Azure/sonic-platform-daemons',
+    maintainer='Kebo Liu',
+    maintainer_email='kebol@mellanox.com',
+    scripts=[
         'scripts/xcvrd',
     ],
-    install_requires = [
-        # NOTE: This package also requires swsscommon, but it is not currently installed as a wheel
-        'sonic-py-common',
-    ],
-    setup_requires = [
+    setup_requires= [
         'wheel'
     ],
-    classifiers = [
+    classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: No Input/Output (Daemon)',
         'Intended Audience :: Developers',
@@ -32,5 +28,5 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Topic :: System :: Hardware',
     ],
-    keywords = 'sonic SONiC TRANSCEIVER transceiver daemon XCVRD xcvrd',
+    keywords='sonic SONiC TRANSCEIVER transceiver daemon XCVRD xcvrd',
 )

--- a/sonic-xcvrd/setup.py
+++ b/sonic-xcvrd/setup.py
@@ -15,7 +15,7 @@ setup(
     ],
     install_requires = [
         # NOTE: This package also requires swsscommon, but it is not currently installed as a wheel
-        'enum34; python_version < "3.4"'
+        'enum34; python_version < "3.4"',
         'sonic-py-common',
     ],
     setup_requires = [

--- a/sonic-xcvrd/setup.py
+++ b/sonic-xcvrd/setup.py
@@ -1,22 +1,27 @@
 from setuptools import setup
 
 setup(
-    name='sonic-xcvrd',
-    version='1.0',
-    description='Transceiver monitoring daemon for SONiC',
-    license='Apache 2.0',
-    author='SONiC Team',
-    author_email='linuxnetdev@microsoft.com',
-    url='https://github.com/Azure/sonic-platform-daemons',
-    maintainer='Kebo Liu',
-    maintainer_email='kebol@mellanox.com',
-    scripts=[
+    name = 'sonic-xcvrd',
+    version = '1.0',
+    description = 'Transceiver monitoring daemon for SONiC',
+    license = 'Apache 2.0',
+    author = 'SONiC Team',
+    author_email = 'linuxnetdev@microsoft.com',
+    url = 'https://github.com/Azure/sonic-platform-daemons',
+    maintainer = 'Kebo Liu',
+    maintainer_email = 'kebol@mellanox.com',
+    scripts = [
         'scripts/xcvrd',
     ],
-    setup_requires= [
+    install_requires = [
+        # NOTE: This package also requires swsscommon, but it is not currently installed as a wheel
+        'enum34; python_version < "3.4"'
+        'sonic-py-common',
+    ],
+    setup_requires = [
         'wheel'
     ],
-    classifiers=[
+    classifiers = [
         'Development Status :: 4 - Beta',
         'Environment :: No Input/Output (Daemon)',
         'Intended Audience :: Developers',
@@ -28,5 +33,5 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Topic :: System :: Hardware',
     ],
-    keywords='sonic SONiC TRANSCEIVER transceiver daemon XCVRD xcvrd',
+    keywords = 'sonic SONiC TRANSCEIVER transceiver daemon XCVRD xcvrd',
 )


### PR DESCRIPTION
Add dependence on 'enum' package back to xcvrd (basically reverting most of https://github.com/Azure/sonic-platform-daemons/pull/106). However, in setup.py, we only install the enum34 package if the version of Python we are installing for is < 3.4. Thus, when installing the Python 3 xcvrd package in Python 2.7, the Python 2 version of enum34 will be installed. However, if installing the Python 3 xcvrd package on Python 3.7, enum34 will not be installed, causing xcrvd to import the 'enum' module from the standard library. This should prevent any conflicts which arise when 'enum34' is ever installed on Python versions >= 3.4 by preventing this situation.