### PR TITLE
[xcvrd] Remove log errors in single ASIC platforms with init Global config

### DIFF
--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -790,9 +790,6 @@ class DomInfoUpdateTask(object):
         self.task_thread = None
         self.task_stopping_event = threading.Event()
 
-        # Load the namespace details first from the database_global.json file.
-        swsscommon.SonicDBConfig.initializeGlobalConfig()
-
     def task_worker(self):
         helper_logger.log_info("Start DOM monitoring loop")
 
@@ -839,9 +836,6 @@ class SfpStateUpdateTask(object):
     def __init__(self):
         self.task_process = None
         self.task_stopping_event = multiprocessing.Event()
-
-        # Load the namespace details first from the database_global.json file.
-        swsscommon.SonicDBConfig.initializeGlobalConfig()
 
     def _mapping_event_from_change_event(self, status, port_dict):
         """
@@ -1195,8 +1189,9 @@ class DaemonXcvrd(daemon_base.DaemonBase):
                 self.log_error("Failed to load sfputil: %s" % (str(e)), True)
                 sys.exit(SFPUTIL_LOAD_ERROR)
 
-        # Load the namespace details first from the database_global.json file.
-        swsscommon.SonicDBConfig.initializeGlobalConfig()
+        if multi_asic.is_multi_asic():
+            # Load the namespace details first from the database_global.json file.
+            swsscommon.SonicDBConfig.initializeGlobalConfig()
 
         # Load port info
         try:


### PR DESCRIPTION
Add check to make sure that the initializeGlobalConfig is invoked only in multi-asic platforms.

Additionaly remove the initializeGlobalConfig() call in the DomUpdate thread and SFPUpdate process. This is because initializeGlobalConfig() is already invoked and initialized in the parent Xcvrd daemon which is available to the child thread/process.

This fixes https://github.com/Azure/sonic-buildimage/issues/5680