### PR TITLE
[chassisd][thermalctld] Import of mock libraries determined by environment variable

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -14,18 +14,16 @@ try:
 
     from sonic_py_common import daemon_base, logger
     from sonic_py_common.task_base import ProcessTaskBase
+
+    # If unit testing is occurring, mock swsscommon and module_base
+    if os.environ["CHASSISD_UNIT_TESTING"] == "1":
+        from tests import mock_swsscommon as swsscommon
+        from tests.mock_module_base import ModuleBase
+    else:
+        from swsscommon import swsscommon
+        from sonic_platform_base.module_base import ModuleBase
 except ImportError as e:
     raise ImportError (str(e) + " - required module not found")
-
-try:
-    from swsscommon import swsscommon
-except ImportError as e:
-    from tests import mock_swsscommon as swsscommon
-
-try:
-    from sonic_platform_base.module_base import ModuleBase
-except ImportError as e:
-    from tests.mock_module_base import ModuleBase
 
 #
 # Constants ====================================================================

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from imp import load_source
 
 from mock import Mock, MagicMock, patch
 from sonic_py_common import daemon_base
@@ -17,10 +18,7 @@ modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, modules_path)
 
-from imp import load_source
 
-load_source('chassisd', scripts_path + '/chassisd')
-from chassisd import *
 
 CHASSIS_MODULE_INFO_NAME_FIELD = 'name'
 CHASSIS_MODULE_INFO_DESC_FIELD = 'desc'
@@ -31,6 +29,11 @@ CHASSIS_INFO_KEY_TEMPLATE = 'CHASSIS {}'
 CHASSIS_INFO_CARD_NUM_FIELD = 'module_num'
 
 def setup_function():
+    os.environ["CHASSISD_UNIT_TESTING"] = "1"
+
+    load_source('chassisd', scripts_path + '/chassisd')
+    from chassisd import *
+
     ModuleUpdater.log_notice = MagicMock()
     ModuleUpdater.log_warning = MagicMock()
 
@@ -38,6 +41,7 @@ def setup_function():
 def teardown_function():
     ModuleUpdater.log_notice.reset()
     ModuleUpdater.log_warning.reset()
+    os.environ["CHASSISD_UNIT_TESTING"] = "0"
 
 
 def test_moduleupdater_check_valid_fields():

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -13,13 +13,15 @@ try:
 
     from sonic_py_common import daemon_base, logger
     from sonic_py_common.task_base import ProcessTaskBase
+
+    # If unit testing is occurring, mock swsscommon
+    if os.environ["THERMALCTLD_UNIT_TESTING"] == "1":
+        from tests import mock_swsscommon as swsscommon
+    else:
+        from swsscommon import swsscommon
 except ImportError as e:
     raise ImportError(repr(e) + " - required module not found")
 
-try:
-    from swsscommon import swsscommon
-except ImportError as e:
-    from tests import mock_swsscommon as swsscommon
 
 SYSLOG_IDENTIFIER = 'thermalctld'
 NOT_AVAILABLE = 'N/A'

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from imp import load_source
 
 from mock import Mock, MagicMock, patch
 from sonic_py_common import daemon_base
@@ -16,14 +17,15 @@ modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, modules_path)
 
-from imp import load_source
-
-load_source('thermalctld', scripts_path + '/thermalctld')
-from thermalctld import *
 
 TEMPER_INFO_TABLE_NAME = 'TEMPERATURE_INFO'
 
 def setup_function():
+    os.environ["THERMALCTLD_UNIT_TESTING"] = "1"
+
+    load_source('thermalctld', scripts_path + '/thermalctld')
+    from thermalctld import *
+
     FanStatus.log_notice = MagicMock()
     FanStatus.log_warning = MagicMock()
     FanUpdater.log_notice = MagicMock()
@@ -43,6 +45,7 @@ def teardown_function():
     TemperatureStatus.log_warning.reset()
     TemperatureUpdater.log_warning.reset()
     TemperatureUpdater.log_warning.reset()
+    os.environ["THERMALCTLD_UNIT_TESTING"] = "0"
 
 
 def test_fanstatus_set_presence():


### PR DESCRIPTION
Previously, chassisd and thermalctld assumed that the swsscommon library would not be installed in the unit testing environment. This is not a valid assumption, and would cause unit tests to fail if swsscommon was available in the unit test environement, because it would get imported, but there would be no Redis DB to communicate with.

This PR uses environment variables, which are set by the unit tests themselves, to determine whether to load the real or mock libraries. This solution is similar to what is done in sonic-utilities.