### PR TITLE
[chassisd][thermalctld] Import os module, now needed for env var checking

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -8,6 +8,7 @@
 """
 
 try:
+    import os
     import signal
     import sys
     import threading

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -6,6 +6,7 @@
 """
 
 try:
+    import os
     import signal
     import threading
     import time


### PR DESCRIPTION
This was missed in https://github.com/Azure/sonic-platform-daemons/pull/112