### PR TITLE
[chassisd][thermalctld] Set testing env var at top of file, not in setup_function()

### DIFF
--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -18,6 +18,9 @@ modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, modules_path)
 
+os.environ["CHASSISD_UNIT_TESTING"] = "1"
+load_source('chassisd', scripts_path + '/chassisd')
+from chassisd import *
 
 
 CHASSIS_MODULE_INFO_NAME_FIELD = 'name'
@@ -29,11 +32,6 @@ CHASSIS_INFO_KEY_TEMPLATE = 'CHASSIS {}'
 CHASSIS_INFO_CARD_NUM_FIELD = 'module_num'
 
 def setup_function():
-    os.environ["CHASSISD_UNIT_TESTING"] = "1"
-
-    load_source('chassisd', scripts_path + '/chassisd')
-    from chassisd import *
-
     ModuleUpdater.log_notice = MagicMock()
     ModuleUpdater.log_warning = MagicMock()
 
@@ -41,7 +39,6 @@ def setup_function():
 def teardown_function():
     ModuleUpdater.log_notice.reset()
     ModuleUpdater.log_warning.reset()
-    os.environ["CHASSISD_UNIT_TESTING"] = "0"
 
 
 def test_moduleupdater_check_valid_fields():

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -17,15 +17,14 @@ modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, modules_path)
 
+os.environ["THERMALCTLD_UNIT_TESTING"] = "1"
+load_source('thermalctld', scripts_path + '/thermalctld')
+from thermalctld import *
+
 
 TEMPER_INFO_TABLE_NAME = 'TEMPERATURE_INFO'
 
 def setup_function():
-    os.environ["THERMALCTLD_UNIT_TESTING"] = "1"
-
-    load_source('thermalctld', scripts_path + '/thermalctld')
-    from thermalctld import *
-
     FanStatus.log_notice = MagicMock()
     FanStatus.log_warning = MagicMock()
     FanUpdater.log_notice = MagicMock()
@@ -45,7 +44,6 @@ def teardown_function():
     TemperatureStatus.log_warning.reset()
     TemperatureUpdater.log_warning.reset()
     TemperatureUpdater.log_warning.reset()
-    os.environ["THERMALCTLD_UNIT_TESTING"] = "0"
 
 
 def test_fanstatus_set_presence():


### PR DESCRIPTION
Since these tests are run via unittest infrastructure, and not via Pytest, `setup_function()` is not the proper location to set these variables.