### PR TITLE
[psud] Import of mock libraries determined by environment variable

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -10,24 +10,23 @@
 """
 
 try:
+    import os
     import signal
     import sys
     import threading
 
     from sonic_py_common import daemon_base, logger
 
+    # If unit testing is occurring, mock swsscommon and module_base
+    if os.environ["PSUD_UNIT_TESTING"] == "1":
+        from tests import mock_swsscommon as swsscommon
+        from tests.mock_device_base import DeviceBase
+    else:
+        from swsscommon import swsscommon
+        from sonic_platform_base.device_base import DeviceBase
 except ImportError as e:
     raise ImportError (str(e) + " - required module not found")
 
-try:
-    from swsscommon import swsscommon
-except ImportError as e:
-    from tests import mock_swsscommon as swsscommon
-
-try:
-    from sonic_platform_base.device_base import DeviceBase
-except ImportError as e:
-    from tests.mock_device_base import DeviceBase
 
 #
 # Constants ====================================================================

--- a/sonic-psud/tests/test_psud.py
+++ b/sonic-psud/tests/test_psud.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from imp import load_source
 
 from mock import Mock, MagicMock, patch
 from sonic_py_common import daemon_base
@@ -17,8 +18,7 @@ modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, modules_path)
 
-from imp import load_source
-
+os.environ["PSUD_UNIT_TESTING"] = "1"
 load_source('psud', scripts_path + '/psud')
 from psud import *
 


### PR DESCRIPTION
Previously, psud assumed that the swsscommon library would not be installed in the unit testing environment. This is not a valid assumption, and would cause unit tests to fail if swsscommon was available in the unit test environment, because it would get imported, but there would be no Redis DB to communicate with.

This PR uses environment variables, which are set by the unit tests themselves, to determine whether to load the real or mock libraries. This solution is similar to what is done in sonic-utilities.