### PR TITLE
[thermalctld] [psud] [chassisd] Fix crash with undefined environment variable

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -17,7 +17,7 @@ try:
     from sonic_py_common.task_base import ProcessTaskBase
 
     # If unit testing is occurring, mock swsscommon and module_base
-    if os.environ["CHASSISD_UNIT_TESTING"] == "1":
+    if os.getenv("CHASSISD_UNIT_TESTING") == "1":
         from tests import mock_swsscommon as swsscommon
         from tests.mock_module_base import ModuleBase
     else:

--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -18,7 +18,7 @@ try:
     from sonic_py_common import daemon_base, logger
 
     # If unit testing is occurring, mock swsscommon and module_base
-    if os.environ["PSUD_UNIT_TESTING"] == "1":
+    if os.getenv("PSUD_UNIT_TESTING") == "1":
         from tests import mock_swsscommon as swsscommon
         from tests.mock_device_base import DeviceBase
     else:

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -16,7 +16,7 @@ try:
     from sonic_py_common.task_base import ProcessTaskBase
 
     # If unit testing is occurring, mock swsscommon
-    if os.environ["THERMALCTLD_UNIT_TESTING"] == "1":
+    if os.getenv("THERMALCTLD_UNIT_TESTING") == "1":
         from tests import mock_swsscommon as swsscommon
     else:
         from swsscommon import swsscommon


### PR DESCRIPTION
 
When  `PSUD_UNIT_TESTING` and  `THERMALCTLD_UNIT_TESTING` variables don`t set we have the next problems:
```
 psud Traceback (most recent call last):
 psud File "/usr/local/bin/psud", line 21, in <module>
 psud if os.environ["PSUD_UNIT_TESTING"] == "1":
 psud File "/usr/lib/python2.7/UserDict.py", line 40, in __getitem__
 psud raise KeyError(key)
 psud KeyError: 'PSUD_UNIT_TESTING'
```

```
 thermalctld Traceback (most recent call last):
 thermalctld File "/usr/local/bin/thermalctld", line 19, in <module>
 thermalctld if os.environ["THERMALCTLD_UNIT_TESTING"] == "1":
 thermalctld File "/usr/lib/python2.7/UserDict.py", line 40, in __getitem__
 thermalctld raise KeyError(key)
 thermalctld KeyError: 'THERMALCTLD_UNIT_TESTING'
```

Also fixed the same issue in `chassisd`.

Signed-off-by: Petro Bratash <petrox.bratash@intel.com>