### PR TITLE
Fix test_updater_thermal_check_min_max() failure

### DIFF
--- a/sonic-thermalctld/tests/mock_platform.py
+++ b/sonic-thermalctld/tests/mock_platform.py
@@ -112,9 +112,10 @@ class MockFanDrawer(MockDevice):
 
 
 class MockThermal(MockDevice):
-    def __init__(self):
+    def __init__(self, index = None):
         MockDevice.__init__(self)
         self.name = None
+        self.name = 'Thermal {}'.format(index) if index != None else None
         self.temperature = 2
         self.minimum_temperature = 1
         self.maximum_temperature = 5
@@ -122,7 +123,7 @@ class MockThermal(MockDevice):
         self.low_threshold = 1
         self.high_critical_threshold = 4
         self.low_critical_threshold = 0
-    
+
     def get_name(self):
         return self.name
 

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -329,7 +329,7 @@ def test_updater_thermal_check_chassis_table():
 def test_updater_thermal_check_min_max():
     chassis = MockChassis()
 
-    thermal = MockThermal()
+    thermal = MockThermal(1)
     chassis.get_all_thermals().append(thermal)
 
     chassis.set_modular_chassis(True)
@@ -337,6 +337,6 @@ def test_updater_thermal_check_min_max():
     temperature_updater = TemperatureUpdater(SYSLOG_IDENTIFIER, chassis)
 
     temperature_updater.update()
-    slot_dict = temperature_updater.chassis_table.get('Thermal 1')
+    slot_dict = temperature_updater.chassis_table.get(thermal.get_name())
     assert slot_dict['minimum_temperature'] == str(thermal.get_minimum_recorded())
     assert slot_dict['maximum_temperature'] == str(thermal.get_maximum_recorded())


### PR DESCRIPTION
On this [PR ](https://github.com/Azure/sonic-platform-daemons/commit/ef15ff51dfc70791d0b31d097e56e70ef6c25441)was changed [name generation:
](https://github.com/Azure/sonic-platform-daemons/blob/f63ec30521d690e9bbef76fdbbed52e4af56ec44/sonic-thermalctld/scripts/thermalctld#L591)
![image](https://user-images.githubusercontent.com/68950226/99567620-085dbb00-29d7-11eb-8e30-5d00f274b498.png)

and after this changes **_test_updater_thermal_check_min_max()_**  fails:

```
01:33:00  ______________________ test_updater_thermal_check_min_max ______________________
01:33:00  
01:33:00      def test_updater_thermal_check_min_max():
01:33:00          chassis = MockChassis()
01:33:00      
01:33:00          thermal = MockThermal()
01:33:00          chassis.get_all_thermals().append(thermal)
01:33:00      
01:33:00          chassis.set_modular_chassis(True)
01:33:00          chassis.set_my_slot(1)
01:33:00          temperature_updater = TemperatureUpdater(SYSLOG_IDENTIFIER, chassis)
01:33:00      
01:33:00          temperature_updater.update()
01:33:00          slot_dict = temperature_updater.chassis_table.get('Thermal 1')
01:33:00  >       assert slot_dict['minimum_temperature'] == str(thermal.get_minimum_recorded())
01:33:00  E       TypeError: 'NoneType' object has no attribute '__getitem__'
01:33:00  
01:33:00  tests/test_thermalctld.py:341: TypeError
```

Signed-off-by: Petro Bratash <petrox.bratash@intel.com>