### PR TITLE
[xcvrd] Fix xcvrd crash on other port prefixes

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -107,14 +107,14 @@ EMPTY_NAMESPACE = ''
 
 # Find out the underneath physical port list by logical name
 def logical_port_name_to_physical_port_list(port_name):
-    if port_name.startswith("Ethernet"):
+    try:
+        return [int(port_name)]
+    except ValueError:
         if platform_sfputil.is_logical_port(port_name):
             return platform_sfputil.get_logical_to_physical(port_name)
         else:
             helper_logger.log_error("Invalid port '%s'" % port_name)
             return None
-    else:
-        return [int(port_name)]
 
 # Get physical port name
 def get_physical_port_name(logical_port, physical_port, ganged):


### PR DESCRIPTION
Implement a better check for logical_port_name_to_physical_port_list function.

Currently it will only accept names that start with "Ethernet". If we try to add other ports it will crash.

In the future Arista will implement other port types. For example "Recirc0".