### PR TITLE
[psud] Make sure psu leds are set on the first run

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -336,6 +336,7 @@ class DaemonPsud(daemon_base.DaemonBase):
         self.psu_status_dict = {}
         self.fan_tbl = None
         self.psu_chassis_info = None
+        self.first_run = True
 
     # Signal handler
     def signal_handler(self, sig, frame):
@@ -396,6 +397,8 @@ class DaemonPsud(daemon_base.DaemonBase):
                 self.update_psu_chassis_info(chassis_tbl)
                 self.update_master_led_color(chassis_tbl)
 
+            self.first_run = False
+
         self.log_info("Stop daemon main loop")
 
         # Delete all the information from DB and then exit
@@ -440,7 +443,7 @@ class DaemonPsud(daemon_base.DaemonBase):
             self.psu_status_dict[index] = PsuStatus(self, psu)
 
         psu_status = self.psu_status_dict[index]
-        set_led = False
+        set_led = self.first_run
         if psu_status.set_presence(presence):
             set_led = True
             log_on_status_changed(self, psu_status.presence,


### PR DESCRIPTION
Without this change, leds were only set when an event happened.
Given that power supplies are assumed present by default, leds would never be set to `green`.
Instead they would have been left in the state the platform initialization left them (e.g `off`)

Fix for #124