### PR TITLE
Clean some unused variables, check for multiAsic before calling initializeGlobalConfig

### DIFF
--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -37,9 +37,6 @@ SELECT_TIMEOUT = 1000
 
 LEDUTIL_LOAD_ERROR = 1
 
-# The empty namespace refers to linux host namespace.
-EMPTY_NAMESPACE = ''
-
 class DaemonLedd(daemon_base.DaemonBase):
 
     # Run daemon
@@ -70,8 +67,9 @@ class DaemonLedd(daemon_base.DaemonBase):
             self.log_error("Failed to load ledutil: %s" % (str(e)), True)
             sys.exit(LEDUTIL_LOAD_ERROR)
 
-        # Load the namespace details first from the database_global.json file.
-        swsscommon.SonicDBConfig.initializeGlobalConfig()
+        if multi_asic.is_multi_asic():
+            # Load the namespace details first from the database_global.json file.
+            swsscommon.SonicDBConfig.initializeGlobalConfig()
 
         # Get the namespaces in the platform. For multi-asic devices we get the namespaces
         # of front-end ascis which have front-panel interfaces.

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -98,9 +98,6 @@ platform_chassis = None
 # by DaemonXcvrd
 helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 
-# The empty namespace refers to linux host namespace.
-EMPTY_NAMESPACE = ''
-
 #
 # Helper functions =============================================================
 #

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -393,8 +393,9 @@ class YCableTableUpdateTask(object):
     def __init__(self):
         self.task_thread = None
 
-        # Load the namespace details first from the database_global.json file.
-        swsscommon.SonicDBConfig.initializeGlobalConfig()
+        if multi_asic.is_multi_asic():
+            # Load the namespace details first from the database_global.json file.
+            swsscommon.SonicDBConfig.initializeGlobalConfig()
 
     def task_worker(self):
 


### PR DESCRIPTION
The check for multiAsic before calling initializeGlobalConfig was done in xcvrd earlier. 
Adding now to the other processes in sonic-platform-daemons as well.