### PR TITLE
[xcvrd] replace check_active_linked_tor_side api to check_mux_direction for establishing the direction mux points to on y_cable

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -176,7 +176,7 @@ def update_appdb_port_mux_cable_response_table(logical_port_name, asic_index, ap
                     "Error: Could not get read side for mux cable port probe command logical port {} and physical port {}".format(logical_port_name, physical_port))
                 return
 
-            active_side = y_cable.check_active_linked_tor_side(physical_port)
+            active_side = y_cable.check_mux_direction(physical_port)
 
             if active_side is None:
 
@@ -234,7 +234,7 @@ def read_y_cable_and_update_statedb_port_tbl(logical_port_name, mux_config_tbl):
                     "Error: Could not establish the read side for  Y cable port {}".format(logical_port_name))
                 return
 
-            active_side = y_cable.check_active_linked_tor_side(physical_port)
+            active_side = y_cable.check_mux_direction(physical_port)
             if active_side is None or active_side not in y_cable_switch_state_values:
                 read_side = active_side = -1
                 update_table_mux_status_for_statedb_port_tbl(


### PR DESCRIPTION
Summary:
This PR provides replaces the logic to check mux_direction on the y_cable by checking the mux_direction register instead of actively linked and routing TOR register

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
added the changes in y_cable_helper.py by replacing the API

#### What is the motivation for this PR?
check_mux_direction is required as per design to replace the active_linked_tor_side
active_linked_tor_side -> check_mux_direction 
check_mux_direction will be utlized as for establishing mux direction explicitly

#### How did you do it?
changed the api calls at appropriate places

#### How did you verify/test it?
Ran the pmon docker with the changed file, and redis-cli to obtain the events and check the functionality is working, also confirmed the same with i2c commands by toggling the mux


Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>