### PR TITLE
[xcvrd] removing the delete notification message logic for command probe in mux cable driver

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -82,11 +82,6 @@ def delete_port_from_y_cable_table(logical_port_name, y_cable_tbl):
     y_cable_tbl._del(logical_port_name)
 
 
-# Delete port from Y cable status table
-def delete_port_from_y_cable_command_table(logical_port_name, y_cable_command_tbl):
-    y_cable_command_tbl._del(logical_port_name)
-
-
 def update_table_mux_status_for_response_tbl(table_name, status, logical_port_name):
     fvs = swsscommon.FieldValuePairs([('response', status)])
     table_name.set(logical_port_name, fvs)


### PR DESCRIPTION
Summary:
This PR provides removes the delete logic on command probe message received from linkmgr after processing the message
### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
added the changes in y_cable_helper.py by replacing the API

#### What is the motivation for this PR?
the delete message tends to create an error scenario if many probe messages come and redis-api fails to retrieve the message contents  

#### How did you do it?
removed the call for deletion of the message 

#### How did you verify/test it?
Ran the pmon docker with the changed file, and redis-cli to obtain the events and check the functionality is working

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>