### PR TITLE
[thermalctld] Report unit test coverage

### DIFF
--- a/sonic-thermalctld/pytest.ini
+++ b/sonic-thermalctld/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
-filterwarnings =
-    ignore::DeprecationWarning
+addopts = --cov=scripts --cov-report html --cov-report term --cov-report xml

--- a/sonic-thermalctld/setup.py
+++ b/sonic-thermalctld/setup.py
@@ -21,8 +21,9 @@ setup(
         'wheel'
     ],
     tests_require=[
+        'mock>=2.0.0; python_version < "3.3"',
         'pytest',
-        'mock>=2.0.0'
+        'pytest-cov'
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -2,7 +2,11 @@ import os
 import sys
 from imp import load_source
 
-from mock import Mock, MagicMock, patch
+# TODO: Clean this up once we no longer need to support Python 2
+if sys.version_info.major == 3:
+    from unittest.mock import Mock, MagicMock, patch
+else:
+    from mock import Mock, MagicMock, patch
 from sonic_py_common import daemon_base
 
 from .mock_platform import MockChassis, MockFan, MockThermal


### PR DESCRIPTION
Report Pytest unit test coverage for thermalctld.

Current coverage:

```
----------- coverage: platform linux, python 3.7.3-final-0 -----------
Name                  Stmts   Miss  Cover
-----------------------------------------
scripts/thermalctld     424    113    73%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml
```

- Also add check to import 'mock' from the 'unittest' package if running with Python 3