### PR TITLE
[xcvrd] Store mux_cable telemetry data in State DB

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -215,3 +215,103 @@ class TestXcvrdScript(object):
     def test_init_port_sfp_status_tbl(self):
         stop_event = threading.Event()
         init_port_sfp_status_tbl(stop_event)
+
+    @patch('xcvrd.xcvrd_utilities.y_cable_helper.y_cable_platform_sfputil', MagicMock(return_value=[0]))
+    @patch('y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('y_cable_helper._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('y_cable_helper.get_muxcable_info', MagicMock(return_value={'tor_active': 'True',
+                                                                       'mux_direction': '1',
+                                                                       'manual_switch_count': '7',
+                                                                       'auto_switch_count': '0.7',
+                                                                       'link_status_self': '0.7',
+                                                                       'link_status_peer': '0.7',
+                                                                       'link_status_nic': '0.7',
+                                                                       'nic_lane1_active': '0.7',
+                                                                       'nic_lane2_active': '0.7',
+                                                                       'nic_lane3_active': '0.7',
+                                                                       'nic_lane4_active': '0.7',
+                                                                       'self_eye_height_lane1': '0.7',
+                                                                       'self_eye_height_lane2': '0.7',
+                                                                       'peer_eye_height_lane1': '0.7',
+                                                                       'peer_eye_height_lane2': '0.7',
+                                                                       'nic_eye_height_lane1': '0.7',
+                                                                       'nic_eye_height_lane2': '0.7',
+                                                                       'internal_temperature': '0.7',
+                                                                       'internal_voltage': '0.7',
+                                                                       'nic_temperature': '0.7',
+                                                                       'nic_voltage': '0.7',
+                                                                       'build_slot1_nic': '0.7',
+                                                                       'build_slot2_nic': '0.7',
+                                                                       'version_slot1_nic': '0.7',
+                                                                       'version_slot2_nic': '0.7',
+                                                                       'run_slot1_nic': '0.7',
+                                                                       'run_slot2_nic': '0.7',
+                                                                       'commit_slot1_nic': '0.7',
+                                                                       'commit_slot2_nic': '0.7',
+                                                                       'empty_slot1_nic': '0.7',
+                                                                       'empty_slot2_nic': '0.7',
+                                                                       'build_slot1_tor1': '0.7',
+                                                                       'build_slot2_tor1': '0.7',
+                                                                       'version_slot1_tor1': '0.7',
+                                                                       'version_slot2_tor1': '0.7',
+                                                                       'run_slot1_tor1': '0.7',
+                                                                       'run_slot2_tor1': '0.7',
+                                                                       'commit_slot1_tor1': '0.7',
+                                                                       'commit_slot2_tor1': '0.7',
+                                                                       'empty_slot1_tor1': '0.7',
+                                                                       'empty_slot2_tor1': '0.7',
+                                                                       'build_slot1_tor2': '0.7',
+                                                                       'build_slot2_tor2': '0.7',
+                                                                       'version_slot1_tor2': '0.7',
+                                                                       'version_slot2_tor2': '0.7',
+                                                                       'run_slot1_tor2': '0.7',
+                                                                       'run_slot2_tor2': '0.7',
+                                                                       'commit_slot1_tor2': '0.7',
+                                                                       'commit_slot2_tor2': '0.7',
+                                                                       'empty_slot1_tor2': '0.7',
+                                                                       'empty_slot2_tor2': '0.7'}))
+    def test_post_port_mux_info_to_db(self):
+        logical_port_name = "Ethernet0"
+        mux_tbl = Table("state_db", "mux_info_tbl")
+        rc = post_port_mux_info_to_db(logical_port_name, mux_tbl)
+        assert(rc != -1)
+
+    @patch('xcvrd.xcvrd_utilities.y_cable_helper.y_cable_platform_sfputil', MagicMock(return_value=[0]))
+    @patch('y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('y_cable_helper._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('y_cable_helper.get_muxcable_static_info', MagicMock(return_value={'read_side': '0',
+                                                                              'nic_lane1_precursor1': '1',
+                                                                              'nic_lane1_precursor2': '0.7',
+                                                                              'nic_lane1_maincursor': '1',
+                                                                              'nic_lane1_postcursor1': '1',
+                                                                              'nic_lane1_postcursor2': '0.7',
+                                                                              'nic_lane2_precursor1': '0.7',
+                                                                              'nic_lane2_precursor2': '0.7',
+                                                                              'nic_lane2_maincursor': '0.7',
+                                                                              'nic_lane2_postcursor1': '0.7',
+                                                                              'nic_lane2_postcursor2': '0.7',
+                                                                              'tor_self_lane1_precursor1': '0.7',
+                                                                              'tor_self_lane1_precursor2': '0.7',
+                                                                              'tor_self_lane1_maincursor': '0.7',
+                                                                              'tor_self_lane1_postcursor1': '0.7',
+                                                                              'tor_self_lane1_postcursor2': '0.7',
+                                                                              'tor_self_lane2_precursor1': '0.7',
+                                                                              'tor_self_lane2_precursor2': '0.7',
+                                                                              'tor_self_lane2_maincursor': '0.7',
+                                                                              'tor_self_lane2_postcursor1': '0.7',
+                                                                              'tor_self_lane2_postcursor2': '0.7',
+                                                                              'tor_peer_lane1_precursor1': '0.7',
+                                                                              'tor_peer_lane1_precursor2': '0.7',
+                                                                              'tor_peer_lane1_maincursor': '0.7',
+                                                                              'tor_peer_lane1_postcursor1': '0.7',
+                                                                              'tor_peer_lane1_postcursor2': '0.7',
+                                                                              'tor_peer_lane2_precursor1': '0.7',
+                                                                              'tor_peer_lane2_precursor2': '0.7',
+                                                                              'tor_peer_lane2_maincursor': '0.7',
+                                                                              'tor_peer_lane2_postcursor1': '0.7',
+                                                                              'tor_peer_lane2_postcursor2': '0.7'}))
+    def test_post_port_mux_static_info_to_db(self):
+        logical_port_name = "Ethernet0"
+        mux_tbl = Table("state_db", "mux_static_info_tbl")
+        rc = post_port_mux_static_info_to_db(logical_port_name, mux_tbl)
+        assert(rc != -1)

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -69,7 +69,7 @@ class TestXcvrdScript(object):
     def test_post_port_dom_info_to_db(self):
         logical_port_name = "Ethernet0"
         stop_event = threading.Event()
-        dom_tbl = Table("STATE_DB", "DOM_INFO_TBL")
+        dom_tbl = Table("STATE_DB", TRANSCEIVER_DOM_SENSOR_TABLE)
         post_port_dom_info_to_db(logical_port_name, dom_tbl, stop_event)
 
     @patch('xcvrd.xcvrd.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -77,8 +77,8 @@ class TestXcvrdScript(object):
     def test_del_port_sfp_dom_info_from_db(self):
         logical_port_name = "Ethernet0"
         stop_event = threading.Event()
-        dom_tbl = Table("STATE_DB", "DOM_INFO_TBL")
-        init_tbl = Table("STATE_DB", "init_info_tbl")
+        dom_tbl = Table("STATE_DB", TRANSCEIVER_DOM_SENSOR_TABLE)
+        init_tbl = Table("STATE_DB", TRANSCEIVER_INFO_TABLE)
         del_port_sfp_dom_info_from_db(logical_port_name, init_tbl, dom_tbl)
 
     @patch('xcvrd.xcvrd.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -106,7 +106,7 @@ class TestXcvrdScript(object):
     def test_post_port_dom_threshold_info_to_db(self):
         logical_port_name = "Ethernet0"
         stop_event = threading.Event()
-        dom_tbl = Table("STATE_DB", "DOM_INFO_TBL")
+        dom_tbl = Table("STATE_DB", TRANSCEIVER_DOM_SENSOR_TABLE)
         post_port_dom_threshold_info_to_db(logical_port_name, dom_tbl, stop_event)
 
     @patch('xcvrd.xcvrd.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -132,7 +132,7 @@ class TestXcvrdScript(object):
     def test_post_port_sfp_info_to_db(self):
         logical_port_name = "Ethernet0"
         stop_event = threading.Event()
-        dom_tbl = Table("STATE_DB", "DOM_INFO_TBL")
+        dom_tbl = Table("STATE_DB", TRANSCEIVER_DOM_SENSOR_TABLE)
         transceiver_dict = {}
         post_port_sfp_info_to_db(logical_port_name, dom_tbl, transceiver_dict, stop_event)
 
@@ -272,7 +272,7 @@ class TestXcvrdScript(object):
                                                                        'empty_slot2_tor2': 'False'}))
     def test_post_port_mux_info_to_db(self):
         logical_port_name = "Ethernet0"
-        mux_tbl = Table("STATE_DB", "MUX_CABLE_INFO")
+        mux_tbl = Table("STATE_DB", y_cable_helper.MUX_CABLE_INFO_TABLE)
         rc = post_port_mux_info_to_db(logical_port_name, mux_tbl)
         assert(rc != -1)
 
@@ -312,6 +312,6 @@ class TestXcvrdScript(object):
                                                                               'tor_peer_lane2_postcursor2': '17'}))
     def test_post_port_mux_static_info_to_db(self):
         logical_port_name = "Ethernet0"
-        mux_tbl = Table("STATE_DB", "MUX_CABLE_STATIC_INFO")
+        mux_tbl = Table("STATE_DB", y_cable_helper.MUX_CABLE_STATIC_INFO_TABLE)
         rc = post_port_mux_static_info_to_db(logical_port_name, mux_tbl)
         assert(rc != -1)

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -69,7 +69,7 @@ class TestXcvrdScript(object):
     def test_post_port_dom_info_to_db(self):
         logical_port_name = "Ethernet0"
         stop_event = threading.Event()
-        dom_tbl = Table("state_db", "dom_info_tbl")
+        dom_tbl = Table("STATE_DB", "DOM_INFO_TBL")
         post_port_dom_info_to_db(logical_port_name, dom_tbl, stop_event)
 
     @patch('xcvrd.xcvrd.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -77,8 +77,8 @@ class TestXcvrdScript(object):
     def test_del_port_sfp_dom_info_from_db(self):
         logical_port_name = "Ethernet0"
         stop_event = threading.Event()
-        dom_tbl = Table("state_db", "dom_info_tbl")
-        init_tbl = Table("state_db", "init_info_tbl")
+        dom_tbl = Table("STATE_DB", "DOM_INFO_TBL")
+        init_tbl = Table("STATE_DB", "init_info_tbl")
         del_port_sfp_dom_info_from_db(logical_port_name, init_tbl, dom_tbl)
 
     @patch('xcvrd.xcvrd.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -106,7 +106,7 @@ class TestXcvrdScript(object):
     def test_post_port_dom_threshold_info_to_db(self):
         logical_port_name = "Ethernet0"
         stop_event = threading.Event()
-        dom_tbl = Table("state_db", "dom_info_tbl")
+        dom_tbl = Table("STATE_DB", "DOM_INFO_TBL")
         post_port_dom_threshold_info_to_db(logical_port_name, dom_tbl, stop_event)
 
     @patch('xcvrd.xcvrd.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -132,7 +132,7 @@ class TestXcvrdScript(object):
     def test_post_port_sfp_info_to_db(self):
         logical_port_name = "Ethernet0"
         stop_event = threading.Event()
-        dom_tbl = Table("state_db", "dom_info_tbl")
+        dom_tbl = Table("STATE_DB", "DOM_INFO_TBL")
         transceiver_dict = {}
         post_port_sfp_info_to_db(logical_port_name, dom_tbl, transceiver_dict, stop_event)
 
@@ -219,99 +219,99 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd_utilities.y_cable_helper.y_cable_platform_sfputil', MagicMock(return_value=[0]))
     @patch('y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('y_cable_helper._wrapper_get_presence', MagicMock(return_value=True))
-    @patch('y_cable_helper.get_muxcable_info', MagicMock(return_value={'tor_active': 'True',
-                                                                       'mux_direction': '1',
+    @patch('y_cable_helper.get_muxcable_info', MagicMock(return_value={'tor_active': 'self',
+                                                                       'mux_direction': 'self',
                                                                        'manual_switch_count': '7',
-                                                                       'auto_switch_count': '0.7',
-                                                                       'link_status_self': '0.7',
-                                                                       'link_status_peer': '0.7',
-                                                                       'link_status_nic': '0.7',
-                                                                       'nic_lane1_active': '0.7',
-                                                                       'nic_lane2_active': '0.7',
-                                                                       'nic_lane3_active': '0.7',
-                                                                       'nic_lane4_active': '0.7',
-                                                                       'self_eye_height_lane1': '0.7',
-                                                                       'self_eye_height_lane2': '0.7',
-                                                                       'peer_eye_height_lane1': '0.7',
-                                                                       'peer_eye_height_lane2': '0.7',
-                                                                       'nic_eye_height_lane1': '0.7',
-                                                                       'nic_eye_height_lane2': '0.7',
-                                                                       'internal_temperature': '0.7',
-                                                                       'internal_voltage': '0.7',
-                                                                       'nic_temperature': '0.7',
-                                                                       'nic_voltage': '0.7',
-                                                                       'build_slot1_nic': '0.7',
-                                                                       'build_slot2_nic': '0.7',
-                                                                       'version_slot1_nic': '0.7',
-                                                                       'version_slot2_nic': '0.7',
-                                                                       'run_slot1_nic': '0.7',
-                                                                       'run_slot2_nic': '0.7',
-                                                                       'commit_slot1_nic': '0.7',
-                                                                       'commit_slot2_nic': '0.7',
-                                                                       'empty_slot1_nic': '0.7',
-                                                                       'empty_slot2_nic': '0.7',
-                                                                       'build_slot1_tor1': '0.7',
-                                                                       'build_slot2_tor1': '0.7',
-                                                                       'version_slot1_tor1': '0.7',
-                                                                       'version_slot2_tor1': '0.7',
-                                                                       'run_slot1_tor1': '0.7',
-                                                                       'run_slot2_tor1': '0.7',
-                                                                       'commit_slot1_tor1': '0.7',
-                                                                       'commit_slot2_tor1': '0.7',
-                                                                       'empty_slot1_tor1': '0.7',
-                                                                       'empty_slot2_tor1': '0.7',
-                                                                       'build_slot1_tor2': '0.7',
-                                                                       'build_slot2_tor2': '0.7',
-                                                                       'version_slot1_tor2': '0.7',
-                                                                       'version_slot2_tor2': '0.7',
-                                                                       'run_slot1_tor2': '0.7',
-                                                                       'run_slot2_tor2': '0.7',
-                                                                       'commit_slot1_tor2': '0.7',
-                                                                       'commit_slot2_tor2': '0.7',
-                                                                       'empty_slot1_tor2': '0.7',
-                                                                       'empty_slot2_tor2': '0.7'}))
+                                                                       'auto_switch_count': '71',
+                                                                       'link_status_self': 'up',
+                                                                       'link_status_peer': 'up',
+                                                                       'link_status_nic': 'up',
+                                                                       'nic_lane1_active': 'True',
+                                                                       'nic_lane2_active': 'True',
+                                                                       'nic_lane3_active': 'True',
+                                                                       'nic_lane4_active': 'True',
+                                                                       'self_eye_height_lane1': '500',
+                                                                       'self_eye_height_lane2': '510',
+                                                                       'peer_eye_height_lane1': '520',
+                                                                       'peer_eye_height_lane2': '530',
+                                                                       'nic_eye_height_lane1': '742',
+                                                                       'nic_eye_height_lane2': '750',
+                                                                       'internal_temperature': '28',
+                                                                       'internal_voltage': '3.3',
+                                                                       'nic_temperature': '20',
+                                                                       'nic_voltage': '2.7',
+                                                                       'build_slot1_nic': 'MS',
+                                                                       'build_slot2_nic': 'MS',
+                                                                       'version_slot1_nic': '1.7',
+                                                                       'version_slot2_nic': '1.7',
+                                                                       'run_slot1_nic': 'True',
+                                                                       'run_slot2_nic': 'False',
+                                                                       'commit_slot1_nic': 'True',
+                                                                       'commit_slot2_nic': 'False',
+                                                                       'empty_slot1_nic': 'True',
+                                                                       'empty_slot2_nic': 'False',
+                                                                       'build_slot1_tor1': 'MS',
+                                                                       'build_slot2_tor1': 'MS',
+                                                                       'version_slot1_tor1': '1.7',
+                                                                       'version_slot2_tor1': '1.7',
+                                                                       'run_slot1_tor1': 'True',
+                                                                       'run_slot2_tor1': 'False',
+                                                                       'commit_slot1_tor1': 'True',
+                                                                       'commit_slot2_tor1': 'False',
+                                                                       'empty_slot1_tor1': 'True',
+                                                                       'empty_slot2_tor1': 'False',
+                                                                       'build_slot1_tor2': 'MS',
+                                                                       'build_slot2_tor2': 'MS',
+                                                                       'version_slot1_tor2': '1.7',
+                                                                       'version_slot2_tor2': '1.7',
+                                                                       'run_slot1_tor2': 'True',
+                                                                       'run_slot2_tor2': 'False',
+                                                                       'commit_slot1_tor2': 'True',
+                                                                       'commit_slot2_tor2': 'False',
+                                                                       'empty_slot1_tor2': 'True',
+                                                                       'empty_slot2_tor2': 'False'}))
     def test_post_port_mux_info_to_db(self):
         logical_port_name = "Ethernet0"
-        mux_tbl = Table("state_db", "mux_info_tbl")
+        mux_tbl = Table("STATE_DB", "MUX_CABLE_INFO")
         rc = post_port_mux_info_to_db(logical_port_name, mux_tbl)
         assert(rc != -1)
 
     @patch('xcvrd.xcvrd_utilities.y_cable_helper.y_cable_platform_sfputil', MagicMock(return_value=[0]))
     @patch('y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('y_cable_helper._wrapper_get_presence', MagicMock(return_value=True))
-    @patch('y_cable_helper.get_muxcable_static_info', MagicMock(return_value={'read_side': '0',
+    @patch('y_cable_helper.get_muxcable_static_info', MagicMock(return_value={'read_side': 'self',
                                                                               'nic_lane1_precursor1': '1',
-                                                                              'nic_lane1_precursor2': '0.7',
-                                                                              'nic_lane1_maincursor': '1',
-                                                                              'nic_lane1_postcursor1': '1',
-                                                                              'nic_lane1_postcursor2': '0.7',
-                                                                              'nic_lane2_precursor1': '0.7',
-                                                                              'nic_lane2_precursor2': '0.7',
-                                                                              'nic_lane2_maincursor': '0.7',
-                                                                              'nic_lane2_postcursor1': '0.7',
-                                                                              'nic_lane2_postcursor2': '0.7',
-                                                                              'tor_self_lane1_precursor1': '0.7',
-                                                                              'tor_self_lane1_precursor2': '0.7',
-                                                                              'tor_self_lane1_maincursor': '0.7',
-                                                                              'tor_self_lane1_postcursor1': '0.7',
-                                                                              'tor_self_lane1_postcursor2': '0.7',
-                                                                              'tor_self_lane2_precursor1': '0.7',
-                                                                              'tor_self_lane2_precursor2': '0.7',
-                                                                              'tor_self_lane2_maincursor': '0.7',
-                                                                              'tor_self_lane2_postcursor1': '0.7',
-                                                                              'tor_self_lane2_postcursor2': '0.7',
-                                                                              'tor_peer_lane1_precursor1': '0.7',
-                                                                              'tor_peer_lane1_precursor2': '0.7',
-                                                                              'tor_peer_lane1_maincursor': '0.7',
-                                                                              'tor_peer_lane1_postcursor1': '0.7',
-                                                                              'tor_peer_lane1_postcursor2': '0.7',
-                                                                              'tor_peer_lane2_precursor1': '0.7',
-                                                                              'tor_peer_lane2_precursor2': '0.7',
-                                                                              'tor_peer_lane2_maincursor': '0.7',
-                                                                              'tor_peer_lane2_postcursor1': '0.7',
-                                                                              'tor_peer_lane2_postcursor2': '0.7'}))
+                                                                              'nic_lane1_precursor2': '-7',
+                                                                              'nic_lane1_maincursor': '-1',
+                                                                              'nic_lane1_postcursor1': '11',
+                                                                              'nic_lane1_postcursor2': '11',
+                                                                              'nic_lane2_precursor1': '12',
+                                                                              'nic_lane2_precursor2': '7',
+                                                                              'nic_lane2_maincursor': '7',
+                                                                              'nic_lane2_postcursor1': '7',
+                                                                              'nic_lane2_postcursor2': '7',
+                                                                              'tor_self_lane1_precursor1': '17',
+                                                                              'tor_self_lane1_precursor2': '17',
+                                                                              'tor_self_lane1_maincursor': '17',
+                                                                              'tor_self_lane1_postcursor1': '17',
+                                                                              'tor_self_lane1_postcursor2': '17',
+                                                                              'tor_self_lane2_precursor1': '7',
+                                                                              'tor_self_lane2_precursor2': '7',
+                                                                              'tor_self_lane2_maincursor': '7',
+                                                                              'tor_self_lane2_postcursor1': '7',
+                                                                              'tor_self_lane2_postcursor2': '7',
+                                                                              'tor_peer_lane1_precursor1': '7',
+                                                                              'tor_peer_lane1_precursor2': '7',
+                                                                              'tor_peer_lane1_maincursor': '17',
+                                                                              'tor_peer_lane1_postcursor1': '7',
+                                                                              'tor_peer_lane1_postcursor2': '17',
+                                                                              'tor_peer_lane2_precursor1': '7',
+                                                                              'tor_peer_lane2_precursor2': '7',
+                                                                              'tor_peer_lane2_maincursor': '17',
+                                                                              'tor_peer_lane2_postcursor1': '7',
+                                                                              'tor_peer_lane2_postcursor2': '17'}))
     def test_post_port_mux_static_info_to_db(self):
         logical_port_name = "Ethernet0"
-        mux_tbl = Table("state_db", "mux_static_info_tbl")
+        mux_tbl = Table("STATE_DB", "MUX_CABLE_STATIC_INFO")
         rc = post_port_mux_static_info_to_db(logical_port_name, mux_tbl)
         assert(rc != -1)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -833,6 +833,7 @@ class DomInfoUpdateTask(object):
         self.task_stopping_event = threading.Event()
 
     def task_worker(self, y_cable_presence):
+        helper_logger.log_info("Start DOM monitoring loop")
 
         # Connect to STATE_DB and create transceiver dom info table
         state_db, dom_tbl, status_tbl = {}, {}, {}

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -829,10 +829,11 @@ def init_port_sfp_status_tbl(stop_event=threading.Event()):
 
 class DomInfoUpdateTask(object):
     def __init__(self):
-        self.task_process = None
-        self.task_stopping_event = multiprocessing.Event()
+        self.task_thread = None
+        self.task_stopping_event = threading.Event()
 
     def task_worker(self, y_cable_presence):
+
         # Connect to STATE_DB and create transceiver dom info table
         state_db, dom_tbl, status_tbl = {}, {}, {}
         static_tbl, mux_tbl = {}, {}
@@ -867,12 +868,12 @@ class DomInfoUpdateTask(object):
         if self.task_stopping_event.is_set():
             return
 
-        self.task_process = multiprocessing.Process(target=self.task_worker, args=(y_cable_presence,))
-        self.task_process.start()
+        self.task_thread = threading.Thread(target=self.task_worker, args=(y_cable_presence,))
+        self.task_thread.start()
 
     def task_stop(self):
         self.task_stopping_event.set()
-        os.kill(self.task_process.pid, signal.SIGKILL)
+        self.task_thread.join()
 
 # Process wrapper class to update sfp state info periodically
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -832,7 +832,7 @@ class DomInfoUpdateTask(object):
         self.task_thread = None
         self.task_stopping_event = threading.Event()
 
-    def task_worker(self, y_cable_presence)):
+    def task_worker(self, y_cable_presence):
         helper_logger.log_info("Start DOM monitoring loop")
 
         # Connect to STATE_DB and create transceiver dom info table

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -836,7 +836,7 @@ class DomInfoUpdateTask(object):
 
         # Connect to STATE_DB and create transceiver dom info table
         state_db, dom_tbl, status_tbl = {}, {}, {}
-        static_tbl, mux_tbl = {}, {}
+        mux_tbl = {}
 
         # Get the namespaces in the platform
         namespaces = multi_asic.get_front_end_namespaces()
@@ -860,7 +860,7 @@ class DomInfoUpdateTask(object):
                     post_port_dom_info_to_db(logical_port_name, dom_tbl[asic_index], self.task_stopping_event)
                     post_port_dom_threshold_info_to_db(logical_port_name, dom_tbl[asic_index], self.task_stopping_event)
                     if y_cable_presence[0] is True:
-                        y_cable_helper.check_identifier_presence_and_update_mux_info_and_static_entry(state_db, static_tbl, mux_tbl, asic_index, logical_port_name)
+                        y_cable_helper.check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_index, logical_port_name)
 
         helper_logger.log_info("Stop DOM monitoring loop")
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -832,11 +832,12 @@ class DomInfoUpdateTask(object):
         self.task_thread = None
         self.task_stopping_event = threading.Event()
 
-    def task_worker(self):
+    def task_worker(self, y_cable_presence)):
         helper_logger.log_info("Start DOM monitoring loop")
 
         # Connect to STATE_DB and create transceiver dom info table
         state_db, dom_tbl, status_tbl = {}, {}, {}
+        static_tbl, mux_tbl = {}, {}
 
         # Get the namespaces in the platform
         namespaces = multi_asic.get_front_end_namespaces()
@@ -859,14 +860,16 @@ class DomInfoUpdateTask(object):
                 if not detect_port_in_error_status(logical_port_name, status_tbl[asic_index]):
                     post_port_dom_info_to_db(logical_port_name, dom_tbl[asic_index], self.task_stopping_event)
                     post_port_dom_threshold_info_to_db(logical_port_name, dom_tbl[asic_index], self.task_stopping_event)
+                    if y_cable_presence[0] == True:
+                        y_cable.check_identifier_presence_and_update_mux_info_and_static_entry(state_db, static_tbl, mux_tbl, asic_index, logical_port_name)
 
         helper_logger.log_info("Stop DOM monitoring loop")
 
-    def task_run(self):
+    def task_run(self, y_cable_presence):
         if self.task_stopping_event.is_set():
             return
 
-        self.task_thread = threading.Thread(target=self.task_worker)
+        self.task_thread = threading.Thread(target=self.task_worker, args=(y_cable_presence))
         self.task_thread.start()
 
     def task_stop(self):
@@ -1325,7 +1328,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
 
         # Start the dom sensor info update thread
         dom_info_update = DomInfoUpdateTask()
-        dom_info_update.task_run()
+        dom_info_update.task_run(self.y_cable_presence)
 
         # Start the sfp state info update process
         sfp_state_update = SfpStateUpdateTask()

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -609,7 +609,7 @@ def get_muxcable_info(physical_port, logical_port_name):
     mux_dir_val = y_cable.check_mux_direction(physical_port)
     if mux_dir_val is None or mux_dir_val == y_cable.EEPROM_ERROR:
         mux_direction = 'unknown'
-    if read_side == mux_dir_val and (active_side == 1 or active_side == 2):
+    elif read_side == mux_dir_val and (active_side == 1 or active_side == 2):
         mux_direction = 'self'
     elif read_side != mux_dir_val and (active_side == 1 or active_side == 2):
         mux_direction = 'peer'

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -52,6 +52,9 @@ y_cable_switch_state_values = {
     Y_CABLE_STATUS_TORB_ACTIVE
 }
 
+MUX_CABLE_STATIC_INFO_TABLE = "MUX_CABLE_STATIC_INFO"
+MUX_CABLE_INFO_TABLE = "MUX_CABLE_INFO"
+
 # Find out the underneath physical port list by logical name
 
 
@@ -304,8 +307,8 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
                             "STATE_DB", namespace)
                         y_cable_tbl[asic_id] = swsscommon.Table(
                             state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
-                        static_tbl[asic_id] = swsscommon.Table(state_db[asic_id], "MUX_CABLE_STATIC_INFO")
-                        mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], "MUX_CABLE_INFO")
+                        static_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
+                        mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_INFO_TABLE)
                     # fill the newly found entry
                     read_y_cable_and_update_statedb_port_tbl(
                         logical_port_name, y_cable_tbl[asic_index])
@@ -342,8 +345,8 @@ def check_identifier_presence_and_delete_mux_table_entry(state_db, port_tbl, asi
                         "STATE_DB", namespace)
                     y_cable_tbl[asic_id] = swsscommon.Table(
                         state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
-                    static_tbl[asic_id] = swsscommon.Table(state_db[asic_id], "MUX_CABLE_STATIC_INFO")
-                    mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], "MUX_CABLE_INFO")
+                    static_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
+                    mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_INFO_TABLE)
                 # fill the newly found entry
                 delete_port_from_y_cable_table(
                     logical_port_name, y_cable_tbl[asic_index])
@@ -472,8 +475,8 @@ def delete_ports_status_for_y_cable():
         y_cable_tbl[asic_id] = swsscommon.Table(
             state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
         y_cable_tbl_keys[asic_id] = y_cable_tbl[asic_id].getKeys()
-        static_tbl[asic_id] = swsscommon.Table(state_db[asic_id], "MUX_CABLE_STATIC_INFO")
-        mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], "MUX_CABLE_INFO")
+        static_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
+        mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_INFO_TABLE)
 
     # delete PORTS on Y cable table if ports on Y cable
     logical_port_list = y_cable_platform_sfputil.logical
@@ -529,7 +532,7 @@ def check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_
                     for namespace in namespaces:
                         asic_id = multi_asic.get_asic_index_from_namespace(
                             namespace)
-                        mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], "MUX_CABLE_INFO")
+                        mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_INFO_TABLE)
                     # fill the newly found entry
                     post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
 
@@ -974,7 +977,7 @@ def post_mux_static_info_to_db(is_warm_start, stop_event=threading.Event()):
     for namespace in namespaces:
         asic_id = multi_asic.get_asic_index_from_namespace(namespace)
         state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
-        static_tbl[asic_id] = swsscommon.Table(state_db[asic_id], "MUX_CABLE_STATIC_INFO")
+        static_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
 
     # Post all the current interface dom/sfp info to STATE_DB
     logical_port_list = y_cable_platform_sfputil.logical
@@ -999,7 +1002,7 @@ def post_mux_info_to_db(is_warm_start, stop_event=threading.Event()):
     for namespace in namespaces:
         asic_id = multi_asic.get_asic_index_from_namespace(namespace)
         state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
-        mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], "MUX_CABLE_INFO")
+        mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_INFO_TABLE)
 
     # Post all the current interface dom/sfp info to STATE_DB
     logical_port_list = y_cable_platform_sfputil.logical

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -3,16 +3,13 @@
     helper utlities configuring y_cable for xcvrd daemon
 """
 
-try:
-    import time
-    import threading
+import threading
+import time
 
-    from sonic_py_common import daemon_base, logger
-    from sonic_py_common import multi_asic
-    from sonic_y_cable import y_cable
-    from swsscommon import swsscommon
-except ImportError as e:
-    raise ImportError(str(e) + " - required module not found")
+from sonic_py_common import daemon_base, logger
+from sonic_py_common import multi_asic
+from sonic_y_cable import y_cable
+from swsscommon import swsscommon
 
 
 SELECT_TIMEOUT = 1000

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -664,25 +664,25 @@ def get_muxcable_info(physical_port, logical_port_name):
     eye_result_nic = y_cable.get_eye_info(physical_port, 3)
 
     if eye_result_self is not None and eye_result_self is not y_cable.EEPROM_ERROR and isinstance(eye_result_self, list):
-        mux_info_dict["Self_eye_height_lane1"] = eye_result_self[0]
-        mux_info_dict["Self_eye_height_lane2"] = eye_result_self[1]
+        mux_info_dict["self_eye_height_lane1"] = eye_result_self[0]
+        mux_info_dict["self_eye_height_lane2"] = eye_result_self[1]
     else:
-        mux_info_dict["Self_eye_height_lane1"] = "N/A"
-        mux_info_dict["Self_eye_height_lane2"] = "N/A"
+        mux_info_dict["self_eye_height_lane1"] = "N/A"
+        mux_info_dict["self_eye_height_lane2"] = "N/A"
 
     if eye_result_peer is not None and eye_result_peer is not y_cable.EEPROM_ERROR and isinstance(eye_result_peer, list):
-        mux_info_dict["Peer_eye_height_lane1"] = eye_result_peer[0]
-        mux_info_dict["Peer_eye_height_lane2"] = eye_result_peer[1]
+        mux_info_dict["peer_eye_height_lane1"] = eye_result_peer[0]
+        mux_info_dict["peer_eye_height_lane2"] = eye_result_peer[1]
     else:
-        mux_info_dict["Peer_eye_height_lane1"] = "N/A"
-        mux_info_dict["Peer_eye_height_lane2"] = "N/A"
+        mux_info_dict["peer_eye_height_lane1"] = "N/A"
+        mux_info_dict["peer_eye_height_lane2"] = "N/A"
 
     if eye_result_nic is not None and eye_result_nic is not y_cable.EEPROM_ERROR and isinstance(eye_result_nic, list):
-        mux_info_dict["NIC_eye_height_lane1"] = eye_result_nic[0]
-        mux_info_dict["NIC_eye_height_lane2"] = eye_result_nic[1]
+        mux_info_dict["nic_eye_height_lane1"] = eye_result_nic[0]
+        mux_info_dict["nic_eye_height_lane2"] = eye_result_nic[1]
     else:
-        mux_info_dict["NIC_eye_height_lane1"] = "N/A"
-        mux_info_dict["NIC_eye_height_lane2"] = "N/A"
+        mux_info_dict["nic_eye_height_lane1"] = "N/A"
+        mux_info_dict["nic_eye_height_lane2"] = "N/A"
 
     if read_side == 1:
         if y_cable.check_if_link_is_active_for_torA(physical_port):
@@ -788,40 +788,40 @@ def get_muxcable_static_info(physical_port, logical_port_name):
             cursor_tor2_values.append(dummy_list)
 
     for i in range(1, 3):
-        mux_static_info_dict[("Nic_Lane{}_Precursor1".format(i))] = cursor_nic_values[i-1][0]
-        mux_static_info_dict[("Nic_Lane{}_Precursor2".format(i))] = cursor_nic_values[i-1][1]
-        mux_static_info_dict[("Nic_Lane{}_Maincursor".format(i))] = cursor_nic_values[i-1][2]
-        mux_static_info_dict[("Nic_Lane{}_Postcursor1".format(i))] = cursor_nic_values[i-1][3]
-        mux_static_info_dict[("Nic_Lane{}_Postcursor2".format(i))] = cursor_nic_values[i-1][4]
+        mux_static_info_dict[("nic_lane{}_precursor1".format(i))] = cursor_nic_values[i-1][0]
+        mux_static_info_dict[("nic_lane{}_precursor2".format(i))] = cursor_nic_values[i-1][1]
+        mux_static_info_dict[("nic_lane{}_maincursor".format(i))] = cursor_nic_values[i-1][2]
+        mux_static_info_dict[("nic_lane{}_postcursor1".format(i))] = cursor_nic_values[i-1][3]
+        mux_static_info_dict[("nic_lane{}_postcursor2".format(i))] = cursor_nic_values[i-1][4]
 
     if read_side == 1:
         for i in range(1, 3):
-            mux_static_info_dict[("TOR_self_Lane{}_Precursor1".format(i))] = cursor_tor1_values[i-1][0]
-            mux_static_info_dict[("TOR_self_Lane{}_Precursor2".format(i))] = cursor_tor1_values[i-1][1]
-            mux_static_info_dict[("TOR_self_Lane{}_Maincursor".format(i))] = cursor_tor1_values[i-1][2]
-            mux_static_info_dict[("TOR_self_Lane{}_Postcursor1".format(i))] = cursor_tor1_values[i-1][3]
-            mux_static_info_dict[("TOR_self_Lane{}_Postcursor2".format(i))] = cursor_tor1_values[i-1][4]
+            mux_static_info_dict[("tor_self_lane{}_precursor1".format(i))] = cursor_tor1_values[i-1][0]
+            mux_static_info_dict[("tor_self_lane{}_precursor2".format(i))] = cursor_tor1_values[i-1][1]
+            mux_static_info_dict[("tor_self_lane{}_maincursor".format(i))] = cursor_tor1_values[i-1][2]
+            mux_static_info_dict[("tor_self_lane{}_postcursor1".format(i))] = cursor_tor1_values[i-1][3]
+            mux_static_info_dict[("tor_self_lane{}_postcursor2".format(i))] = cursor_tor1_values[i-1][4]
 
         for i in range(1, 3):
-            mux_static_info_dict[("TOR_peer_Lane{}_Precursor1".format(i))] = cursor_tor2_values[i-1][0]
-            mux_static_info_dict[("TOR_peer_Lane{}_Precursor2".format(i))] = cursor_tor2_values[i-1][1]
-            mux_static_info_dict[("TOR_peer_Lane{}_Maincursor".format(i))] = cursor_tor2_values[i-1][2]
-            mux_static_info_dict[("TOR_peer_Lane{}_Postcursor1".format(i))] = cursor_tor2_values[i-1][3]
-            mux_static_info_dict[("TOR_peer_Lane{}_Postcursor2".format(i))] = cursor_tor2_values[i-1][4]
+            mux_static_info_dict[("tor_peer_lane{}_precursor1".format(i))] = cursor_tor2_values[i-1][0]
+            mux_static_info_dict[("tor_peer_lane{}_precursor2".format(i))] = cursor_tor2_values[i-1][1]
+            mux_static_info_dict[("tor_peer_lane{}_maincursor".format(i))] = cursor_tor2_values[i-1][2]
+            mux_static_info_dict[("tor_peer_lane{}_postcursor1".format(i))] = cursor_tor2_values[i-1][3]
+            mux_static_info_dict[("tor_peer_lane{}_postcursor2".format(i))] = cursor_tor2_values[i-1][4]
     else:
         for i in range(1, 3):
-            mux_static_info_dict[("TOR_self_Lane{}_Precursor1".format(i))] = cursor_tor2_values[i-1][0]
-            mux_static_info_dict[("TOR_self_Lane{}_Precursor2".format(i))] = cursor_tor2_values[i-1][1]
-            mux_static_info_dict[("TOR_self_Lane{}_Maincursor".format(i))] = cursor_tor2_values[i-1][2]
-            mux_static_info_dict[("TOR_self_Lane{}_Postcursor1".format(i))] = cursor_tor2_values[i-1][3]
-            mux_static_info_dict[("TOR_self_Lane{}_Postcursor2".format(i))] = cursor_tor2_values[i-1][4]
+            mux_static_info_dict[("tor_self_lane{}_precursor1".format(i))] = cursor_tor2_values[i-1][0]
+            mux_static_info_dict[("tor_self_lane{}_precursor2".format(i))] = cursor_tor2_values[i-1][1]
+            mux_static_info_dict[("tor_self_lane{}_maincursor".format(i))] = cursor_tor2_values[i-1][2]
+            mux_static_info_dict[("tor_self_lane{}_postcursor1".format(i))] = cursor_tor2_values[i-1][3]
+            mux_static_info_dict[("tor_self_lane{}_postcursor2".format(i))] = cursor_tor2_values[i-1][4]
 
         for i in range(1, 3):
-            mux_static_info_dict[("TOR_peer_Lane{}_Precursor1".format(i))] = cursor_tor1_values[i-1][0]
-            mux_static_info_dict[("TOR_peer_Lane{}_Precursor2".format(i))] = cursor_tor1_values[i-1][1]
-            mux_static_info_dict[("TOR_peer_Lane{}_Maincursor".format(i))] = cursor_tor1_values[i-1][2]
-            mux_static_info_dict[("TOR_peer_Lane{}_Postcursor1".format(i))] = cursor_tor1_values[i-1][3]
-            mux_static_info_dict[("TOR_peer_Lane{}_Postcursor2".format(i))] = cursor_tor1_values[i-1][4]
+            mux_static_info_dict[("tor_peer_lane{}_precursor1".format(i))] = cursor_tor1_values[i-1][0]
+            mux_static_info_dict[("tor_peer_lane{}_precursor2".format(i))] = cursor_tor1_values[i-1][1]
+            mux_static_info_dict[("tor_peer_lane{}_maincursor".format(i))] = cursor_tor1_values[i-1][2]
+            mux_static_info_dict[("tor_peer_lane{}_postcursor1".format(i))] = cursor_tor1_values[i-1][3]
+            mux_static_info_dict[("tor_peer_lane{}_postcursor2".format(i))] = cursor_tor1_values[i-1][4]
 
     return mux_static_info_dict
 
@@ -860,12 +860,12 @@ def post_port_mux_info_to_db(logical_port_name, table):
                  ('nic_lane2_active', mux_info_dict["nic_lane2_active"]),
                  ('nic_lane3_active', mux_info_dict["nic_lane3_active"]),
                  ('nic_lane4_active', mux_info_dict["nic_lane4_active"]),
-                 ('Self_eye_height_lane1', str(mux_info_dict["Self_eye_height_lane1"])),
-                 ('Self_eye_height_lane2', str(mux_info_dict["Self_eye_height_lane2"])),
-                 ('Peer_eye_height_lane1', str(mux_info_dict["Peer_eye_height_lane1"])),
-                 ('Peer_eye_height_lane2', str(mux_info_dict["Peer_eye_height_lane1"])),
-                 ('NIC_eye_height_lane1', str(mux_info_dict["NIC_eye_height_lane1"])),
-                 ('NIC_eye_height_lane2', str(mux_info_dict["NIC_eye_height_lane2"])),
+                 ('self_eye_height_lane1', str(mux_info_dict["self_eye_height_lane1"])),
+                 ('self_eye_height_lane2', str(mux_info_dict["self_eye_height_lane2"])),
+                 ('peer_eye_height_lane1', str(mux_info_dict["peer_eye_height_lane1"])),
+                 ('peer_eye_height_lane2', str(mux_info_dict["peer_eye_height_lane1"])),
+                 ('nic_eye_height_lane1', str(mux_info_dict["nic_eye_height_lane1"])),
+                 ('nic_eye_height_lane2', str(mux_info_dict["nic_eye_height_lane2"])),
                  ('internal_temperature', str(mux_info_dict["internal_temperature"])),
                  ('internal_voltage', str(mux_info_dict["internal_voltage"])),
                  ('nic_temperature', str(mux_info_dict["nic_temperature"])),
@@ -929,36 +929,36 @@ def post_port_mux_static_info_to_db(logical_port_name, static_table):
             #transceiver_dict[physical_port] = port_info_dict
             fvs = swsscommon.FieldValuePairs(
                 [('read_side',  mux_static_info_dict["read_side"]),
-                 ('Nic_Lane1_Precursor1', str(mux_static_info_dict["Nic_Lane1_Precursor1"])),
-                 ('Nic_Lane1_Precursor2', str(mux_static_info_dict["Nic_Lane1_Precursor2"])),
-                 ('Nic_Lane1_Maincursor', str(mux_static_info_dict["Nic_Lane1_Maincursor"])),
-                 ('Nic_Lane1_Precursor1', str(mux_static_info_dict["Nic_Lane1_Postcursor1"])),
-                 ('Nic_Lane1_Postcursor2', str(mux_static_info_dict["Nic_Lane1_Postcursor2"])),
-                 ('Nic_Lane2_Precursor1', str(mux_static_info_dict["Nic_Lane2_Precursor1"])),
-                 ('Nic_Lane2_Precursor2', str(mux_static_info_dict["Nic_Lane2_Precursor2"])),
-                 ('Nic_Lane2_Maincursor', str(mux_static_info_dict["Nic_Lane2_Maincursor"])),
-                 ('Nic_Lane2_Precursor1', str(mux_static_info_dict["Nic_Lane2_Postcursor1"])),
-                 ('Nic_Lane2_Postcursor2', str(mux_static_info_dict["Nic_Lane2_Postcursor2"])),
-                 ('TOR_self_Lane1_Precursor1', str(mux_static_info_dict["TOR_self_Lane1_Precursor1"])),
-                 ('TOR_self_Lane1_Precursor2', str(mux_static_info_dict["TOR_self_Lane1_Precursor2"])),
-                 ('TOR_self_Lane1_Maincursor', str(mux_static_info_dict["TOR_self_Lane1_Maincursor"])),
-                 ('TOR_self_Lane1_Precursor1', str(mux_static_info_dict["TOR_self_Lane1_Postcursor1"])),
-                 ('TOR_self_Lane1_Postcursor2', str(mux_static_info_dict["TOR_self_Lane1_Postcursor2"])),
-                 ('TOR_self_Lane2_Precursor1', str(mux_static_info_dict["TOR_self_Lane2_Precursor1"])),
-                 ('TOR_self_Lane2_Precursor2', str(mux_static_info_dict["TOR_self_Lane2_Precursor2"])),
-                 ('TOR_self_Lane2_Maincursor', str(mux_static_info_dict["TOR_self_Lane2_Maincursor"])),
-                 ('TOR_self_Lane2_Precursor1', str(mux_static_info_dict["TOR_self_Lane2_Postcursor1"])),
-                 ('TOR_self_Lane2_Postcursor2', str(mux_static_info_dict["TOR_self_Lane2_Postcursor2"])),
-                 ('TOR_peer_Lane1_Precursor1', str(mux_static_info_dict["TOR_peer_Lane1_Precursor1"])),
-                 ('TOR_peer_Lane1_Precursor2', str(mux_static_info_dict["TOR_peer_Lane1_Precursor2"])),
-                 ('TOR_peer_Lane1_Maincursor', str(mux_static_info_dict["TOR_peer_Lane1_Maincursor"])),
-                 ('TOR_peer_Lane1_Precursor1', str(mux_static_info_dict["TOR_peer_Lane1_Postcursor1"])),
-                 ('TOR_peer_Lane1_Postcursor2', str(mux_static_info_dict["TOR_peer_Lane1_Postcursor2"])),
-                 ('TOR_peer_Lane2_Precursor1', str(mux_static_info_dict["TOR_peer_Lane2_Precursor1"])),
-                 ('TOR_peer_Lane2_Precursor2', str(mux_static_info_dict["TOR_peer_Lane2_Precursor2"])),
-                 ('TOR_peer_Lane2_Maincursor', str(mux_static_info_dict["TOR_peer_Lane2_Maincursor"])),
-                 ('TOR_peer_Lane2_Precursor1', str(mux_static_info_dict["TOR_peer_Lane2_Postcursor1"])),
-                 ('TOR_peer_Lane2_Postcursor2', str(mux_static_info_dict["TOR_peer_Lane2_Postcursor2"]))
+                 ('nic_lane1_precursor1', str(mux_static_info_dict["nic_lane1_precursor1"])),
+                 ('nic_lane1_precursor2', str(mux_static_info_dict["nic_lane1_precursor2"])),
+                 ('nic_lane1_maincursor', str(mux_static_info_dict["nic_lane1_maincursor"])),
+                 ('nic_lane1_postcursor1', str(mux_static_info_dict["nic_lane1_postcursor1"])),
+                 ('nic_lane1_postcursor2', str(mux_static_info_dict["nic_lane1_postcursor2"])),
+                 ('nic_lane2_precursor1', str(mux_static_info_dict["nic_lane2_precursor1"])),
+                 ('nic_lane2_precursor2', str(mux_static_info_dict["nic_lane2_precursor2"])),
+                 ('nic_lane2_maincursor', str(mux_static_info_dict["nic_lane2_maincursor"])),
+                 ('nic_lane2_postcursor1', str(mux_static_info_dict["nic_lane2_postcursor1"])),
+                 ('nic_lane2_postcursor2', str(mux_static_info_dict["nic_lane2_postcursor2"])),
+                 ('tor_self_lane1_precursor1', str(mux_static_info_dict["tor_self_lane1_precursor1"])),
+                 ('tor_self_lane1_precursor2', str(mux_static_info_dict["tor_self_lane1_precursor2"])),
+                 ('tor_self_lane1_maincursor', str(mux_static_info_dict["tor_self_lane1_maincursor"])),
+                 ('tor_self_lane1_postcursor1', str(mux_static_info_dict["tor_self_lane1_postcursor1"])),
+                 ('tor_self_lane1_postcursor2', str(mux_static_info_dict["tor_self_lane1_postcursor2"])),
+                 ('tor_self_lane2_precursor1', str(mux_static_info_dict["tor_self_lane2_precursor1"])),
+                 ('tor_self_lane2_precursor2', str(mux_static_info_dict["tor_self_lane2_precursor2"])),
+                 ('tor_self_lane2_maincursor', str(mux_static_info_dict["tor_self_lane2_maincursor"])),
+                 ('tor_self_lane2_postcursor1', str(mux_static_info_dict["tor_self_lane2_postcursor1"])),
+                 ('tor_self_lane2_postcursor2', str(mux_static_info_dict["tor_self_lane2_postcursor2"])),
+                 ('tor_peer_lane1_precursor1', str(mux_static_info_dict["tor_peer_lane1_precursor1"])),
+                 ('tor_peer_lane1_precursor2', str(mux_static_info_dict["tor_peer_lane1_precursor2"])),
+                 ('tor_peer_lane1_maincursor', str(mux_static_info_dict["tor_peer_lane1_maincursor"])),
+                 ('tor_peer_lane1_postcursor1', str(mux_static_info_dict["tor_peer_lane1_postcursor1"])),
+                 ('tor_peer_lane1_postcursor2', str(mux_static_info_dict["tor_peer_lane1_postcursor2"])),
+                 ('tor_peer_lane2_precursor1', str(mux_static_info_dict["tor_peer_lane2_precursor1"])),
+                 ('tor_peer_lane2_precursor2', str(mux_static_info_dict["tor_peer_lane2_precursor2"])),
+                 ('tor_peer_lane2_maincursor', str(mux_static_info_dict["tor_peer_lane2_maincursor"])),
+                 ('tor_peer_lane2_postcursor1', str(mux_static_info_dict["tor_peer_lane2_postcursor1"])),
+                 ('tor_peer_lane2_postcursor2', str(mux_static_info_dict["tor_peer_lane2_postcursor2"]))
                  ])
             static_table.set(logical_port_name, fvs)
         else:

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -613,6 +613,8 @@ def get_muxcable_info(physical_port, logical_port_name):
         mux_direction = 'self'
     elif read_side != mux_dir_val and (active_side == 1 or active_side == 2):
         mux_direction = 'peer'
+    else:
+        mux_direction = 'unknown'
 
     mux_info_dict["mux_direction"] = mux_direction
 

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -637,7 +637,7 @@ def _wrapper_get_muxcable_info(physical_port, logical_port_name):
             mux_static_info_dict[("TOR_peer_Lane{}_Postcursor1".format(i))] = cursor_tor1_values[i][3]
             mux_static_info_dict[("TOR_peer_Lane{}_Postcursor2".format(i))] = cursor_tor1_values[i][4]
 
-   return (mux_info_dict, mux_static_info_dict)
+   return mux_info_dict, mux_static_info_dict
 
 def post_port_mux_info_to_db(logical_port_name, table, static_table,
                              stop_event=threading.Event()):

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -846,7 +846,7 @@ def post_port_mux_info_to_db(logical_port_name, table):
             continue
 
         mux_info_dict = get_muxcable_info(physical_port, logical_port_name)
-        if mux_info_dict is not None:
+        if mux_info_dict is not None and mux_info_dict is not -1:
             #transceiver_dict[physical_port] = port_info_dict
             fvs = swsscommon.FieldValuePairs(
                 [('tor_active',  mux_info_dict["tor_active"]),
@@ -925,7 +925,7 @@ def post_port_mux_static_info_to_db(logical_port_name, static_table):
 
         mux_static_info_dict = get_muxcable_static_info(physical_port, logical_port_name)
 
-        if mux_static_info_dict is not None:
+        if mux_static_info_dict is not None and mux_static_info_dict is not -1:
             #transceiver_dict[physical_port] = port_info_dict
             fvs = swsscommon.FieldValuePairs(
                 [('read_side',  mux_static_info_dict["read_side"]),

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -54,6 +54,7 @@ y_cable_switch_state_values = {
 
 # Find out the underneath physical port list by logical name
 
+
 def logical_port_name_to_physical_port_list(port_name):
     if port_name.startswith("Ethernet"):
         if y_cable_platform_sfputil.is_logical_port(port_name):
@@ -315,7 +316,7 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
 def check_identifier_presence_and_delete_mux_table_entry(state_db, port_tbl, asic_index, logical_port_name, y_cable_presence, delete_change_event):
 
     y_cable_tbl = {}
-    static_tbl, mux_tbl = {} , {}
+    static_tbl, mux_tbl = {}, {}
 
     # if there is No Y cable do not do anything here
     if y_cable_presence[0] is False:
@@ -493,6 +494,7 @@ def delete_ports_status_for_y_cable():
             delete_port_from_y_cable_table(
                 logical_port_name, mux_tbl[asic_index])
 
+
 def check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_index, logical_port_name):
 
     # Get the namespaces in the platform
@@ -530,6 +532,7 @@ def check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_
                         mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], "MUX_CABLE_INFO")
                     # fill the newly found entry
                     post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
+
 
 def get_firmware_dict(physical_port, target, side, mux_info_dict):
 
@@ -623,7 +626,6 @@ def get_muxcable_info(physical_port, logical_port_name):
     else:
         mux_info_dict["auto_switch_count"] = "N/A"
 
-
     lane_active = y_cable.check_if_nic_lanes_active(physical_port)
 
     if lane_active is not y_cable.EEPROM_ERROR:
@@ -651,8 +653,6 @@ def get_muxcable_info(physical_port, logical_port_name):
         mux_info_dict["nic_lane2_active"] = "N/A"
         mux_info_dict["nic_lane3_active"] = "N/A"
         mux_info_dict["nic_lane4_active"] = "N/A"
-
-
 
     if read_side == 1:
         eye_result_self = y_cable.get_eye_info(physical_port, 1)
@@ -708,7 +708,6 @@ def get_muxcable_info(physical_port, logical_port_name):
     else:
         mux_info_dict["link_status_nic"] = "down"
 
-
     get_firmware_dict(physical_port, 0, "nic", mux_info_dict)
     get_firmware_dict(physical_port, 1, "tor1", mux_info_dict)
     get_firmware_dict(physical_port, 2, "tor2", mux_info_dict)
@@ -721,7 +720,6 @@ def get_muxcable_info(physical_port, logical_port_name):
     else:
         mux_info_dict["internal_temperature"] = "N/A"
         mux_info_dict["internal_voltage"] = "N/A"
-
 
     res = y_cable.get_nic_voltage_temp(physical_port)
 
@@ -906,6 +904,7 @@ def post_port_mux_info_to_db(logical_port_name, table):
             table.set(logical_port_name, fvs)
         else:
             return -1
+
 
 def post_port_mux_static_info_to_db(logical_port_name, static_table):
 

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -530,7 +530,6 @@ def check_identifier_presence_and_update_mux_info_and_static_entry(state_db, sta
 def get_muxcable_info(physical_port, logical_port_name):
 
     mux_info_dict = {}
-    mux_static_info_dict = {}
     y_cable_tbl, state_db = {}, {}
 
     namespaces = multi_asic.get_front_end_namespaces()
@@ -559,7 +558,7 @@ def get_muxcable_info(physical_port, logical_port_name):
 
     if active_side is None:
         tor_active = 'unknown'
-    if read_side == active_side and (active_side == 1 or active_side == 2):
+    elif read_side == active_side and (active_side == 1 or active_side == 2):
         tor_active = 'active'
     elif read_side != active_side and (active_side == 1 or active_side == 2):
         tor_active = 'standby'
@@ -651,7 +650,6 @@ def get_muxcable_info(physical_port, logical_port_name):
 
 def get_muxcable_static_info(physical_port, logical_port_name):
 
-    mux_info_dict = {}
     mux_static_info_dict = {}
     y_cable_tbl, state_db = {}, {}
 


### PR DESCRIPTION
Summary:
This PR provides the necessary infrastructure to initialize the mux_cable info and static tables and post them within state db
as part of xcvrd. The data is posted every 60 secs and streaming telemetry can utilize this info. 
    
### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
Added changes in the sonic_xcvrd directory of sonic-platform-daemons

#### What is the motivation for this PR?

To add the necessary infrastructure for Credo Y cable support for posting streaming telemetry data inside state-db

#### How did you do it?
Added the necessary changes and a new xcvrd_utilities sub directory for utilities of y_cable code.

#### How did you verify/test it?
Ran the docker restart command for pmon to ascertain the values are getting posted inside the state-db.
Ran redis-cli commands to confirm all the data exists as intended

#### Any platform specific information?

Platform must have optoe driver support for  instantiation of sysfs/eeprom 

The following are snapshots on state DB of what is populated for sonic-telemetry
```
admin@str-7050cx3-acs-04:~$ redis-cli -n 6  hgetall "MUX_CABLE_INFO|Ethernet4"
  1) "tor_active"
  2) "standby"
  3) "mux_direction"
  4) "peer"
  5) "manual_switch_count"
  6) "0"
  7) "auto_switch_count"
  8) "0"
  9) "link_status_self"
 10) "down"
 11) "link_status_peer"
 12) "up"
 13) "link_status_nic"
 14) "up"
 15) "nic_lane1_active"
 16) "False"
 17) "nic_lane2_active"
 18) "False"
 19) "nic_lane3_active"
 20) "False"
 21) "nic_lane4_active"
 22) "False"
 23) "self_eye_height_lane1"
 24) "N/A"
 25) "self_eye_height_lane2"
 26) "N/A"
 27) "peer_eye_height_lane1"
 28) "617"
 29) "peer_eye_height_lane2"
 30) "617"
 31) "nic_eye_height_lane1"
 32) "757"
 33) "nic_eye_height_lane2"
 34) "851"
 35) "internal_temperature"
 36) "23"
 37) "internal_voltage"
 38) "3.309"
 39) "nic_temperature"
 40) "43"
 41) "nic_voltage"
 42) "3.256"
 43) "build_slot1_nic"
 44) "MS"
 45) "build_slot2_nic"
 46) "MS"
 47) "version_slot1_nic"
 48) "0.6"
 49) "version_slot2_nic"
 50) "0.6"
 51) "run_slot1_nic"
 52) "True"
 53) "run_slot2_nic"
 54) "False"
 55) "commit_slot1_nic"
 56) "True"
 57) "commit_slot2_nic"
 58) "False"
 59) "empty_slot1_nic"
 60) "False"
 61) "empty_slot2_nic"
 62) "False"
 63) "build_slot1_tor1"
 64) "MS"
 65) "build_slot2_tor1"
 66) "MS"
 67) "version_slot1_tor1"
 68) "0.6"
 69) "version_slot2_tor1"
 70) "0.6"
 71) "run_slot1_tor1"
 72) "True"
 73) "run_slot2_tor1"
 74) "False"
 75) "commit_slot1_tor1"
 76) "True"
 77) "commit_slot2_tor1"
 78) "False"
 79) "empty_slot1_tor1"
 80) "False"
 81) "empty_slot2_tor1"
 82) "False"
 83) "build_slot1_tor2"
 84) "MS"
 85) "build_slot2_tor2"
 86) "MS"
 87) "version_slot1_tor2"
 88) "0.6"
 89) "version_slot2_tor2"
 90) "0.6"
 91) "run_slot1_tor2"
 92) "True"
 93) "run_slot2_tor2"
 94) "False"
 95) "commit_slot1_tor2"
 96) "True"
 97) "commit_slot2_tor2"
 98) "False"
 99) "empty_slot1_tor2"
100) "False"
101) "empty_slot2_tor2"
102) "False"

admin@str-7050cx3-acs-04:~$ redis-cli -n 6  hgetall "MUX_CABLE_STATIC_INFO|Ethernet4"
 1) "read_side"
 2) "tor2"
 3) "nic_lane1_precursor1"
 4) "0"
 5) "nic_lane1_precursor2"
 6) "-4"
 7) "nic_lane1_maincursor"
 8) "25"
 9) "nic_lane1_postcursor1"
10) "-2"
11) "nic_lane1_postcursor2"
12) "0"
13) "nic_lane2_precursor1"
14) "0"
15) "nic_lane2_precursor2"
16) "-4"
17) "nic_lane2_maincursor"
18) "25"
19) "nic_lane2_postcursor1"
20) "-2"
21) "nic_lane2_postcursor2"
22) "0"
23) "tor_self_lane1_precursor1"
24) "0"
25) "tor_self_lane1_precursor2"
26) "-4"
27) "tor_self_lane1_maincursor"
28) "25"
29) "tor_self_lane1_postcursor1"
30) "-2"
31) "tor_self_lane1_postcursor2"
32) "0"
33) "tor_self_lane2_precursor1"
34) "0"
35) "tor_self_lane2_precursor2"
36) "-4"
37) "tor_self_lane2_maincursor"
38) "25"
39) "tor_self_lane2_postcursor1"
40) "-2"
41) "tor_self_lane2_postcursor2"
42) "0"
43) "tor_peer_lane1_precursor1"
44) "0"
45) "tor_peer_lane1_precursor2"
46) "-4"
47) "tor_peer_lane1_maincursor"
48) "25"
49) "tor_peer_lane1_postcursor1"
50) "-2"
51) "tor_peer_lane1_postcursor2"
52) "0"
53) "tor_peer_lane2_precursor1"
54) "0"
55) "tor_peer_lane2_precursor2"
56) "-4"
57) "tor_peer_lane2_maincursor"
58) "25"
59) "tor_peer_lane2_postcursor1"
60) "-2"
61) "tor_peer_lane2_postcursor2"
62) "0"
```

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>