### PR TITLE
[xcvrd] Make functions used for media setting python3 compatible

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -11,7 +11,6 @@ try:
     import multiprocessing
     import os
     import signal
-    import string
     import sys
     import threading
     import time
@@ -624,7 +623,7 @@ def get_media_settings_key(physical_port, transceiver_dict):
     sup_len_str = 'Length Cable Assembly(m)'
     vendor_name_str = transceiver_dict[physical_port]['manufacturer']
     vendor_pn_str = transceiver_dict[physical_port]['model']
-    vendor_key = string.upper(vendor_name_str) + '-' + vendor_pn_str
+    vendor_key = vendor_name_str.upper() + '-' + vendor_pn_str
 
     media_len = ''
     if transceiver_dict[physical_port]['cable_type'] == sup_len_str:
@@ -664,7 +663,7 @@ def get_media_val_str_from_dict(media_dict):
 
     for key in range(0, len(tmp_dict)):
         media_str += tmp_dict[key]
-        if key != tmp_dict.keys()[-1]:
+        if key != list(tmp_dict.keys())[-1]:
             media_str += lane_separator
     return media_str
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Make functions used for media setting python3 compatible

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

fixes #139 

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Verified that the media settings are updated in APPL_DB by xcvrd in dynamic transceiver tuning supported platform. 
Logs: [UT_logs.txt](https://github.com/Azure/sonic-platform-daemons/files/5987046/UT_logs.txt)


#### Additional Information (Optional)
