### PR TITLE
[201911][xcvrd] Change in xcvrd ports cache creation, now ports are being fetched from config DB

### DIFF
--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -1193,9 +1193,8 @@ class DaemonXcvrd(daemon_base.DaemonBase):
                 (platform_path, hwsku_path) = device_info.get_paths_to_platform_and_hwsku_dirs()
                 platform_sfputil.read_all_porttab_mappings(hwsku_path, self.num_asics)
             else:
-                # For single ASIC platforms we pass port_config_file_path and the asic_inst as 0
-                port_config_file_path = device_info.get_path_to_port_config_file()
-                platform_sfputil.read_porttab_mappings(port_config_file_path, 0)
+                # For single ASIC platforms we pass asic_inst 0
+                platform_sfputil.read_porttab_mappings(None, asic_inst=0, get_ports_from_db=True)
         except Exception, e:
             self.log_error("Failed to read port info: %s" % (str(e)), True)
             sys.exit(PORT_CONFIG_LOAD_ERROR)


### PR DESCRIPTION
[xcvrd] Change in xcvrd ports cache creation, now ports are being fetched from config DB.
This change is not needed in master since in master the whole code was rewritten as part of the DPB therefore the bug was solved there (same goes for 202012).

Signed-off-by: liora <liora@nvidia.com>

**- Dependencies**
This must be merged only after https://github.com/Azure/sonic-platform-common/pull/172 is merged

**- Why I did it**
Fix community issue https://github.com/Azure/sonic-platform-daemons/issues/110
Issue description: newly created ports as part of dynamic port breakout process are not being added to XCVRD cache, hence not shown in SNMP get on entPhysicalEntry mib.

**- How I did it**
Add new option in XCVRD ports cache creation, fetch ports from config DB instead of port_config.ini

**- How to verify it**
SNMP walk on entPhysicalTable after static port breakout.

**- Which release branch to backport (provide reason below if selected)**
None