### PR TITLE
[syseepromd] Add unit tests; Refactor to allow for greater unit test coverage

### DIFF
--- a/sonic-syseepromd/pytest.ini
+++ b/sonic-syseepromd/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=scripts --cov-report html --cov-report term --cov-report xml --junitxml=test-results.xml -vv

--- a/sonic-syseepromd/scripts/syseepromd
+++ b/sonic-syseepromd/scripts/syseepromd
@@ -57,14 +57,13 @@ class DaemonSyseeprom(daemon_base.DaemonBase):
             self.eeprom = sonic_platform.platform.Platform().get_chassis().get_eeprom()
         except Exception as e:
             self.log_warning(
-                "Failed to load platform-specific eeprom from sonic_platform package due to {}".format(repr(e)))
+                "Failed to load platform-specific eeprom from sonic_platform package due to {}. Trying deprecated plugin method ...".format(repr(e)))
 
-        # If we didn't successfully load the class from the sonic_platform package, try loading the old plugin
-        if not self.eeprom:
+            # If we didn't successfully load the class from the sonic_platform package, try loading the old plugin
             try:
                 self.eeprom = self.load_platform_util(PLATFORM_SPECIFIC_MODULE_NAME, PLATFORM_SPECIFIC_CLASS_NAME)
             except Exception as e:
-                self.log_error("Failed to load platform-specific eeprom implementation: {}".format(repr(e)))
+                self.log_error("Failed to load platform-specific eeprom from deprecated plugin: {}".format(repr(e)))
 
         if not self.eeprom:
             sys.exit(ERR_EEPROM_LOAD)

--- a/sonic-syseepromd/scripts/syseepromd
+++ b/sonic-syseepromd/scripts/syseepromd
@@ -8,83 +8,93 @@
     With this daemon, show syseeprom CLI will be able to get data from state DB instead of access hw or cache.
 '''
 
-try:
-    import signal
-    import sys
-    import threading
+import os
+import signal
+import sys
+import threading
 
-    from sonic_py_common import daemon_base
+from sonic_py_common import daemon_base
+
+# If unit testing is occurring, mock swsscommon and module_base
+if os.getenv("SYSEEPROMD_UNIT_TESTING") == "1":
+    #from tests.mock_platform import MockPsu as Psu
+    from tests import mock_swsscommon as swsscommon
+else:
+    import sonic_platform
     from swsscommon import swsscommon
-except ImportError as e:
-    raise ImportError(str(e) + " - required module not found")
 
-PLATFORM_SPECIFIC_MODULE_NAME = 'eeprom'
-PLATFORM_SPECIFIC_CLASS_NAME = 'board'
+
+# TODO: Once we no longer support Python 2, we can eliminate this and get the
+# name using the 'name' field (e.g., `signal.SIGINT.name`) starting with Python 3.5
+SIGNALS_TO_NAMES_DICT = dict((getattr(signal, n), n) \
+        for n in dir(signal) if n.startswith('SIG') and '_' not in n )
 
 EEPROM_INFO_UPDATE_PERIOD_SECS = 60
 
-POST_EEPROM_SUCCESS = 0
+ERR_NONE = 0
 ERR_PLATFORM_NOT_SUPPORT = 1
 ERR_FAILED_EEPROM = 2
 ERR_FAILED_UPDATE_DB = 3
 ERR_INVALID_PARAMETER = 4
-ERR_EEPROMUTIL_LOAD = 5
+ERR_EEPROM_LOAD = 5
 
 EEPROM_TABLE_NAME = 'EEPROM_INFO'
+
 SYSLOG_IDENTIFIER = 'syseepromd'
 
 
 class DaemonSyseeprom(daemon_base.DaemonBase):
-    def __init__(self, log_identifier):
-        super(DaemonSyseeprom, self).__init__(log_identifier)
+    def __init__(self):
+        super(DaemonSyseeprom, self).__init__(SYSLOG_IDENTIFIER)
 
         self.stop_event = threading.Event()
         self.eeprom = None
+        self.eeprom_tbl = None
 
+        # Load the new platform API
+        try:
+            self.eeprom = sonic_platform.platform.Platform().get_chassis().get_eeprom()
+        except Exception as e:
+            self.log_warning(
+                "Failed to load Eeprom class from sonic_platform package due to {}".format(repr(e)))
+
+        if not self.eeprom:
+            sys.exit(ERR_EEPROM_LOAD)
+
+        # Connect to STATE_DB
         state_db = daemon_base.db_connect("STATE_DB")
         self.eeprom_tbl = swsscommon.Table(state_db, EEPROM_TABLE_NAME)
         self.eepromtbl_keys = []
 
-    def _wrapper_read_eeprom(self):
-        if self.eeprom is not None:
-            try:
-                return self.eeprom.read_eeprom()
-            except (NotImplementedError, IOError):
-                pass
+        # Post system EEPROM info to state DB once at start-up
+        rc = self.post_eeprom_to_db()
+        if rc != ERR_NONE:
+            self.log_error("Failed to post system EEPROM info to database")
 
-        try:
-            return self.eeprom.read_eeprom()
-        except IOError:
-            pass
-
-    def _wrapper_update_eeprom_db(self, eeprom):
-        if self.eeprom is not None:
-            try:
-                return self.eeprom.update_eeprom_db(eeprom)
-            except NotImplementedError:
-                pass
-
-        return self.eeprom.update_eeprom_db(eeprom)
+    def __del__(self):
+        # Delete all the information from DB
+        self.clear_db()
 
     def post_eeprom_to_db(self):
-        eeprom = self._wrapper_read_eeprom()
-        if eeprom is None:
-            self.log_error("Failed to read eeprom")
+        eeprom_data = self.eeprom.read_eeprom()
+        if eeprom_data is None:
+            self.log_error("Failed to read EEPROM")
             return ERR_FAILED_EEPROM
 
-        err = self._wrapper_update_eeprom_db(eeprom)
+        err = self.eeprom.update_eeprom_db(eeprom_data)
         if err:
-            self.log_error("Failed to update eeprom info to database")
+            self.log_error("Failed to update EEPROM info in database")
             return ERR_FAILED_UPDATE_DB
 
         self.eepromtbl_keys = self.eeprom_tbl.getKeys()
 
-        return POST_EEPROM_SUCCESS
+        return ERR_NONE
 
     def clear_db(self):
-        keys = self.eeprom_tbl.getKeys()
-        for key in keys:
-            self.eeprom_tbl._del(key)
+        if self.eeprom_tbl:
+            keys = self.eeprom_tbl.getKeys()
+            for key in keys:
+                self.eeprom_tbl._del(key)
 
     def detect_eeprom_table_integrity(self):
         keys = self.eeprom_tbl.getKeys()
@@ -109,54 +119,23 @@ class DaemonSyseeprom(daemon_base.DaemonBase):
             self.log_info("Caught SIGTERM - exiting...")
             self.stop_event.set()
         else:
-            self.log_warning("Caught unhandled signal '" + sig + "'")
+            self.log_warning("Caught unhandled signal '{}'".format(SIGNALS_TO_NAMES_DICT[sig]))
 
     # Run daemon
     def run(self):
-        self.log_info("Starting up...")
+        if self.stop_event.wait(EEPROM_INFO_UPDATE_PERIOD_SECS):
+            # We received a fatal signal
+            return False
 
-        # First, try to load the new platform API
-        try:
-            import sonic_platform
-            self.chassis = sonic_platform.platform.Platform().get_chassis()
-            self.eeprom = self.chassis.get_eeprom()
-        except Exception as e:
-            self.log_warning("Failed to load data from eeprom using sonic_platform package due to {}, retrying using deprecated plugin method".format(repr(e)))
+        rc = self.detect_eeprom_table_integrity()
+        if not rc:
+            self.log_info("System EEPROM table was changed, needs update")
+            self.clear_db()
+            rcs = self.post_eeprom_to_db()
+            if rcs != ERR_NONE:
+                self.log_error("Failed to post EEPROM to database")
 
-        # If we didn't successfully load the class from the sonic_platform package, try loading the old plugin
-        if not self.eeprom:
-            try:
-                self.eeprom = self.load_platform_util(PLATFORM_SPECIFIC_MODULE_NAME, PLATFORM_SPECIFIC_CLASS_NAME)
-            except Exception as e:
-                self.log_error("Failed to load platform-specific eeprom implementation: {}".format(repr(e)))
-
-        if not self.eeprom:
-            sys.exit(ERR_EEPROMUTIL_LOAD)
-
-        # Connect to STATE_DB and post syseeprom info to state DB
-        rc = self.post_eeprom_to_db()
-        if rc != POST_EEPROM_SUCCESS:
-            self.log_error("Failed to post eeprom to database")
-
-        # Start main loop
-        self.log_info("Start daemon main loop")
-
-        while not self.stop_event.wait(EEPROM_INFO_UPDATE_PERIOD_SECS):
-            rc = self.detect_eeprom_table_integrity()
-            if not rc:
-                self.log_info("sys eeprom table was changed, need update")
-                self.clear_db()
-                rcs = self.post_eeprom_to_db()
-                if rcs != POST_EEPROM_SUCCESS:
-                    self.log_error("Failed to post eeprom to database")
-                    continue
-
-        self.log_info("Stop daemon main loop")
-
-        # Delete all the information from DB and then exit
-        self.clear_db()
-
-        self.log_info("Shutting down...")
+        return True
 
 #
 # Main =========================================================================
@@ -164,8 +143,14 @@ class DaemonSyseeprom(daemon_base.DaemonBase):
 
 
 def main():
-    syseepromd = DaemonSyseeprom(SYSLOG_IDENTIFIER)
-    syseepromd.run()
+    syseepromd = DaemonSyseeprom()
+
+    syseepromd.log_info("Starting up...")
+
+    while syseepromd.run():
+        pass
+
+    syseepromd.log_info("Shutting down...")
 
 
 if __name__ == '__main__':

--- a/sonic-syseepromd/scripts/syseepromd
+++ b/sonic-syseepromd/scripts/syseepromd
@@ -12,7 +12,6 @@ import signal
 import sys
 import threading
 
-import sonic_platform
 from sonic_py_common import daemon_base
 from swsscommon import swsscommon
 
@@ -21,6 +20,9 @@ from swsscommon import swsscommon
 # name using the 'name' field (e.g., `signal.SIGINT.name`) starting with Python 3.5
 SIGNALS_TO_NAMES_DICT = dict((getattr(signal, n), n) \
         for n in dir(signal) if n.startswith('SIG') and '_' not in n )
+
+PLATFORM_SPECIFIC_MODULE_NAME = 'eeprom'
+PLATFORM_SPECIFIC_CLASS_NAME = 'board'
 
 EEPROM_INFO_UPDATE_PERIOD_SECS = 60
 
@@ -44,12 +46,20 @@ class DaemonSyseeprom(daemon_base.DaemonBase):
         self.eeprom = None
         self.eeprom_tbl = None
 
-        # Load the new platform API
+        # First, try to load the new platform API
         try:
+            import sonic_platform
             self.eeprom = sonic_platform.platform.Platform().get_chassis().get_eeprom()
         except Exception as e:
             self.log_warning(
-                "Failed to load Eeprom class from sonic_platform package due to {}".format(repr(e)))
+                "Failed to load platform-specific eeprom from sonic_platform package due to {}".format(repr(e)))
+
+        # If we didn't successfully load the class from the sonic_platform package, try loading the old plugin
+        if not self.eeprom:
+            try:
+                self.eeprom = self.load_platform_util(PLATFORM_SPECIFIC_MODULE_NAME, PLATFORM_SPECIFIC_CLASS_NAME)
+            except Exception as e:
+                self.log_error("Failed to load platform-specific eeprom implementation: {}".format(repr(e)))
 
         if not self.eeprom:
             sys.exit(ERR_EEPROM_LOAD)

--- a/sonic-syseepromd/scripts/syseepromd
+++ b/sonic-syseepromd/scripts/syseepromd
@@ -8,20 +8,13 @@
     With this daemon, show syseeprom CLI will be able to get data from state DB instead of access hw or cache.
 '''
 
-import os
 import signal
 import sys
 import threading
 
+import sonic_platform
 from sonic_py_common import daemon_base
-
-# If unit testing is occurring, mock swsscommon and module_base
-if os.getenv("SYSEEPROMD_UNIT_TESTING") == "1":
-    #from tests.mock_platform import MockPsu as Psu
-    from tests import mock_swsscommon as swsscommon
-else:
-    import sonic_platform
-    from swsscommon import swsscommon
+from swsscommon import swsscommon
 
 
 # TODO: Once we no longer support Python 2, we can eliminate this and get the

--- a/sonic-syseepromd/scripts/syseepromd
+++ b/sonic-syseepromd/scripts/syseepromd
@@ -37,6 +37,8 @@ EEPROM_TABLE_NAME = 'EEPROM_INFO'
 
 SYSLOG_IDENTIFIER = 'syseepromd'
 
+exit_code = 0
+
 
 class DaemonSyseeprom(daemon_base.DaemonBase):
     def __init__(self):
@@ -111,20 +113,23 @@ class DaemonSyseeprom(daemon_base.DaemonBase):
 
         return True
 
-    # Signal handler
+    # Override signal handler from DaemonBase
     def signal_handler(self, sig, frame):
-        if sig == signal.SIGHUP:
-            self.log_info("Caught SIGHUP - ignoring...")
-        elif sig == signal.SIGINT:
-            self.log_info("Caught SIGINT - exiting...")
-            self.stop_event.set()
-        elif sig == signal.SIGTERM:
-            self.log_info("Caught SIGTERM - exiting...")
-            self.stop_event.set()
-        else:
-            self.log_warning("Caught unhandled signal '{}'".format(SIGNALS_TO_NAMES_DICT[sig]))
+        FATAL_SIGNALS = [signal.SIGINT, signal.SIGTERM]
+        NONFATAL_SIGNALS = [signal.SIGHUP]
 
-    # Run daemon
+        global exit_code
+
+        if sig in FATAL_SIGNALS:
+            self.log_info("Caught signal '{}' - exiting...".format(SIGNALS_TO_NAMES_DICT[sig]))
+            exit_code = 128 + sig  # Make sure we exit with a non-zero code so that supervisor will try to restart us
+            self.stop_event.set()
+        elif sig in NONFATAL_SIGNALS:
+            self.log_info("Caught signal '{}' - ignoring...".format(SIGNALS_TO_NAMES_DICT[sig]))
+        else:
+            self.log_warning("Caught unhandled signal '{}' - ignoring...".format(SIGNALS_TO_NAMES_DICT[sig]))
+
+    # Main daemon logic
     def run(self):
         if self.stop_event.wait(EEPROM_INFO_UPDATE_PERIOD_SECS):
             # We received a fatal signal
@@ -155,6 +160,8 @@ def main():
 
     syseepromd.log_info("Shutting down...")
 
+    return exit_code
+
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/sonic-syseepromd/scripts/syseepromd
+++ b/sonic-syseepromd/scripts/syseepromd
@@ -44,6 +44,9 @@ class DaemonSyseeprom(daemon_base.DaemonBase):
     def __init__(self):
         super(DaemonSyseeprom, self).__init__(SYSLOG_IDENTIFIER)
 
+        # Set minimum logging level to INFO
+        self.set_min_log_priority_info()
+
         self.stop_event = threading.Event()
         self.eeprom = None
         self.eeprom_tbl = None

--- a/sonic-syseepromd/scripts/syseepromd
+++ b/sonic-syseepromd/scripts/syseepromd
@@ -18,8 +18,8 @@ from swsscommon import swsscommon
 
 # TODO: Once we no longer support Python 2, we can eliminate this and get the
 # name using the 'name' field (e.g., `signal.SIGINT.name`) starting with Python 3.5
-SIGNALS_TO_NAMES_DICT = dict((getattr(signal, n), n) \
-        for n in dir(signal) if n.startswith('SIG') and '_' not in n )
+SIGNALS_TO_NAMES_DICT = dict((getattr(signal, n), n)
+                             for n in dir(signal) if n.startswith('SIG') and '_' not in n)
 
 PLATFORM_SPECIFIC_MODULE_NAME = 'eeprom'
 PLATFORM_SPECIFIC_CLASS_NAME = 'board'

--- a/sonic-syseepromd/setup.cfg
+++ b/sonic-syseepromd/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/sonic-syseepromd/setup.py
+++ b/sonic-syseepromd/setup.py
@@ -16,6 +16,12 @@ setup(
     setup_requires=[
         'wheel'
     ],
+    tests_require=[
+        'mock>=2.0.0; python_version < "3.3"',
+        'pytest',
+        'pytest-cov',
+        'sonic_platform_common'
+    ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: No Input/Output (Daemon)',

--- a/sonic-syseepromd/tests/mock_swsscommon.py
+++ b/sonic-syseepromd/tests/mock_swsscommon.py
@@ -1,0 +1,47 @@
+STATE_DB = ''
+
+
+class Table:
+    def __init__(self, db, table_name):
+        self.table_name = table_name
+        self.mock_dict = {}
+
+    def _del(self, key):
+        del self.mock_dict[key]
+        pass
+
+    def set(self, key, fvs):
+        self.mock_dict[key] = fvs.fv_dict
+        pass
+
+    def get(self, key):
+        if key in self.mock_dict:
+            return self.mock_dict[key]
+        return None
+
+
+class FieldValuePairs:
+    fv_dict = {}
+
+    def __init__(self, tuple_list):
+        if isinstance(tuple_list, list) and isinstance(tuple_list[0], tuple):
+            self.fv_dict = dict(tuple_list)
+
+    def __setitem__(self, key, kv_tuple):
+        self.fv_dict[kv_tuple[0]] = kv_tuple[1]
+
+    def __getitem__(self, key):
+        return self.fv_dict[key]
+
+    def __eq__(self, other):
+        if not isinstance(other, FieldValuePairs):
+            # don't attempt to compare against unrelated types
+            return NotImplemented
+
+        return self.fv_dict == other.fv_dict
+
+    def __repr__(self):
+        return repr(self.fv_dict)
+
+    def __str__(self):
+        return repr(self.fv_dict)

--- a/sonic-syseepromd/tests/mocked_libs/sonic_platform/__init__.py
+++ b/sonic-syseepromd/tests/mocked_libs/sonic_platform/__init__.py
@@ -1,0 +1,6 @@
+"""
+    Mock implementation of sonic_platform package for unit testing
+"""
+
+from . import chassis
+from . import platform

--- a/sonic-syseepromd/tests/mocked_libs/sonic_platform/chassis.py
+++ b/sonic-syseepromd/tests/mocked_libs/sonic_platform/chassis.py
@@ -1,0 +1,21 @@
+"""
+    Mock implementation of sonic_platform package for unit testing
+"""
+
+# TODO: Clean this up once we no longer need to support Python 2
+import sys
+if sys.version_info.major == 3:
+    from unittest import mock
+else:
+    import mock
+
+from sonic_platform_base.chassis_base import ChassisBase
+
+
+class Chassis(ChassisBase):
+    def __init__(self):
+        ChassisBase.__init__(self)
+        self.eeprom = mock.MagicMock()
+
+    def get_eeprom(self):
+        return self.eeprom

--- a/sonic-syseepromd/tests/mocked_libs/sonic_platform/platform.py
+++ b/sonic-syseepromd/tests/mocked_libs/sonic_platform/platform.py
@@ -1,0 +1,11 @@
+"""
+    Mock implementation of sonic_platform package for unit testing
+"""
+
+from sonic_platform_base.platform_base import PlatformBase
+from sonic_platform.chassis import Chassis
+
+class Platform(PlatformBase):
+    def __init__(self):
+        PlatformBase.__init__(self)
+        self._chassis = Chassis()

--- a/sonic-syseepromd/tests/mocked_libs/sonic_platform/platform.py
+++ b/sonic-syseepromd/tests/mocked_libs/sonic_platform/platform.py
@@ -5,6 +5,7 @@
 from sonic_platform_base.platform_base import PlatformBase
 from sonic_platform.chassis import Chassis
 
+
 class Platform(PlatformBase):
     def __init__(self):
         PlatformBase.__init__(self)

--- a/sonic-syseepromd/tests/mocked_libs/swsscommon/__init__.py
+++ b/sonic-syseepromd/tests/mocked_libs/swsscommon/__init__.py
@@ -1,0 +1,5 @@
+'''
+    Mock implementation of swsscommon package for unit testing
+'''
+
+from . import swsscommon

--- a/sonic-syseepromd/tests/mocked_libs/swsscommon/swsscommon.py
+++ b/sonic-syseepromd/tests/mocked_libs/swsscommon/swsscommon.py
@@ -1,3 +1,7 @@
+'''
+    Mock implementation of swsscommon package for unit testing
+'''
+
 STATE_DB = ''
 
 

--- a/sonic-syseepromd/tests/test_syseepromd.py
+++ b/sonic-syseepromd/tests/test_syseepromd.py
@@ -79,6 +79,28 @@ def test_clear_db():
     assert daemon_syseepromd.eeprom_tbl._del.call_count == 2
 
 
+def test_detect_eeprom_table_integrity():
+    daemon_syseepromd = syseepromd.DaemonSyseeprom()
+
+    # Test entries as expected
+    daemon_syseepromd.eeprom_tbl.getKeys = mock.MagicMock(return_value=['key1', 'key2'])
+    daemon_syseepromd.eepromtbl_keys = ['key1', 'key2']
+    ret = daemon_syseepromd.detect_eeprom_table_integrity()
+    assert ret == True
+
+    # Test differing amounts of entries
+    daemon_syseepromd.eeprom_tbl.getKeys = mock.MagicMock(return_value=['key1', 'key2'])
+    daemon_syseepromd.eepromtbl_keys = ['key1']
+    ret = daemon_syseepromd.detect_eeprom_table_integrity()
+    assert ret == False
+
+    # Test same amount of entries, but with different keys
+    daemon_syseepromd.eeprom_tbl.getKeys = mock.MagicMock(return_value=['key1', 'key2'])
+    daemon_syseepromd.eepromtbl_keys = ['key1', 'key3']
+    ret = daemon_syseepromd.detect_eeprom_table_integrity()
+    assert ret == False
+
+
 def test_signal_handler():
     daemon_syseepromd = syseepromd.DaemonSyseeprom()
     daemon_syseepromd.stop_event.set = mock.MagicMock()

--- a/sonic-syseepromd/tests/test_syseepromd.py
+++ b/sonic-syseepromd/tests/test_syseepromd.py
@@ -31,9 +31,42 @@ load_source('syseepromd', os.path.join(scripts_path, 'syseepromd'))
 import syseepromd
 
 
-def test_post_eeprom_to_db():
+def test_post_eeprom_to_db_eeprom_read_fail():
     daemon_syseepromd = syseepromd.DaemonSyseeprom()
-    daemon_syseepromd.post_eeprom_to_db()
+    daemon_syseepromd.eeprom.read_eeprom = mock.MagicMock(return_value=None)
+    daemon_syseepromd.eeprom_tbl = mock.MagicMock()
+    daemon_syseepromd.log_error = mock.MagicMock()
+
+    ret = daemon_syseepromd.post_eeprom_to_db()
+    assert ret == syseepromd.ERR_FAILED_EEPROM
+    assert daemon_syseepromd.log_error.call_count == 1
+    daemon_syseepromd.log_error.assert_called_with('Failed to read EEPROM')
+    assert daemon_syseepromd.eeprom_tbl.getKeys.call_count == 0
+
+
+def test_post_eeprom_to_db_update_fail():
+    daemon_syseepromd = syseepromd.DaemonSyseeprom()
+    daemon_syseepromd.eeprom.update_eeprom_db = mock.MagicMock(return_value=1)
+    daemon_syseepromd.eeprom_tbl = mock.MagicMock()
+    daemon_syseepromd.log_error = mock.MagicMock()
+
+    ret = daemon_syseepromd.post_eeprom_to_db()
+    assert ret == syseepromd.ERR_FAILED_UPDATE_DB
+    assert daemon_syseepromd.log_error.call_count == 1
+    daemon_syseepromd.log_error.assert_called_with('Failed to update EEPROM info in database')
+    assert daemon_syseepromd.eeprom_tbl.getKeys.call_count == 0
+
+
+def test_post_eeprom_to_db_ok():
+    daemon_syseepromd = syseepromd.DaemonSyseeprom()
+    daemon_syseepromd.eeprom.update_eeprom_db = mock.MagicMock(return_value=0)
+    daemon_syseepromd.eeprom_tbl = mock.MagicMock()
+    daemon_syseepromd.log_error = mock.MagicMock()
+
+    ret = daemon_syseepromd.post_eeprom_to_db()
+    assert ret == syseepromd.ERR_NONE
+    assert daemon_syseepromd.log_error.call_count == 0
+    assert daemon_syseepromd.eeprom_tbl.getKeys.call_count == 1
 
 #@mock.patch('psud.platform_chassis', mock.MagicMock())
 #@mock.patch('psud.platform_psuutil', mock.MagicMock())

--- a/sonic-syseepromd/tests/test_syseepromd.py
+++ b/sonic-syseepromd/tests/test_syseepromd.py
@@ -68,6 +68,16 @@ def test_post_eeprom_to_db_ok():
     assert daemon_syseepromd.log_error.call_count == 0
     assert daemon_syseepromd.eeprom_tbl.getKeys.call_count == 1
 
+
+def test_clear_db():
+    daemon_syseepromd = syseepromd.DaemonSyseeprom()
+    daemon_syseepromd.eeprom_tbl.getKeys = mock.MagicMock(return_value=['key1', 'key2'])
+    daemon_syseepromd.eeprom_tbl._del = mock.MagicMock()
+
+    daemon_syseepromd.clear_db()
+    assert daemon_syseepromd.eeprom_tbl.getKeys.call_count == 1
+    assert daemon_syseepromd.eeprom_tbl._del.call_count == 2
+
 #@mock.patch('psud.platform_chassis', mock.MagicMock())
 #@mock.patch('psud.platform_psuutil', mock.MagicMock())
 #def test_wrapper_get_num_psus():

--- a/sonic-syseepromd/tests/test_syseepromd.py
+++ b/sonic-syseepromd/tests/test_syseepromd.py
@@ -78,130 +78,175 @@ def test_clear_db():
     assert daemon_syseepromd.eeprom_tbl.getKeys.call_count == 1
     assert daemon_syseepromd.eeprom_tbl._del.call_count == 2
 
-#@mock.patch('psud.platform_chassis', mock.MagicMock())
-#@mock.patch('psud.platform_psuutil', mock.MagicMock())
+
+def test_signal_handler():
+    daemon_syseepromd = syseepromd.DaemonSyseeprom()
+    daemon_syseepromd.stop_event.set = mock.MagicMock()
+    daemon_syseepromd.log_info = mock.MagicMock()
+    daemon_syseepromd.log_warning = mock.MagicMock()
+
+    # Test SIGHUP
+    daemon_syseepromd.signal_handler(syseepromd.signal.SIGHUP, None)
+    assert daemon_syseepromd.log_info.call_count == 1
+    daemon_syseepromd.log_info.assert_called_with("Caught SIGHUP - ignoring...")
+    assert daemon_syseepromd.log_warning.call_count == 0
+    assert daemon_syseepromd.stop_event.set.call_count == 0
+
+    # Test SIGINT
+    daemon_syseepromd.log_info.reset_mock()
+    daemon_syseepromd.log_warning.reset_mock()
+    daemon_syseepromd.stop_event.set.reset_mock()
+    daemon_syseepromd.signal_handler(syseepromd.signal.SIGINT, None)
+    assert daemon_syseepromd.log_info.call_count == 1
+    daemon_syseepromd.log_info.assert_called_with("Caught SIGINT - exiting...")
+    assert daemon_syseepromd.log_warning.call_count == 0
+    assert daemon_syseepromd.stop_event.set.call_count == 1
+
+    # Test SIGTERM
+    daemon_syseepromd.log_info.reset_mock()
+    daemon_syseepromd.log_warning.reset_mock()
+    daemon_syseepromd.stop_event.set.reset_mock()
+    daemon_syseepromd.signal_handler(syseepromd.signal.SIGTERM, None)
+    assert daemon_syseepromd.log_info.call_count == 1
+    daemon_syseepromd.log_info.assert_called_with("Caught SIGTERM - exiting...")
+    assert daemon_syseepromd.log_warning.call_count == 0
+    assert daemon_syseepromd.stop_event.set.call_count == 1
+
+    # Test an unhandled signal
+    daemon_syseepromd.log_info.reset_mock()
+    daemon_syseepromd.log_warning.reset_mock()
+    daemon_syseepromd.stop_event.set.reset_mock()
+    daemon_syseepromd.signal_handler(syseepromd.signal.SIGUSR1, None)
+    assert daemon_syseepromd.log_warning.call_count == 1
+    daemon_syseepromd.log_warning.assert_called_with("Caught unhandled signal 'SIGUSR1'")
+    assert daemon_syseepromd.log_info.call_count == 0
+    assert daemon_syseepromd.stop_event.set.call_count == 0
+
+
+#@mock.patch('syseepromd.platform_chassis', mock.MagicMock())
+#@mock.patch('syseepromd.platform_psuutil', mock.MagicMock())
 #def test_wrapper_get_num_psus():
 #    # Test new platform API is available and implemented
-#    psud._wrapper_get_num_psus()
-#    assert psud.platform_chassis.get_num_psus.call_count == 1
-#    assert psud.platform_psuutil.get_num_psus.call_count == 0
+#    syseepromd._wrapper_get_num_psus()
+#    assert syseepromd.platform_chassis.get_num_psus.call_count == 1
+#    assert syseepromd.platform_psuutil.get_num_psus.call_count == 0
 #
 #    # Test new platform API is available but not implemented
-#    psud.platform_chassis.get_num_psus.side_effect = NotImplementedError
-#    psud._wrapper_get_num_psus()
-#    assert psud.platform_chassis.get_num_psus.call_count == 2
-#    assert psud.platform_psuutil.get_num_psus.call_count == 1
+#    syseepromd.platform_chassis.get_num_psus.side_effect = NotImplementedError
+#    syseepromd._wrapper_get_num_psus()
+#    assert syseepromd.platform_chassis.get_num_psus.call_count == 2
+#    assert syseepromd.platform_psuutil.get_num_psus.call_count == 1
 #
 #    # Test new platform API not available
-#    psud.platform_chassis = None
-#    psud._wrapper_get_num_psus()
-#    assert psud.platform_psuutil.get_num_psus.call_count == 2
+#    syseepromd.platform_chassis = None
+#    syseepromd._wrapper_get_num_psus()
+#    assert syseepromd.platform_psuutil.get_num_psus.call_count == 2
 #
 #
-#@mock.patch('psud.platform_chassis', mock.MagicMock())
-#@mock.patch('psud.platform_psuutil', mock.MagicMock())
+#@mock.patch('syseepromd.platform_chassis', mock.MagicMock())
+#@mock.patch('syseepromd.platform_psuutil', mock.MagicMock())
 #def test_wrapper_get_psu_presence():
 #    # Test new platform API is available
-#    psud._wrapper_get_psu_presence(1)
-#    assert psud.platform_chassis.get_psu(0).get_presence.call_count == 1
-#    assert psud.platform_psuutil.get_psu_presence.call_count == 0
+#    syseepromd._wrapper_get_psu_presence(1)
+#    assert syseepromd.platform_chassis.get_psu(0).get_presence.call_count == 1
+#    assert syseepromd.platform_psuutil.get_psu_presence.call_count == 0
 #
 #    # Test new platform API is available but not implemented
-#    psud.platform_chassis.get_psu(0).get_presence.side_effect = NotImplementedError
-#    psud._wrapper_get_psu_presence(1)
-#    assert psud.platform_chassis.get_psu(0).get_presence.call_count == 2
-#    assert psud.platform_psuutil.get_psu_presence.call_count == 1
+#    syseepromd.platform_chassis.get_psu(0).get_presence.side_effect = NotImplementedError
+#    syseepromd._wrapper_get_psu_presence(1)
+#    assert syseepromd.platform_chassis.get_psu(0).get_presence.call_count == 2
+#    assert syseepromd.platform_psuutil.get_psu_presence.call_count == 1
 #
 #    # Test new platform API not available
-#    psud.platform_chassis = None
-#    psud._wrapper_get_psu_presence(1)
-#    assert psud.platform_psuutil.get_psu_presence.call_count == 2
-#    psud.platform_psuutil.get_psu_presence.assert_called_with(1)
+#    syseepromd.platform_chassis = None
+#    syseepromd._wrapper_get_psu_presence(1)
+#    assert syseepromd.platform_psuutil.get_psu_presence.call_count == 2
+#    syseepromd.platform_psuutil.get_psu_presence.assert_called_with(1)
 #
 #
-#@mock.patch('psud.platform_chassis', mock.MagicMock())
-#@mock.patch('psud.platform_psuutil', mock.MagicMock())
+#@mock.patch('syseepromd.platform_chassis', mock.MagicMock())
+#@mock.patch('syseepromd.platform_psuutil', mock.MagicMock())
 #def test_wrapper_get_psu_status():
 #    # Test new platform API is available
-#    psud._wrapper_get_psu_status(1)
-#    assert psud.platform_chassis.get_psu(0).get_powergood_status.call_count == 1
-#    assert psud.platform_psuutil.get_psu_status.call_count == 0
+#    syseepromd._wrapper_get_psu_status(1)
+#    assert syseepromd.platform_chassis.get_psu(0).get_powergood_status.call_count == 1
+#    assert syseepromd.platform_psuutil.get_psu_status.call_count == 0
 #
 #    # Test new platform API is available but not implemented
-#    psud.platform_chassis.get_psu(0).get_powergood_status.side_effect = NotImplementedError
-#    psud._wrapper_get_psu_status(1)
-#    assert psud.platform_chassis.get_psu(0).get_powergood_status.call_count == 2
-#    assert psud.platform_psuutil.get_psu_status.call_count == 1
+#    syseepromd.platform_chassis.get_psu(0).get_powergood_status.side_effect = NotImplementedError
+#    syseepromd._wrapper_get_psu_status(1)
+#    assert syseepromd.platform_chassis.get_psu(0).get_powergood_status.call_count == 2
+#    assert syseepromd.platform_psuutil.get_psu_status.call_count == 1
 #
 #    # Test new platform API not available
-#    psud.platform_chassis = None
-#    psud._wrapper_get_psu_status(1)
-#    assert psud.platform_psuutil.get_psu_status.call_count == 2
-#    psud.platform_psuutil.get_psu_status.assert_called_with(1)
+#    syseepromd.platform_chassis = None
+#    syseepromd._wrapper_get_psu_status(1)
+#    assert syseepromd.platform_psuutil.get_psu_status.call_count == 2
+#    syseepromd.platform_psuutil.get_psu_status.assert_called_with(1)
 #
 #
-#@mock.patch('psud._wrapper_get_psu_presence', mock.MagicMock())
-#@mock.patch('psud._wrapper_get_psu_status', mock.MagicMock())
+#@mock.patch('syseepromd._wrapper_get_psu_presence', mock.MagicMock())
+#@mock.patch('syseepromd._wrapper_get_psu_status', mock.MagicMock())
 #def test_psu_db_update():
 #    psu_tbl = mock.MagicMock()
 #
-#    psud._wrapper_get_psu_presence.return_value = True
-#    psud._wrapper_get_psu_status.return_value = True
-#    expected_fvp = psud.swsscommon.FieldValuePairs(
-#        [(psud.PSU_INFO_PRESENCE_FIELD, 'true'),
-#         (psud.PSU_INFO_STATUS_FIELD, 'true'),
+#    syseepromd._wrapper_get_psu_presence.return_value = True
+#    syseepromd._wrapper_get_psu_status.return_value = True
+#    expected_fvp = syseepromd.swsscommon.FieldValuePairs(
+#        [(syseepromd.PSU_INFO_PRESENCE_FIELD, 'true'),
+#         (syseepromd.PSU_INFO_STATUS_FIELD, 'true'),
 #         ])
-#    psud.psu_db_update(psu_tbl, 1)
+#    syseepromd.psu_db_update(psu_tbl, 1)
 #    assert psu_tbl.set.call_count == 1
-#    psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+#    psu_tbl.set.assert_called_with(syseepromd.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
 #
 #    psu_tbl.set.reset_mock()
 #
-#    psud._wrapper_get_psu_presence.return_value = False
-#    psud._wrapper_get_psu_status.return_value = True
-#    expected_fvp = psud.swsscommon.FieldValuePairs(
-#        [(psud.PSU_INFO_PRESENCE_FIELD, 'false'),
-#         (psud.PSU_INFO_STATUS_FIELD, 'true'),
+#    syseepromd._wrapper_get_psu_presence.return_value = False
+#    syseepromd._wrapper_get_psu_status.return_value = True
+#    expected_fvp = syseepromd.swsscommon.FieldValuePairs(
+#        [(syseepromd.PSU_INFO_PRESENCE_FIELD, 'false'),
+#         (syseepromd.PSU_INFO_STATUS_FIELD, 'true'),
 #         ])
-#    psud.psu_db_update(psu_tbl, 1)
+#    syseepromd.psu_db_update(psu_tbl, 1)
 #    assert psu_tbl.set.call_count == 1
-#    psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+#    psu_tbl.set.assert_called_with(syseepromd.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
 #
 #    psu_tbl.set.reset_mock()
 #
-#    psud._wrapper_get_psu_presence.return_value = True
-#    psud._wrapper_get_psu_status.return_value = False
-#    expected_fvp = psud.swsscommon.FieldValuePairs(
-#        [(psud.PSU_INFO_PRESENCE_FIELD, 'true'),
-#         (psud.PSU_INFO_STATUS_FIELD, 'false'),
+#    syseepromd._wrapper_get_psu_presence.return_value = True
+#    syseepromd._wrapper_get_psu_status.return_value = False
+#    expected_fvp = syseepromd.swsscommon.FieldValuePairs(
+#        [(syseepromd.PSU_INFO_PRESENCE_FIELD, 'true'),
+#         (syseepromd.PSU_INFO_STATUS_FIELD, 'false'),
 #         ])
-#    psud.psu_db_update(psu_tbl, 1)
+#    syseepromd.psu_db_update(psu_tbl, 1)
 #    assert psu_tbl.set.call_count == 1
-#    psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+#    psu_tbl.set.assert_called_with(syseepromd.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
 #
 #    psu_tbl.set.reset_mock()
 #
-#    psud._wrapper_get_psu_presence.return_value = False
-#    psud._wrapper_get_psu_status.return_value = False
-#    expected_fvp = psud.swsscommon.FieldValuePairs(
-#        [(psud.PSU_INFO_PRESENCE_FIELD, 'false'),
-#         (psud.PSU_INFO_STATUS_FIELD, 'false'),
+#    syseepromd._wrapper_get_psu_presence.return_value = False
+#    syseepromd._wrapper_get_psu_status.return_value = False
+#    expected_fvp = syseepromd.swsscommon.FieldValuePairs(
+#        [(syseepromd.PSU_INFO_PRESENCE_FIELD, 'false'),
+#         (syseepromd.PSU_INFO_STATUS_FIELD, 'false'),
 #         ])
-#    psud.psu_db_update(psu_tbl, 1)
+#    syseepromd.psu_db_update(psu_tbl, 1)
 #    assert psu_tbl.set.call_count == 1
-#    psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+#    psu_tbl.set.assert_called_with(syseepromd.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
 #
 #    psu_tbl.set.reset_mock()
 #
-#    psud._wrapper_get_psu_presence.return_value = True
-#    psud._wrapper_get_psu_status.return_value = True
-#    expected_fvp = psud.swsscommon.FieldValuePairs(
-#        [(psud.PSU_INFO_PRESENCE_FIELD, 'true'),
-#         (psud.PSU_INFO_STATUS_FIELD, 'true'),
+#    syseepromd._wrapper_get_psu_presence.return_value = True
+#    syseepromd._wrapper_get_psu_status.return_value = True
+#    expected_fvp = syseepromd.swsscommon.FieldValuePairs(
+#        [(syseepromd.PSU_INFO_PRESENCE_FIELD, 'true'),
+#         (syseepromd.PSU_INFO_STATUS_FIELD, 'true'),
 #         ])
-#    psud.psu_db_update(psu_tbl, 32)
+#    syseepromd.psu_db_update(psu_tbl, 32)
 #    assert psu_tbl.set.call_count == 32
-#    psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(32), expected_fvp)
+#    psu_tbl.set.assert_called_with(syseepromd.PSU_INFO_KEY_TEMPLATE.format(32), expected_fvp)
 #
 #
 #def test_log_on_status_changed():
@@ -210,14 +255,14 @@ def test_clear_db():
 #
 #    mock_logger = mock.MagicMock()
 #
-#    psud.log_on_status_changed(mock_logger, True, normal_log, abnormal_log)
+#    syseepromd.log_on_status_changed(mock_logger, True, normal_log, abnormal_log)
 #    assert mock_logger.log_notice.call_count == 1
 #    assert mock_logger.log_warning.call_count == 0
 #    mock_logger.log_notice.assert_called_with(normal_log)
 #
 #    mock_logger.log_notice.reset_mock()
 #
-#    psud.log_on_status_changed(mock_logger, False, normal_log, abnormal_log)
+#    syseepromd.log_on_status_changed(mock_logger, False, normal_log, abnormal_log)
 #    assert mock_logger.log_notice.call_count == 0
 #    assert mock_logger.log_warning.call_count == 1
 #    mock_logger.log_warning.assert_called_with(abnormal_log)

--- a/sonic-syseepromd/tests/test_syseepromd.py
+++ b/sonic-syseepromd/tests/test_syseepromd.py
@@ -11,25 +11,26 @@ else:
     import mock
 from sonic_py_common import daemon_base
 
-from . import mock_swsscommon
-#from .mock_platform import MockPsu
-
 SYSLOG_IDENTIFIER = 'syseepromd_test'
 NOT_AVAILABLE = 'N/A'
 
 daemon_base.db_connect = mock.MagicMock()
 
-test_path = os.path.dirname(os.path.abspath(__file__))
-modules_path = os.path.dirname(test_path)
-scripts_path = os.path.join(modules_path, "scripts")
+tests_path = os.path.dirname(os.path.abspath(__file__))
+
+# Add mocked_libs path so that the file under test can load mocked modules from there
+mocked_libs_path = os.path.join(tests_path, 'mocked_libs')
+sys.path.insert(0, mocked_libs_path)
+
+# Add path to the file under test so that we can load it
+modules_path = os.path.dirname(tests_path)
+scripts_path = os.path.join(modules_path, 'scripts')
 sys.path.insert(0, modules_path)
 
-os.environ["SYSEEPROMD_UNIT_TESTING"] = "1"
 load_source('syseepromd', os.path.join(scripts_path, 'syseepromd'))
 import syseepromd
 
 
-@mock.patch('syseepromd.DaemonSyseeprom.eeprom', mock.MagicMock())
 def test_post_eeprom_to_db():
     daemon_syseepromd = syseepromd.DaemonSyseeprom()
     daemon_syseepromd.post_eeprom_to_db()

--- a/sonic-syseepromd/tests/test_syseepromd.py
+++ b/sonic-syseepromd/tests/test_syseepromd.py
@@ -110,39 +110,52 @@ def test_signal_handler():
     # Test SIGHUP
     daemon_syseepromd.signal_handler(syseepromd.signal.SIGHUP, None)
     assert daemon_syseepromd.log_info.call_count == 1
-    daemon_syseepromd.log_info.assert_called_with("Caught SIGHUP - ignoring...")
+    daemon_syseepromd.log_info.assert_called_with("Caught signal 'SIGHUP' - ignoring...")
     assert daemon_syseepromd.log_warning.call_count == 0
     assert daemon_syseepromd.stop_event.set.call_count == 0
+    assert syseepromd.exit_code == 0
+
+    # Reset
+    daemon_syseepromd.log_info.reset_mock()
+    daemon_syseepromd.log_warning.reset_mock()
+    daemon_syseepromd.stop_event.set.reset_mock()
 
     # Test SIGINT
+    test_signal = syseepromd.signal.SIGINT
+    daemon_syseepromd.signal_handler(test_signal, None)
+    assert daemon_syseepromd.log_info.call_count == 1
+    daemon_syseepromd.log_info.assert_called_with("Caught signal 'SIGINT' - exiting...")
+    assert daemon_syseepromd.log_warning.call_count == 0
+    assert daemon_syseepromd.stop_event.set.call_count == 1
+    assert syseepromd.exit_code == (128 + test_signal)
+
+    # Reset
     daemon_syseepromd.log_info.reset_mock()
     daemon_syseepromd.log_warning.reset_mock()
     daemon_syseepromd.stop_event.set.reset_mock()
-    daemon_syseepromd.signal_handler(syseepromd.signal.SIGINT, None)
-    assert daemon_syseepromd.log_info.call_count == 1
-    daemon_syseepromd.log_info.assert_called_with("Caught SIGINT - exiting...")
-    assert daemon_syseepromd.log_warning.call_count == 0
-    assert daemon_syseepromd.stop_event.set.call_count == 1
 
     # Test SIGTERM
-    daemon_syseepromd.log_info.reset_mock()
-    daemon_syseepromd.log_warning.reset_mock()
-    daemon_syseepromd.stop_event.set.reset_mock()
-    daemon_syseepromd.signal_handler(syseepromd.signal.SIGTERM, None)
+    test_signal = syseepromd.signal.SIGTERM
+    daemon_syseepromd.signal_handler(test_signal, None)
     assert daemon_syseepromd.log_info.call_count == 1
-    daemon_syseepromd.log_info.assert_called_with("Caught SIGTERM - exiting...")
+    daemon_syseepromd.log_info.assert_called_with("Caught signal 'SIGTERM' - exiting...")
     assert daemon_syseepromd.log_warning.call_count == 0
     assert daemon_syseepromd.stop_event.set.call_count == 1
+    assert syseepromd.exit_code == (128 + test_signal)
 
-    # Test an unhandled signal
+    # Reset
     daemon_syseepromd.log_info.reset_mock()
     daemon_syseepromd.log_warning.reset_mock()
     daemon_syseepromd.stop_event.set.reset_mock()
+    syseepromd.exit_code = 0
+
+    # Test an unhandled signal
     daemon_syseepromd.signal_handler(syseepromd.signal.SIGUSR1, None)
     assert daemon_syseepromd.log_warning.call_count == 1
-    daemon_syseepromd.log_warning.assert_called_with("Caught unhandled signal 'SIGUSR1'")
+    daemon_syseepromd.log_warning.assert_called_with("Caught unhandled signal 'SIGUSR1' - ignoring...")
     assert daemon_syseepromd.log_info.call_count == 0
     assert daemon_syseepromd.stop_event.set.call_count == 0
+    assert syseepromd.exit_code == 0
 
 
 @mock.patch('syseepromd.EEPROM_INFO_UPDATE_PERIOD_SECS', 1)

--- a/sonic-syseepromd/tests/test_syseepromd.py
+++ b/sonic-syseepromd/tests/test_syseepromd.py
@@ -1,0 +1,187 @@
+import os
+import sys
+from imp import load_source
+
+import pytest
+
+# TODO: Clean this up once we no longer need to support Python 2
+if sys.version_info.major == 3:
+    from unittest import mock
+else:
+    import mock
+from sonic_py_common import daemon_base
+
+from . import mock_swsscommon
+#from .mock_platform import MockPsu
+
+SYSLOG_IDENTIFIER = 'syseepromd_test'
+NOT_AVAILABLE = 'N/A'
+
+daemon_base.db_connect = mock.MagicMock()
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+scripts_path = os.path.join(modules_path, "scripts")
+sys.path.insert(0, modules_path)
+
+os.environ["SYSEEPROMD_UNIT_TESTING"] = "1"
+load_source('syseepromd', os.path.join(scripts_path, 'syseepromd'))
+import syseepromd
+
+
+@mock.patch('syseepromd.DaemonSyseeprom.eeprom', mock.MagicMock())
+def test_post_eeprom_to_db():
+    daemon_syseepromd = syseepromd.DaemonSyseeprom()
+    daemon_syseepromd.post_eeprom_to_db()
+
+#@mock.patch('psud.platform_chassis', mock.MagicMock())
+#@mock.patch('psud.platform_psuutil', mock.MagicMock())
+#def test_wrapper_get_num_psus():
+#    # Test new platform API is available and implemented
+#    psud._wrapper_get_num_psus()
+#    assert psud.platform_chassis.get_num_psus.call_count == 1
+#    assert psud.platform_psuutil.get_num_psus.call_count == 0
+#
+#    # Test new platform API is available but not implemented
+#    psud.platform_chassis.get_num_psus.side_effect = NotImplementedError
+#    psud._wrapper_get_num_psus()
+#    assert psud.platform_chassis.get_num_psus.call_count == 2
+#    assert psud.platform_psuutil.get_num_psus.call_count == 1
+#
+#    # Test new platform API not available
+#    psud.platform_chassis = None
+#    psud._wrapper_get_num_psus()
+#    assert psud.platform_psuutil.get_num_psus.call_count == 2
+#
+#
+#@mock.patch('psud.platform_chassis', mock.MagicMock())
+#@mock.patch('psud.platform_psuutil', mock.MagicMock())
+#def test_wrapper_get_psu_presence():
+#    # Test new platform API is available
+#    psud._wrapper_get_psu_presence(1)
+#    assert psud.platform_chassis.get_psu(0).get_presence.call_count == 1
+#    assert psud.platform_psuutil.get_psu_presence.call_count == 0
+#
+#    # Test new platform API is available but not implemented
+#    psud.platform_chassis.get_psu(0).get_presence.side_effect = NotImplementedError
+#    psud._wrapper_get_psu_presence(1)
+#    assert psud.platform_chassis.get_psu(0).get_presence.call_count == 2
+#    assert psud.platform_psuutil.get_psu_presence.call_count == 1
+#
+#    # Test new platform API not available
+#    psud.platform_chassis = None
+#    psud._wrapper_get_psu_presence(1)
+#    assert psud.platform_psuutil.get_psu_presence.call_count == 2
+#    psud.platform_psuutil.get_psu_presence.assert_called_with(1)
+#
+#
+#@mock.patch('psud.platform_chassis', mock.MagicMock())
+#@mock.patch('psud.platform_psuutil', mock.MagicMock())
+#def test_wrapper_get_psu_status():
+#    # Test new platform API is available
+#    psud._wrapper_get_psu_status(1)
+#    assert psud.platform_chassis.get_psu(0).get_powergood_status.call_count == 1
+#    assert psud.platform_psuutil.get_psu_status.call_count == 0
+#
+#    # Test new platform API is available but not implemented
+#    psud.platform_chassis.get_psu(0).get_powergood_status.side_effect = NotImplementedError
+#    psud._wrapper_get_psu_status(1)
+#    assert psud.platform_chassis.get_psu(0).get_powergood_status.call_count == 2
+#    assert psud.platform_psuutil.get_psu_status.call_count == 1
+#
+#    # Test new platform API not available
+#    psud.platform_chassis = None
+#    psud._wrapper_get_psu_status(1)
+#    assert psud.platform_psuutil.get_psu_status.call_count == 2
+#    psud.platform_psuutil.get_psu_status.assert_called_with(1)
+#
+#
+#@mock.patch('psud._wrapper_get_psu_presence', mock.MagicMock())
+#@mock.patch('psud._wrapper_get_psu_status', mock.MagicMock())
+#def test_psu_db_update():
+#    psu_tbl = mock.MagicMock()
+#
+#    psud._wrapper_get_psu_presence.return_value = True
+#    psud._wrapper_get_psu_status.return_value = True
+#    expected_fvp = psud.swsscommon.FieldValuePairs(
+#        [(psud.PSU_INFO_PRESENCE_FIELD, 'true'),
+#         (psud.PSU_INFO_STATUS_FIELD, 'true'),
+#         ])
+#    psud.psu_db_update(psu_tbl, 1)
+#    assert psu_tbl.set.call_count == 1
+#    psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+#
+#    psu_tbl.set.reset_mock()
+#
+#    psud._wrapper_get_psu_presence.return_value = False
+#    psud._wrapper_get_psu_status.return_value = True
+#    expected_fvp = psud.swsscommon.FieldValuePairs(
+#        [(psud.PSU_INFO_PRESENCE_FIELD, 'false'),
+#         (psud.PSU_INFO_STATUS_FIELD, 'true'),
+#         ])
+#    psud.psu_db_update(psu_tbl, 1)
+#    assert psu_tbl.set.call_count == 1
+#    psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+#
+#    psu_tbl.set.reset_mock()
+#
+#    psud._wrapper_get_psu_presence.return_value = True
+#    psud._wrapper_get_psu_status.return_value = False
+#    expected_fvp = psud.swsscommon.FieldValuePairs(
+#        [(psud.PSU_INFO_PRESENCE_FIELD, 'true'),
+#         (psud.PSU_INFO_STATUS_FIELD, 'false'),
+#         ])
+#    psud.psu_db_update(psu_tbl, 1)
+#    assert psu_tbl.set.call_count == 1
+#    psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+#
+#    psu_tbl.set.reset_mock()
+#
+#    psud._wrapper_get_psu_presence.return_value = False
+#    psud._wrapper_get_psu_status.return_value = False
+#    expected_fvp = psud.swsscommon.FieldValuePairs(
+#        [(psud.PSU_INFO_PRESENCE_FIELD, 'false'),
+#         (psud.PSU_INFO_STATUS_FIELD, 'false'),
+#         ])
+#    psud.psu_db_update(psu_tbl, 1)
+#    assert psu_tbl.set.call_count == 1
+#    psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+#
+#    psu_tbl.set.reset_mock()
+#
+#    psud._wrapper_get_psu_presence.return_value = True
+#    psud._wrapper_get_psu_status.return_value = True
+#    expected_fvp = psud.swsscommon.FieldValuePairs(
+#        [(psud.PSU_INFO_PRESENCE_FIELD, 'true'),
+#         (psud.PSU_INFO_STATUS_FIELD, 'true'),
+#         ])
+#    psud.psu_db_update(psu_tbl, 32)
+#    assert psu_tbl.set.call_count == 32
+#    psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(32), expected_fvp)
+#
+#
+#def test_log_on_status_changed():
+#    normal_log = "Normal log message"
+#    abnormal_log = "Abnormal log message"
+#
+#    mock_logger = mock.MagicMock()
+#
+#    psud.log_on_status_changed(mock_logger, True, normal_log, abnormal_log)
+#    assert mock_logger.log_notice.call_count == 1
+#    assert mock_logger.log_warning.call_count == 0
+#    mock_logger.log_notice.assert_called_with(normal_log)
+#
+#    mock_logger.log_notice.reset_mock()
+#
+#    psud.log_on_status_changed(mock_logger, False, normal_log, abnormal_log)
+#    assert mock_logger.log_notice.call_count == 0
+#    assert mock_logger.log_warning.call_count == 1
+#    mock_logger.log_warning.assert_called_with(abnormal_log)
+
+
+@mock.patch('syseepromd.DaemonSyseeprom.run')
+def test_main(mock_run):
+    mock_run.return_value = False
+
+    syseepromd.main()
+    assert mock_run.call_count == 1

--- a/sonic-syseepromd/tests/test_syseepromd.py
+++ b/sonic-syseepromd/tests/test_syseepromd.py
@@ -145,149 +145,59 @@ def test_signal_handler():
     assert daemon_syseepromd.stop_event.set.call_count == 0
 
 
-#@mock.patch('syseepromd.platform_chassis', mock.MagicMock())
-#@mock.patch('syseepromd.platform_psuutil', mock.MagicMock())
-#def test_wrapper_get_num_psus():
-#    # Test new platform API is available and implemented
-#    syseepromd._wrapper_get_num_psus()
-#    assert syseepromd.platform_chassis.get_num_psus.call_count == 1
-#    assert syseepromd.platform_psuutil.get_num_psus.call_count == 0
-#
-#    # Test new platform API is available but not implemented
-#    syseepromd.platform_chassis.get_num_psus.side_effect = NotImplementedError
-#    syseepromd._wrapper_get_num_psus()
-#    assert syseepromd.platform_chassis.get_num_psus.call_count == 2
-#    assert syseepromd.platform_psuutil.get_num_psus.call_count == 1
-#
-#    # Test new platform API not available
-#    syseepromd.platform_chassis = None
-#    syseepromd._wrapper_get_num_psus()
-#    assert syseepromd.platform_psuutil.get_num_psus.call_count == 2
-#
-#
-#@mock.patch('syseepromd.platform_chassis', mock.MagicMock())
-#@mock.patch('syseepromd.platform_psuutil', mock.MagicMock())
-#def test_wrapper_get_psu_presence():
-#    # Test new platform API is available
-#    syseepromd._wrapper_get_psu_presence(1)
-#    assert syseepromd.platform_chassis.get_psu(0).get_presence.call_count == 1
-#    assert syseepromd.platform_psuutil.get_psu_presence.call_count == 0
-#
-#    # Test new platform API is available but not implemented
-#    syseepromd.platform_chassis.get_psu(0).get_presence.side_effect = NotImplementedError
-#    syseepromd._wrapper_get_psu_presence(1)
-#    assert syseepromd.platform_chassis.get_psu(0).get_presence.call_count == 2
-#    assert syseepromd.platform_psuutil.get_psu_presence.call_count == 1
-#
-#    # Test new platform API not available
-#    syseepromd.platform_chassis = None
-#    syseepromd._wrapper_get_psu_presence(1)
-#    assert syseepromd.platform_psuutil.get_psu_presence.call_count == 2
-#    syseepromd.platform_psuutil.get_psu_presence.assert_called_with(1)
-#
-#
-#@mock.patch('syseepromd.platform_chassis', mock.MagicMock())
-#@mock.patch('syseepromd.platform_psuutil', mock.MagicMock())
-#def test_wrapper_get_psu_status():
-#    # Test new platform API is available
-#    syseepromd._wrapper_get_psu_status(1)
-#    assert syseepromd.platform_chassis.get_psu(0).get_powergood_status.call_count == 1
-#    assert syseepromd.platform_psuutil.get_psu_status.call_count == 0
-#
-#    # Test new platform API is available but not implemented
-#    syseepromd.platform_chassis.get_psu(0).get_powergood_status.side_effect = NotImplementedError
-#    syseepromd._wrapper_get_psu_status(1)
-#    assert syseepromd.platform_chassis.get_psu(0).get_powergood_status.call_count == 2
-#    assert syseepromd.platform_psuutil.get_psu_status.call_count == 1
-#
-#    # Test new platform API not available
-#    syseepromd.platform_chassis = None
-#    syseepromd._wrapper_get_psu_status(1)
-#    assert syseepromd.platform_psuutil.get_psu_status.call_count == 2
-#    syseepromd.platform_psuutil.get_psu_status.assert_called_with(1)
-#
-#
-#@mock.patch('syseepromd._wrapper_get_psu_presence', mock.MagicMock())
-#@mock.patch('syseepromd._wrapper_get_psu_status', mock.MagicMock())
-#def test_psu_db_update():
-#    psu_tbl = mock.MagicMock()
-#
-#    syseepromd._wrapper_get_psu_presence.return_value = True
-#    syseepromd._wrapper_get_psu_status.return_value = True
-#    expected_fvp = syseepromd.swsscommon.FieldValuePairs(
-#        [(syseepromd.PSU_INFO_PRESENCE_FIELD, 'true'),
-#         (syseepromd.PSU_INFO_STATUS_FIELD, 'true'),
-#         ])
-#    syseepromd.psu_db_update(psu_tbl, 1)
-#    assert psu_tbl.set.call_count == 1
-#    psu_tbl.set.assert_called_with(syseepromd.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
-#
-#    psu_tbl.set.reset_mock()
-#
-#    syseepromd._wrapper_get_psu_presence.return_value = False
-#    syseepromd._wrapper_get_psu_status.return_value = True
-#    expected_fvp = syseepromd.swsscommon.FieldValuePairs(
-#        [(syseepromd.PSU_INFO_PRESENCE_FIELD, 'false'),
-#         (syseepromd.PSU_INFO_STATUS_FIELD, 'true'),
-#         ])
-#    syseepromd.psu_db_update(psu_tbl, 1)
-#    assert psu_tbl.set.call_count == 1
-#    psu_tbl.set.assert_called_with(syseepromd.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
-#
-#    psu_tbl.set.reset_mock()
-#
-#    syseepromd._wrapper_get_psu_presence.return_value = True
-#    syseepromd._wrapper_get_psu_status.return_value = False
-#    expected_fvp = syseepromd.swsscommon.FieldValuePairs(
-#        [(syseepromd.PSU_INFO_PRESENCE_FIELD, 'true'),
-#         (syseepromd.PSU_INFO_STATUS_FIELD, 'false'),
-#         ])
-#    syseepromd.psu_db_update(psu_tbl, 1)
-#    assert psu_tbl.set.call_count == 1
-#    psu_tbl.set.assert_called_with(syseepromd.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
-#
-#    psu_tbl.set.reset_mock()
-#
-#    syseepromd._wrapper_get_psu_presence.return_value = False
-#    syseepromd._wrapper_get_psu_status.return_value = False
-#    expected_fvp = syseepromd.swsscommon.FieldValuePairs(
-#        [(syseepromd.PSU_INFO_PRESENCE_FIELD, 'false'),
-#         (syseepromd.PSU_INFO_STATUS_FIELD, 'false'),
-#         ])
-#    syseepromd.psu_db_update(psu_tbl, 1)
-#    assert psu_tbl.set.call_count == 1
-#    psu_tbl.set.assert_called_with(syseepromd.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
-#
-#    psu_tbl.set.reset_mock()
-#
-#    syseepromd._wrapper_get_psu_presence.return_value = True
-#    syseepromd._wrapper_get_psu_status.return_value = True
-#    expected_fvp = syseepromd.swsscommon.FieldValuePairs(
-#        [(syseepromd.PSU_INFO_PRESENCE_FIELD, 'true'),
-#         (syseepromd.PSU_INFO_STATUS_FIELD, 'true'),
-#         ])
-#    syseepromd.psu_db_update(psu_tbl, 32)
-#    assert psu_tbl.set.call_count == 32
-#    psu_tbl.set.assert_called_with(syseepromd.PSU_INFO_KEY_TEMPLATE.format(32), expected_fvp)
-#
-#
-#def test_log_on_status_changed():
-#    normal_log = "Normal log message"
-#    abnormal_log = "Abnormal log message"
-#
-#    mock_logger = mock.MagicMock()
-#
-#    syseepromd.log_on_status_changed(mock_logger, True, normal_log, abnormal_log)
-#    assert mock_logger.log_notice.call_count == 1
-#    assert mock_logger.log_warning.call_count == 0
-#    mock_logger.log_notice.assert_called_with(normal_log)
-#
-#    mock_logger.log_notice.reset_mock()
-#
-#    syseepromd.log_on_status_changed(mock_logger, False, normal_log, abnormal_log)
-#    assert mock_logger.log_notice.call_count == 0
-#    assert mock_logger.log_warning.call_count == 1
-#    mock_logger.log_warning.assert_called_with(abnormal_log)
+@mock.patch('syseepromd.EEPROM_INFO_UPDATE_PERIOD_SECS', 1)
+def test_run():
+    daemon_syseepromd = syseepromd.DaemonSyseeprom()
+    daemon_syseepromd.clear_db = mock.MagicMock()
+    daemon_syseepromd.log_info = mock.MagicMock()
+    daemon_syseepromd.log_error = mock.MagicMock()
+    daemon_syseepromd.post_eeprom_to_db = mock.MagicMock(return_value=syseepromd.ERR_NONE)
+
+    # Test no change to EEPROM data
+    daemon_syseepromd.detect_eeprom_table_integrity = mock.MagicMock(return_value=True)
+
+    ret = daemon_syseepromd.run()
+    assert ret == True
+    assert daemon_syseepromd.detect_eeprom_table_integrity.call_count == 1
+    assert daemon_syseepromd.log_info.call_count == 0
+    assert daemon_syseepromd.log_error.call_count == 0
+    assert daemon_syseepromd.clear_db.call_count == 0
+    assert daemon_syseepromd.post_eeprom_to_db.call_count == 0
+
+    # Reset mocks
+    daemon_syseepromd.detect_eeprom_table_integrity.reset_mock()
+
+    # Test EEPROM data has changed, update succeeds
+    daemon_syseepromd.detect_eeprom_table_integrity = mock.MagicMock(return_value=False)
+
+    ret = daemon_syseepromd.run()
+    assert ret == True
+    assert daemon_syseepromd.detect_eeprom_table_integrity.call_count == 1
+    assert daemon_syseepromd.log_info.call_count == 1
+    daemon_syseepromd.log_info.assert_called_with('System EEPROM table was changed, needs update')
+    assert daemon_syseepromd.clear_db.call_count == 1
+    assert daemon_syseepromd.post_eeprom_to_db.call_count == 1
+    assert daemon_syseepromd.log_error.call_count == 0
+
+    # Reset mocks
+    daemon_syseepromd.detect_eeprom_table_integrity.reset_mock()
+    daemon_syseepromd.log_info.reset_mock()
+    daemon_syseepromd.clear_db.reset_mock()
+    daemon_syseepromd.post_eeprom_to_db.reset_mock()
+
+    # Test EEPROM data has changed, update fails
+    daemon_syseepromd.detect_eeprom_table_integrity = mock.MagicMock(return_value=False)
+    daemon_syseepromd.post_eeprom_to_db = mock.MagicMock(return_value=syseepromd.ERR_FAILED_UPDATE_DB)
+
+    ret = daemon_syseepromd.run()
+    assert ret == True
+    assert daemon_syseepromd.detect_eeprom_table_integrity.call_count == 1
+    assert daemon_syseepromd.log_info.call_count == 1
+    daemon_syseepromd.log_info.assert_called_with('System EEPROM table was changed, needs update')
+    assert daemon_syseepromd.clear_db.call_count == 1
+    assert daemon_syseepromd.post_eeprom_to_db.call_count == 1
+    assert daemon_syseepromd.log_error.call_count == 1
+    daemon_syseepromd.log_error.assert_called_with('Failed to post EEPROM to database')
 
 
 @mock.patch('syseepromd.DaemonSyseeprom.run')

--- a/sonic-syseepromd/tests/test_syseepromd.py
+++ b/sonic-syseepromd/tests/test_syseepromd.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from imp import load_source
+from imp import load_source  # Replace with importlib once we no longer need to support Python 2
 
 import pytest
 


### PR DESCRIPTION
#### Description

- Refactor syseepromd to eliminate infinite loops to allow for increased unit test coverage
- Refactor signal handler and ensure daemon always exits with non-zero exit code so that supervisor will restart it
- Add unit tests

Unit test coverage increases from 0% to 90%:
```
----------- coverage: platform linux, python 3.7.3-final-0 -----------
Name                 Stmts   Miss  Cover
----------------------------------------
scripts/syseepromd      97     10    90%
```

#### Motivation and Context

To increase unit test coverage >= 90% in order to prevent regressions

#### How Has This Been Tested?

The refactored psud has been tested on a physical DUT and the unit test results can be examined via the Azure Pipelines check builds in this PR.