### PR TITLE
[xcvrd] Fix crash on platforms which support media settings with Python 3

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -679,7 +679,7 @@ def get_media_val_str(num_logical_ports, lane_dict, logical_idx):
     media_val_str = ''
     if (num_logical_ports > 1) and \
        (num_lanes_on_port >= num_logical_ports):
-        num_lanes_per_logical_port = num_lanes_on_port/num_logical_ports
+        num_lanes_per_logical_port = int(num_lanes_on_port/num_logical_ports)
         start_lane = logical_idx * num_lanes_per_logical_port
 
         for lane_idx in range(start_lane, start_lane +

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -679,7 +679,7 @@ def get_media_val_str(num_logical_ports, lane_dict, logical_idx):
     media_val_str = ''
     if (num_logical_ports > 1) and \
        (num_lanes_on_port >= num_logical_ports):
-        num_lanes_per_logical_port = int(num_lanes_on_port/num_logical_ports)
+        num_lanes_per_logical_port = num_lanes_on_port//num_logical_ports
         start_lane = logical_idx * num_lanes_per_logical_port
 
         for lane_idx in range(start_lane, start_lane +


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description

- xcvrd crashes in media settings supported platforms due to py3 compatibility issue in xcvrd media settings .

```
Mar  2 04:50:36.960634 sonic INFO pmon#/supervisord: xcvrd Traceback (most recent call last):
Mar  2 04:50:36.960704 sonic INFO pmon#/supervisord: xcvrd   File "/usr/local/bin/xcvrd", line 8, in <module>
Mar  2 04:50:36.960744 sonic INFO pmon#/supervisord: xcvrd     sys.exit(main())
Mar  2 04:50:36.960785 sonic INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 1381, in main
Mar  2 04:50:36.960823 sonic INFO pmon#/supervisord: xcvrd     xcvrd.run()
Mar  2 04:50:36.960862 sonic INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 1329, in run
Mar  2 04:50:36.960900 sonic INFO pmon#/supervisord: xcvrd     self.init()
Mar  2 04:50:36.960936 sonic INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 1294, in init
Mar  2 04:50:36.960973 sonic INFO pmon#/supervisord: xcvrd     post_port_sfp_dom_info_to_db(is_warm_start, self.stop_event)
Mar  2 04:50:36.961015 sonic INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 492, in post_port_sfp_dom_info_to_db
Mar  2 04:50:36.961054 sonic-10429 INFO pmon#/supervisord: xcvrd     notify_media_setting(logical_port_name, transceiver_dict, app_port_tbl[asic_index])
Mar  2 04:50:36.961090 sonic INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 743, in notify_media_setting
Mar  2 04:50:36.961127 sonic INFO pmon#/supervisord: xcvrd     logical_idx)
Mar  2 04:50:36.961165 sonic INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 687, in get_media_val_str
```
#### Motivation and Context

- To fix xcvrd crash in media settings supported platforms.

#### How Has This Been Tested?

- Check whether xcvrd daemon stays up after the change.
- py3 returns float when division is used while python2 returns integer.

#### Additional Information (Optional)
UT:
[fix_xcvrd_crash.txt](https://github.com/Azure/sonic-platform-daemons/files/6068182/fix_xcvrd_crash.txt)
