### PR TITLE
fix the muxcable state change notification received from other modules, omit the check inside hw_state table

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -1108,7 +1108,7 @@ class YCableTableUpdateTask(object):
                     # Now whatever is the state requested, toggle the mux appropriately
                     active_side = update_tor_active_side(read_side, new_status, port)
                     if active_side == -1:
-                        helper_logger.log_warning("ERR: Got a change event for toggle but could not toggle the mux-direction for port  {} state from {} to {}, writing unknown".format(
+                        helper_logger.log_warning("ERR: Got a change event for toggle but could not toggle the mux-direction for port {} state from {} to {}, writing unknown".format(
                             port, old_status, new_status))
                         new_status = 'unknown'
 
@@ -1117,7 +1117,7 @@ class YCableTableUpdateTask(object):
                                                                read_side),
                                                               ('active_side', str(active_side))])
                     y_cable_tbl[asic_index].set(port, fvs_updated)
-                    helper_logger.log_info("Got a change event for toggle the mux-direction active side for port  {} state from {} to {}".format(
+                    helper_logger.log_info("Got a change event for toggle the mux-direction active side for port {} state from {} to {}".format(
                         port, old_status, new_status))
                 else:
                     helper_logger.log_info("Got a change event on port {} of table {} that does not contain state".format(

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -1107,29 +1107,22 @@ class YCableTableUpdateTask(object):
                     read_side = mux_port_dict.get("read_side")
                     prev_active_side = mux_port_dict.get("active_side")
                     # Now if the old_status does not match new_status toggle the mux appropriately
-                    if old_status != new_status:
-                        active_side = update_tor_active_side(
-                            read_side, new_status, port)
-                        if active_side == -1:
-                            new_status = 'unknown'
+                    active_side = update_tor_active_side(
+                        read_side, new_status, port)
+                    if active_side == -1:
+                        helper_logger.log_warning("ERR: Got a change event for toggle but could not toggle the mux-direction for port  {} state from {} to {}, writing unknown".format(
+                            port, old_status, new_status))
+                        new_status = 'unknown'
 
-                        fvs_updated = swsscommon.FieldValuePairs([('state', new_status),
-                                                                  ('read_side',
-                                                                   read_side),
-                                                                  ('active_side', str(active_side))])
-                        y_cable_tbl[asic_index].set(port, fvs_updated)
-                    else:
-                        # nothing to do since no status change
-                        active_side = prev_active_side
-                        fvs_updated = swsscommon.FieldValuePairs([('state', new_status),
-                                                                  ('read_side',
-                                                                   read_side),
-                                                                  ('active_side', str(active_side))])
-                        y_cable_tbl[asic_index].set(port, fvs_updated)
-                        helper_logger.log_warning("Got a change event on that does not toggle the TOR active side for port  {} status {} active linked side = {} ".format(
-                            port, old_status, prev_active_side))
+                    fvs_updated = swsscommon.FieldValuePairs([('state', new_status),
+                                                              ('read_side',
+                                                               read_side),
+                                                              ('active_side', str(active_side))])
+                    y_cable_tbl[asic_index].set(port, fvs_updated)
+                    helper_logger.log_info("Got a change event for toggle the mux-direction active side for port  {} state from {} to {}".format(
+                        port, old_status, new_status))
                 else:
-                    helper_logger.log_info("Got a change event on port {} of table {} that does not contain status ".format(
+                    helper_logger.log_info("Got a change event on port {} of table {} that does not contain state".format(
                         port, swsscommon.APP_HW_MUX_CABLE_TABLE_NAME))
 
             (port_m, op_m, fvp_m) = mux_cable_command_tbl[asic_index].pop()

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -1106,8 +1106,7 @@ class YCableTableUpdateTask(object):
                     old_status = mux_port_dict.get("state")
                     read_side = mux_port_dict.get("read_side")
                     # Now whatever is the state requested, toggle the mux appropriately
-                    active_side = update_tor_active_side(
-                        read_side, new_status, port)
+                    active_side = update_tor_active_side(read_side, new_status, port)
                     if active_side == -1:
                         helper_logger.log_warning("ERR: Got a change event for toggle but could not toggle the mux-direction for port  {} state from {} to {}, writing unknown".format(
                             port, old_status, new_status))

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -1105,8 +1105,7 @@ class YCableTableUpdateTask(object):
                     mux_port_dict = dict(fvs)
                     old_status = mux_port_dict.get("state")
                     read_side = mux_port_dict.get("read_side")
-                    prev_active_side = mux_port_dict.get("active_side")
-                    # Now if the old_status does not match new_status toggle the mux appropriately
+                    # Now whatever is the state requested, toggle the mux appropriately
                     active_side = update_tor_active_side(
                         read_side, new_status, port)
                     if active_side == -1:


### PR DESCRIPTION
This change essentially omits a look inside the state DB for HW_MUX_CABLE_TABLE and just directly goes to the muxcable
eeprom to either toggle or remain Iin the same state as is requested from the incoming message from orchagent, and then write back to the DB

<!-- Provide a general summary of your changes in the Title above -->

#### Description
This fix will help in debugging the initialization loop since now other modules will not be dependent on stale state present in
HW_MUX_CABLE_TABLE. 
<!--
     Describe your changes in detail
-->

#### How Has This Been Tested?
Tested on starlab testbed with integration of other modules. 
Change works well
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>