### PR TITLE
[syseepromd] Update warning message to be more informative

### DIFF
--- a/sonic-syseepromd/scripts/syseepromd
+++ b/sonic-syseepromd/scripts/syseepromd
@@ -121,8 +121,7 @@ class DaemonSyseeprom(daemon_base.DaemonBase):
             self.chassis = sonic_platform.platform.Platform().get_chassis()
             self.eeprom = self.chassis.get_eeprom()
         except Exception as e:
-            self.log_warning(
-                "Failed to load platform-specific eeprom from sonic_platform package due to {}".format(repr(e)))
+            self.log_warning("Failed to load data from eeprom using sonic_platform package due to {}, retrying using deprecated plugin method".format(repr(e)))
 
         # If we didn't successfully load the class from the sonic_platform package, try loading the old plugin
         if not self.eeprom:


### PR DESCRIPTION
[syseepromd] Update warning message in syseepromd to be more informative

Signed-off-by: liora <liora@nvidia.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Daemon syseepromd is loading data from eeprom.
When syseepromd fails to load data from eeprom using the new platform API, it tries again using the old plugins way.
In the case where the first method failed, warning message was not informative and confusing, I fixed it.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Update warning message to be more informative.
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
I ran syseepromd manually and verifed that warning is printed as expected.

#### Which release branch to backport
- [ ] 201811
- [x] 201911
- [ ] 202006
- [x] 202012
