### PR TITLE
[xcvrd] Fix crash: If 'dom_capability' not in port_info_dict, insert 'N/A'

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -299,7 +299,8 @@ def post_port_sfp_info_to_db(logical_port_name, table, transceiver_dict,
                      ('application_advertisement', port_info_dict['application_advertisement']
                       if 'application_advertisement' in port_info_dict else 'N/A'),
                      ('is_replaceable', str(is_replaceable)),
-                     ('dom_capability',port_info_dict['dom_capability']),
+                     ('dom_capability', port_info_dict['dom_capability']
+                      if 'dom_capability' in port_info_dict else 'N/A'),
                      ])
                 table.set(port_name, fvs)
             else:


### PR DESCRIPTION
#### Description

If 'dom_capability' not in port_info_dict, insert 'N/A'

#### Motivation and Context

Currently, some vendors are using custom transceiver info parsers which do not yet provide the `dom_capability` field in the results of `get_transceiver_info()`. However, PR https://github.com/Azure/sonic-platform-daemons/pull/72 introduced storing this value to State DB under the assumption that it would always be present. On platforms where this value is not present, it would cause xcvrd to crash (see issue: https://github.com/Azure/sonic-buildimage/issues/6978).

This change will prevent a crash if it is not present, and will in turn save `'N/A'` as the `dom_capability` value in State DB.

#### How Has This Been Tested?
Tested on one affected platform.

#### Additional Information (Optional)
