### PR TITLE
Revert "[xcvrd] Change in xcvrd ports cache creation, now ports are being fetched from config DB"

### DIFF
--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -1193,8 +1193,9 @@ class DaemonXcvrd(daemon_base.DaemonBase):
                 (platform_path, hwsku_path) = device_info.get_paths_to_platform_and_hwsku_dirs()
                 platform_sfputil.read_all_porttab_mappings(hwsku_path, self.num_asics)
             else:
-                # For single ASIC platforms we pass asic_inst 0
-                platform_sfputil.read_porttab_mappings(None, asic_inst=0, get_ports_from_db=True)
+                # For single ASIC platforms we pass port_config_file_path and the asic_inst as 0
+                port_config_file_path = device_info.get_path_to_port_config_file()
+                platform_sfputil.read_porttab_mappings(port_config_file_path, 0)
         except Exception, e:
             self.log_error("Failed to read port info: %s" % (str(e)), True)
             sys.exit(PORT_CONFIG_LOAD_ERROR)


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
This reverts commit 61acd3a2e4a457f3bc706cbfaf3162b947763864  which introdunce by PR https://github.com/Azure/sonic-platform-daemons/pull/155




#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
the above commit change the way of xcvrd reading info from port_config.ini to fetch from DB by extending read_porttab_mappings in sfputilhelper. However there is still some issue in the new change which could cause xvrd crash due to get a wrong port number. 

We believe read from DB is the correct way to go, however, before we fix the bug we need to revert this change temporarily.

```
Mar  3 13:10:24.156122 l-csi-4700-05 INFO pmon#supervisord: xcvrd SFP index 71 out of range (0-31)
Mar  3 13:10:24.156343 l-csi-4700-05 INFO pmon#supervisord: xcvrd Traceback (most recent call last):
Mar  3 13:10:24.156343 l-csi-4700-05 INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1296, in <module>
Mar  3 13:10:24.156512 l-csi-4700-05 INFO pmon#supervisord: xcvrd     main()
Mar  3 13:10:24.156512 l-csi-4700-05 INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1293, in main
Mar  3 13:10:24.156697 l-csi-4700-05 INFO pmon#supervisord: xcvrd     xcvrd.run()
Mar  3 13:10:24.156697 l-csi-4700-05 INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1254, in run
Mar  3 13:10:24.156878 l-csi-4700-05 INFO pmon#supervisord: xcvrd     self.init()
Mar  3 13:10:24.156878 l-csi-4700-05 INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1227, in init
Mar  3 13:10:24.157096 l-csi-4700-05 INFO pmon#supervisord: xcvrd     post_port_sfp_dom_info_to_db(is_warm_start, self.stop_event)
Mar  3 13:10:24.157096 l-csi-4700-05 INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 451, in post_port_sfp_dom_info_to_db
Mar  3 13:10:24.157262 l-csi-4700-05 INFO pmon#supervisord: xcvrd     post_port_sfp_info_to_db(logical_port_name, int_tbl[asic_index], transceiver_dict, stop_event)
Mar  3 13:10:24.157262 l-csi-4700-05 INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 248, in post_port_sfp_info_to_db
Mar  3 13:10:24.157262 l-csi-4700-05 INFO pmon#supervisord: xcvrd     if not _wrapper_get_presence(physical_port):
Mar  3 13:10:24.157285 l-csi-4700-05 INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 140, in _wrapper_get_presence
Mar  3 13:10:24.157297 l-csi-4700-05 INFO pmon#supervisord: xcvrd     return platform_chassis.get_sfp(physical_port).get_presence()
Mar  3 13:10:24.157297 l-csi-4700-05 INFO pmon#supervisord: xcvrd AttributeError: 'NoneType' object has no attribute 'get_presence'
Mar  3 13:10:24.230294 l-csi-4700-05 INFO pmon#supervisord 2021-03-03 13:10:24,229 INFO exited: xcvrd (exit status 1; not expected)
Mar  3 13:10:25.234926 l-csi-4700-05 INFO pmon#supervisor-proc-exit-listener: Process xcvrd exited unxepectedly. Terminating supervisor...
```


#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Tested on Mellanox platform and xcvrd work correctly as before.

#### Additional Information (Optional)
