### PR TITLE
[muxcable] Remove Xcvrd Sleep

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -4,7 +4,6 @@
 """
 
 import threading
-import time
 
 from sonic_py_common import daemon_base, logger
 from sonic_py_common import multi_asic

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -1032,11 +1032,6 @@ class YCableTableUpdateTask(object):
             # Use timeout to prevent ignoring the signals we want to handle
             # in signal_handler() (e.g. SIGTERM for graceful shutdown)
 
-            # A brief sleep appears necessary in this loop or any spawned
-            # update threads will get stuck. Appears to be due to the sel.select() call.
-            # TODO: Eliminate the need for this sleep.
-            time.sleep(0.1)
-
             (state, selectableObj) = sel.select(SELECT_TIMEOUT)
 
             if state == swsscommon.Select.TIMEOUT:


### PR DESCRIPTION
#### Description

When using redis select, xcvrd is sleeping for 100msec which appears
unnecessary after process all content of selectable objects.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

#### Motivation and Context
Reduce overall time it takes to switch multiple/all ports

#### How Has This Been Tested?
Test on test cluster where 24 ports were switched and saw 100msec to 200msec gain in switching time of all ports. Individual port switch time is still within 20msec~30msec.

#### Additional Information (Optional)
