### PR TITLE
[xcvrd] Change the y_cable presence logic to use "mux_cable" table as identifier from Config DB

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -283,35 +283,37 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
         # Convert list of tuples to a dictionary
         mux_table_dict = dict(fvs)
         if "state" in mux_table_dict:
+            val = mux_table_dict.get("state", None)
+            if val in ["active", "auto"]:
 
-            y_cable_asic_table = y_cable_tbl.get(asic_index, None)
-            mux_asic_table = mux_tbl.get(asic_index, None)
-            static_mux_asic_table = static_tbl.get(asic_index, None)
-            if y_cable_presence[0] is True and y_cable_asic_table is not None and mux_asic_table is not None and static_mux_asic_table is not None:
-                # fill in the newly found entry
-                read_y_cable_and_update_statedb_port_tbl(
-                    logical_port_name, y_cable_tbl[asic_index])
-                post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
-                post_port_mux_static_info_to_db(logical_port_name,  static_tbl[asic_index])
+                y_cable_asic_table = y_cable_tbl.get(asic_index, None)
+                mux_asic_table = mux_tbl.get(asic_index, None)
+                static_mux_asic_table = static_tbl.get(asic_index, None)
+                if y_cable_presence[0] is True and y_cable_asic_table is not None and mux_asic_table is not None and static_mux_asic_table is not None:
+                    # fill in the newly found entry
+                    read_y_cable_and_update_statedb_port_tbl(
+                        logical_port_name, y_cable_tbl[asic_index])
+                    post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
+                    post_port_mux_static_info_to_db(logical_port_name,  static_tbl[asic_index])
 
-            else:
-                # first create the state db y cable table and then fill in the entry
-                y_cable_presence[:] = [True]
-                namespaces = multi_asic.get_front_end_namespaces()
-                for namespace in namespaces:
-                    asic_id = multi_asic.get_asic_index_from_namespace(
-                        namespace)
-                    state_db[asic_id] = daemon_base.db_connect(
-                        "STATE_DB", namespace)
-                    y_cable_tbl[asic_id] = swsscommon.Table(
-                        state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
-                    static_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
-                    mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_INFO_TABLE)
-                # fill the newly found entry
-                read_y_cable_and_update_statedb_port_tbl(
-                    logical_port_name, y_cable_tbl[asic_index])
-                post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
-                post_port_mux_static_info_to_db(logical_port_name,  static_tbl[asic_index])
+                else:
+                    # first create the state db y cable table and then fill in the entry
+                    y_cable_presence[:] = [True]
+                    namespaces = multi_asic.get_front_end_namespaces()
+                    for namespace in namespaces:
+                        asic_id = multi_asic.get_asic_index_from_namespace(
+                            namespace)
+                        state_db[asic_id] = daemon_base.db_connect(
+                            "STATE_DB", namespace)
+                        y_cable_tbl[asic_id] = swsscommon.Table(
+                            state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+                        static_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
+                        mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_INFO_TABLE)
+                    # fill the newly found entry
+                    read_y_cable_and_update_statedb_port_tbl(
+                        logical_port_name, y_cable_tbl[asic_index])
+                    post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
+                    post_port_mux_static_info_to_db(logical_port_name,  static_tbl[asic_index])
 
 
 def check_identifier_presence_and_delete_mux_table_entry(state_db, port_tbl, asic_index, logical_port_name, y_cable_presence, delete_change_event):
@@ -517,20 +519,22 @@ def check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_
         # Convert list of tuples to a dictionary
         mux_table_dict = dict(fvs)
         if "state" in mux_table_dict:
+            val = mux_table_dict.get("state", None)
+            if val in ["active", "auto"]:
 
-            if mux_tbl.get(asic_index, None) is not None:
-                # fill in the newly found entry
-                post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
+                if mux_tbl.get(asic_index, None) is not None:
+                    # fill in the newly found entry
+                    post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
 
-            else:
-                # first create the state db y cable table and then fill in the entry
-                namespaces = multi_asic.get_front_end_namespaces()
-                for namespace in namespaces:
-                    asic_id = multi_asic.get_asic_index_from_namespace(
-                        namespace)
-                    mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_INFO_TABLE)
-                # fill the newly found entry
-                post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
+                else:
+                    # first create the state db y cable table and then fill in the entry
+                    namespaces = multi_asic.get_front_end_namespaces()
+                    for namespace in namespaces:
+                        asic_id = multi_asic.get_asic_index_from_namespace(
+                            namespace)
+                        mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_INFO_TABLE)
+                    # fill the newly found entry
+                    post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
 
 
 def get_firmware_dict(physical_port, target, side, mux_info_dict):

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -314,6 +314,9 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
                         logical_port_name, y_cable_tbl[asic_index])
                     post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
                     post_port_mux_static_info_to_db(logical_port_name,  static_tbl[asic_index])
+            else:
+                helper_logger.log_warning(
+                    "Could not retreive active or auto value for state kvp for {}, inside MUX_CABLE table".format(logical_port_name))
 
 
 def check_identifier_presence_and_delete_mux_table_entry(state_db, port_tbl, asic_index, logical_port_name, y_cable_presence, delete_change_event):
@@ -535,6 +538,9 @@ def check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_
                         mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_INFO_TABLE)
                     # fill the newly found entry
                     post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
+            else:
+                helper_logger.log_warning(
+                    "Could not retreive active or auto value for state kvp for {}, inside MUX_CABLE table".format(logical_port_name))
 
 
 def get_firmware_dict(physical_port, target, side, mux_info_dict):

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -283,37 +283,35 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
         # Convert list of tuples to a dictionary
         mux_table_dict = dict(fvs)
         if "state" in mux_table_dict:
-            val = mux_table_dict.get("state", None)
-            if val == "active" or val == "auto":
 
-                y_cable_asic_table = y_cable_tbl.get(asic_index, None)
-                mux_asic_table = mux_tbl.get(asic_index, None)
-                static_mux_asic_table = static_tbl.get(asic_index, None)
-                if y_cable_presence[0] is True and y_cable_asic_table is not None and mux_asic_table is not None and static_mux_asic_table is not None:
-                    # fill in the newly found entry
-                    read_y_cable_and_update_statedb_port_tbl(
-                        logical_port_name, y_cable_tbl[asic_index])
-                    post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
-                    post_port_mux_static_info_to_db(logical_port_name,  static_tbl[asic_index])
+            y_cable_asic_table = y_cable_tbl.get(asic_index, None)
+            mux_asic_table = mux_tbl.get(asic_index, None)
+            static_mux_asic_table = static_tbl.get(asic_index, None)
+            if y_cable_presence[0] is True and y_cable_asic_table is not None and mux_asic_table is not None and static_mux_asic_table is not None:
+                # fill in the newly found entry
+                read_y_cable_and_update_statedb_port_tbl(
+                    logical_port_name, y_cable_tbl[asic_index])
+                post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
+                post_port_mux_static_info_to_db(logical_port_name,  static_tbl[asic_index])
 
-                else:
-                    # first create the state db y cable table and then fill in the entry
-                    y_cable_presence[:] = [True]
-                    namespaces = multi_asic.get_front_end_namespaces()
-                    for namespace in namespaces:
-                        asic_id = multi_asic.get_asic_index_from_namespace(
-                            namespace)
-                        state_db[asic_id] = daemon_base.db_connect(
-                            "STATE_DB", namespace)
-                        y_cable_tbl[asic_id] = swsscommon.Table(
-                            state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
-                        static_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
-                        mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_INFO_TABLE)
-                    # fill the newly found entry
-                    read_y_cable_and_update_statedb_port_tbl(
-                        logical_port_name, y_cable_tbl[asic_index])
-                    post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
-                    post_port_mux_static_info_to_db(logical_port_name,  static_tbl[asic_index])
+            else:
+                # first create the state db y cable table and then fill in the entry
+                y_cable_presence[:] = [True]
+                namespaces = multi_asic.get_front_end_namespaces()
+                for namespace in namespaces:
+                    asic_id = multi_asic.get_asic_index_from_namespace(
+                        namespace)
+                    state_db[asic_id] = daemon_base.db_connect(
+                        "STATE_DB", namespace)
+                    y_cable_tbl[asic_id] = swsscommon.Table(
+                        state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+                    static_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_STATIC_INFO_TABLE)
+                    mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_INFO_TABLE)
+                # fill the newly found entry
+                read_y_cable_and_update_statedb_port_tbl(
+                    logical_port_name, y_cable_tbl[asic_index])
+                post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
+                post_port_mux_static_info_to_db(logical_port_name,  static_tbl[asic_index])
 
 
 def check_identifier_presence_and_delete_mux_table_entry(state_db, port_tbl, asic_index, logical_port_name, y_cable_presence, delete_change_event):
@@ -519,22 +517,20 @@ def check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_
         # Convert list of tuples to a dictionary
         mux_table_dict = dict(fvs)
         if "state" in mux_table_dict:
-            val = mux_table_dict.get("state", None)
-            if val == "active" or val == "auto":
 
-                if mux_tbl.get(asic_index, None) is not None:
-                    # fill in the newly found entry
-                    post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
+            if mux_tbl.get(asic_index, None) is not None:
+                # fill in the newly found entry
+                post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
 
-                else:
-                    # first create the state db y cable table and then fill in the entry
-                    namespaces = multi_asic.get_front_end_namespaces()
-                    for namespace in namespaces:
-                        asic_id = multi_asic.get_asic_index_from_namespace(
-                            namespace)
-                        mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_INFO_TABLE)
-                    # fill the newly found entry
-                    post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
+            else:
+                # first create the state db y cable table and then fill in the entry
+                namespaces = multi_asic.get_front_end_namespaces()
+                for namespace in namespaces:
+                    asic_id = multi_asic.get_asic_index_from_namespace(
+                        namespace)
+                    mux_tbl[asic_id] = swsscommon.Table(state_db[asic_id], MUX_CABLE_INFO_TABLE)
+                # fill the newly found entry
+                post_port_mux_info_to_db(logical_port_name,  mux_tbl[asic_index])
 
 
 def get_firmware_dict(physical_port, target, side, mux_info_dict):

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -282,9 +282,9 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
     else:
         # Convert list of tuples to a dictionary
         mux_table_dict = dict(fvs)
-        if "mux_cable" in mux_table_dict:
-            val = mux_table_dict.get("mux_cable", None)
-            if val == "true":
+        if "state" in mux_table_dict:
+            val = mux_table_dict.get("state", None)
+            if val == "active" or val == "auto":
 
                 y_cable_asic_table = y_cable_tbl.get(asic_index, None)
                 mux_asic_table = mux_tbl.get(asic_index, None)
@@ -373,7 +373,7 @@ def init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presen
     for namespace in namespaces:
         asic_id = multi_asic.get_asic_index_from_namespace(namespace)
         config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
-        port_tbl[asic_id] = swsscommon.Table(config_db[asic_id], "PORT")
+        port_tbl[asic_id] = swsscommon.Table(config_db[asic_id], "MUX_CABLE")
         port_table_keys[asic_id] = port_tbl[asic_id].getKeys()
 
     # Init PORT_STATUS table if ports are on Y cable
@@ -414,7 +414,7 @@ def change_ports_status_for_y_cable_change_event(port_dict, y_cable_presence, st
     for namespace in namespaces:
         asic_id = multi_asic.get_asic_index_from_namespace(namespace)
         config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
-        port_tbl[asic_id] = swsscommon.Table(config_db[asic_id], "PORT")
+        port_tbl[asic_id] = swsscommon.Table(config_db[asic_id], "MUX_CABLE")
         port_table_keys[asic_id] = port_tbl[asic_id].getKeys()
 
     # Init PORT_STATUS table if ports are on Y cable and an event is received
@@ -518,9 +518,9 @@ def check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_
     else:
         # Convert list of tuples to a dictionary
         mux_table_dict = dict(fvs)
-        if "mux_cable" in mux_table_dict:
-            val = mux_table_dict.get("mux_cable", None)
-            if val == "true":
+        if "state" in mux_table_dict:
+            val = mux_table_dict.get("state", None)
+            if val == "active" or val == "auto":
 
                 if mux_tbl.get(asic_index, None) is not None:
                     # fill in the newly found entry


### PR DESCRIPTION



Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

This PR changes the logic to use "mux_cable" table as identifier, and only those ports which have this table inside config DB and key pair of "state:auto/active" will be processed as having a Y-Cable port.
The earlier logic was using the PORT table tag with a mux_cable:true key-value pair. 

#### Description
change the logic to initiate Y-Cable logic
<!--
     Describe your changes in detail
-->

#### Motivation and Context
Required for changing the logic, so that this can be integrated with images which don't support "mux_cable" tag inside config DB
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Ran the change on Arista 7050cx3 platform by restarting the container
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
