### PR TITLE
[xcvrd] Enhance Media Settings

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -311,7 +311,7 @@ class TestXcvrdScript(object):
 
         # Test a good 'specification_compliance' value
         result = get_media_settings_key(0, xcvr_info_dict)
-        assert result == ['MOLEX-1064141421', 'QSFP+-10GBase-SR-255M']
+        assert result == ['MOLEX-1064141421', 'QSFP+-*']
 
         # Test a bad 'specification_compliance' value
         xcvr_info_dict[0]['specification_compliance'] = 'N/A'

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -311,10 +311,10 @@ class TestXcvrdScript(object):
 
         # Test a good 'specification_compliance' value
         result = get_media_settings_key(0, xcvr_info_dict)
-        assert result == ['MOLEX-1064141421', 'QSFP+-*']
+        assert result == ['MOLEX-1064141421', 'QSFP+-10GBase-SR-255M']
 
         # Test a bad 'specification_compliance' value
         xcvr_info_dict[0]['specification_compliance'] = 'N/A'
         result = get_media_settings_key(0, xcvr_info_dict)
-        assert result == ['MOLEX-1064141421', 'QSFP+']
+        assert result == ['MOLEX-1064141421', 'QSFP+-*']
         # TODO: Ensure that error message was logged

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -659,8 +659,13 @@ def get_media_settings_key(physical_port, transceiver_dict):
         media_key += media_type
     if len(media_compliance_code) != 0:
         media_key += '-' + media_compliance_code
-        if len(media_len) != 0:
-            media_key += '-' + media_len + 'M'
+        if _wrapper_get_sfp_type(physical_port) == 'QSFP_DD':
+            if media_compliance_code == "passive_copper_media_interface":
+                if len(media_len) != 0:
+                    media_key += '-' + media_len + 'M'
+        else:
+            if len(media_len) != 0:
+                media_key += '-' + media_len + 'M'
     else:
         media_key += - + '*'
 
@@ -745,7 +750,7 @@ def notify_media_setting(logical_port_name, transceiver_dict,
         media_dict = get_media_settings_value(physical_port, key)
 
         if(len(media_dict) == 0):
-            helper_logger.log_error("Error in obtaining media setting")
+            helper_logger.log_error("Error in obtaining media setting for",logical_port_name)
             return
 
         fvs = swsscommon.FieldValuePairs(len(media_dict))

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -667,7 +667,7 @@ def get_media_settings_key(physical_port, transceiver_dict):
             if len(media_len) != 0:
                 media_key += '-' + media_len + 'M'
     else:
-        media_key += - + '*'
+        media_key += '-' + '*'
 
     return [vendor_key, media_key]
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -749,8 +749,8 @@ def notify_media_setting(logical_port_name, transceiver_dict,
         key = get_media_settings_key(physical_port, transceiver_dict)
         media_dict = get_media_settings_value(physical_port, key)
 
-        if(len(media_dict) == 0):
-            helper_logger.log_error("Error in obtaining media setting for", logical_port_name)
+        if len(media_dict) == 0:
+            helper_logger.log_error("Error in obtaining media setting for {}".format(logical_port_name))
             return
 
         fvs = swsscommon.FieldValuePairs(len(media_dict))

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -638,22 +638,22 @@ def get_media_settings_key(physical_port, transceiver_dict):
         media_len = transceiver_dict[physical_port]['cable_length']
 
     media_compliance_dict_str = transceiver_dict[physical_port]['specification_compliance']
-
+    media_compliance_code = ''
+    media_type = ''
+    media_key = ''
     media_compliance_dict = {}
+
     try:
-        media_compliance_dict = ast.literal_eval(media_compliance_dict_str)
+        if _wrapper_get_sfp_type(physical_port) == 'QSFP_DD':
+            media_compliance_code = media_compliance_dict_str
+        else:
+            media_compliance_dict = ast.literal_eval(media_compliance_dict_str)
+            if sup_compliance_str in media_compliance_dict:
+                media_compliance_code = media_compliance_dict[sup_compliance_str]
     except ValueError as e:
         helper_logger.log_error("Invalid value for port {} 'specification_compliance': {}".format(physical_port, media_compliance_dict_str))
 
-    media_compliance_code = ''
-    media_type = ''
-
-    if sup_compliance_str in media_compliance_dict:
-        media_compliance_code = media_compliance_dict[sup_compliance_str]
-
     media_type = transceiver_dict[physical_port]['type_abbrv_name']
-
-    media_key = ''
 
     if len(media_type) != 0:
         media_key += media_type
@@ -661,6 +661,8 @@ def get_media_settings_key(physical_port, transceiver_dict):
         media_key += '-' + media_compliance_code
         if len(media_len) != 0:
             media_key += '-' + media_len + 'M'
+    else:
+        media_key += - + '*'
 
     return [vendor_key, media_key]
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -750,7 +750,7 @@ def notify_media_setting(logical_port_name, transceiver_dict,
         media_dict = get_media_settings_value(physical_port, key)
 
         if(len(media_dict) == 0):
-            helper_logger.log_error("Error in obtaining media setting for",logical_port_name)
+            helper_logger.log_error("Error in obtaining media setting for", logical_port_name)
             return
 
         fvs = swsscommon.FieldValuePairs(len(media_dict))


### PR DESCRIPTION
#### Description
1. Currently in sonic, for 400G pre-emphasis settings is not programmed via common methodology. 
We use Vendor Name + PN to program which would consume memory and never ending process as we need to add Vendor name + PN for every optic.
2.  For 100G/40G optics, specification compliance is not displayed. Only for DAC, the specification compliance was displayed.
#### Motivation and Context

1. With this PR, we can program the pre-emphasis settings for both DAC,AOC and optics.
QSFP_DD parser doesn't have specification compliance which was need to program pre-emphasis settings.
The platform API code can be changed to return the type_of_media_interface for 400G media specification compliance, so that the type of media can be determined.
     https://github.com/Azure/sonic-platform-common/blob/a95834b65a9f3b17ab1ce4e1ba5d1a60102e4507/sonic_platform_base/sonic_sfp/sff8024.py#L104
2. To address 100G/40G optic, introduced a new key "QSFP28 - *" / "QSFP+ - *" (type_abbrv_name followed by a hyphen) .
The same key can be defined in vendor specific media_settings.json. 
These changes doesn't modify the existing behavior but additionally addresses the above mentioned issues.
Vendors can still add "Vendor_name + PN" in media_settings.json to program media settings if needed.

#### How Has This Been Tested?

- Stop and start pmon docker with updated media_settings and check the values are displayed in APP_DB.
- Verify the syslogs and make sure that it doesn't throw any error.
UT:
[xcvrd_media_settings_UT.txt](https://github.com/Azure/sonic-platform-daemons/files/6385110/xcvrd_media_settings_UT.txt)

#### Additional Information (Optional)
