### PR TITLE
[xcvrd] add support for logging mux_metrics events into state DB

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -1062,9 +1062,10 @@ class YCableTableUpdateTask(object):
                 (port, op, fvp) = status_tbl[asic_index].pop()
                 if not port:
                     break
+
                 # entering this section signifies a start for xcvrd state
                 # change request from swss so initiate recording in mux_metrics table
-                time_start = datetime.datetime.utcnow().strftime("%Y-%b-%d %H:%M:%S.%f"))
+                time_start = datetime.datetime.utcnow().strftime("%Y-%b-%d %H:%M:%S.%f")
                 if fvp:
                     # This check might be redundant, to check, the presence of this Port in keys
                     # in logical_port_list but keep for now for coherency
@@ -1098,7 +1099,7 @@ class YCableTableUpdateTask(object):
                         y_cable_tbl[asic_index].set(port, fvs_updated)
                         helper_logger.log_info("Got a change event for toggle the mux-direction active side for port {} state from {} to {}".format(
                             port, old_status, new_status))
-                        time_end = datetime.datetime.utcnow().strftime("%Y-%b-%d %H:%M:%S.%f"))
+                        time_end = datetime.datetime.utcnow().strftime("%Y-%b-%d %H:%M:%S.%f")
                         fvs_metrics = swsscommon.FieldValuePairs([('xcvrd_switch_{}_start'.format(new_status), str(time_start)),
                                                                   ('xcvrd_switch_{}_end'.format(new_status), str(time_end))])
                         mux_metrics_tbl[asic_index].set(port, fvs_metrics)

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -3,6 +3,7 @@
     helper utlities configuring y_cable for xcvrd daemon
 """
 
+import datetime
 import threading
 
 from sonic_py_common import daemon_base, logger
@@ -1010,6 +1011,7 @@ class YCableTableUpdateTask(object):
         appl_db, state_db, status_tbl, y_cable_tbl = {}, {}, {}, {}
         y_cable_tbl_keys = {}
         mux_cable_command_tbl, y_cable_command_tbl = {}, {}
+        mux_metrics_tbl = {}
 
         sel = swsscommon.Select()
 
@@ -1028,6 +1030,8 @@ class YCableTableUpdateTask(object):
             state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
             y_cable_tbl[asic_id] = swsscommon.Table(
                 state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+            mux_metrics_tbl[asic_id] = swsscommon.Table(
+                state_db[asic_id], swsscommon.STATE_MUX_METRICS_TABLE_NAME)
             y_cable_tbl_keys[asic_id] = y_cable_tbl[asic_id].getKeys()
             sel.addSelectable(status_tbl[asic_id])
             sel.addSelectable(mux_cable_command_tbl[asic_id])
@@ -1058,6 +1062,9 @@ class YCableTableUpdateTask(object):
                 (port, op, fvp) = status_tbl[asic_index].pop()
                 if not port:
                     break
+                # entering this section signifies a start for xcvrd state
+                # change request from swss so initiate recording in mux_metrics table
+                time_start = datetime.datetime.utcnow().strftime("%Y-%b-%d %H:%M:%S.%f"))
                 if fvp:
                     # This check might be redundant, to check, the presence of this Port in keys
                     # in logical_port_list but keep for now for coherency
@@ -1091,6 +1098,10 @@ class YCableTableUpdateTask(object):
                         y_cable_tbl[asic_index].set(port, fvs_updated)
                         helper_logger.log_info("Got a change event for toggle the mux-direction active side for port {} state from {} to {}".format(
                             port, old_status, new_status))
+                        time_end = datetime.datetime.utcnow().strftime("%Y-%b-%d %H:%M:%S.%f"))
+                        fvs_metrics = swsscommon.FieldValuePairs([('xcvrd_switch_{}_start'.format(new_status), str(time_start)),
+                                                                  ('xcvrd_switch_{}_end'.format(new_status), str(time_end))])
+                        mux_metrics_tbl[asic_index].set(port, fvs_metrics)
                     else:
                         helper_logger.log_info("Got a change event on port {} of table {} that does not contain state".format(
                             port, swsscommon.APP_HW_MUX_CABLE_TABLE_NAME))


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
This PR adds support for logging events for change requests received by xcvrd from swss into state DB. 
a typical log would look like this:
` 1) "xcvrd_switch_standby_start"`
 `2) "2021-05-13 10:01:15.690835"`
 `3) "xcvrd_switch_standby_end"`
 `4) "2021-05-13 10:01:15.696051"`
 
where the key-value pairs signify the type of event requested out of 
`active/standby/unknown` and the timestamp associated with the event. 
<!--
     Describe your changes in detail
-->

#### Motivation and Context
This is required for xcvrd to log the events which it receives in form of requests from swss or any other module into the DB. The timestamp will be useful for debugging the timeline of an event processing from a perspective of other modules as well as xcvrd itself. 

<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?

ran the changes on starlab testbed, by changing the file in the container. 
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
