### PR TITLE
Mocking path early so it will applied to sonic_py_common, mock more swsscommon classes

### DIFF
--- a/sonic-thermalctld/tests/mocked_libs/swsscommon/swsscommon.py
+++ b/sonic-thermalctld/tests/mocked_libs/swsscommon/swsscommon.py
@@ -2,6 +2,8 @@
     Mock implementation of swsscommon package for unit testing
 '''
 
+from swsssdk import ConfigDBConnector, SonicDBConfig, SonicV2Connector
+
 STATE_DB = ''
 
 

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -10,17 +10,23 @@ else:
     import mock
 
 import pytest
-from sonic_py_common import daemon_base
-
-from .mock_platform import MockChassis, MockFan, MockPsu, MockSfp, MockThermal
-
-daemon_base.db_connect = mock.MagicMock()
-
 tests_path = os.path.dirname(os.path.abspath(__file__))
 
 # Add mocked_libs path so that the file under test can load mocked modules from there
 mocked_libs_path = os.path.join(tests_path, 'mocked_libs')
 sys.path.insert(0, mocked_libs_path)
+
+
+import swsscommon
+# Check we are using the mocked package
+assert len(swsscommon.__path__) == 1
+assert(os.path.samefile(swsscommon.__path__[0], os.path.join(mocked_libs_path, 'swsscommon')))
+
+from sonic_py_common import daemon_base
+
+from .mock_platform import MockChassis, MockFan, MockPsu, MockSfp, MockThermal
+
+daemon_base.db_connect = mock.MagicMock()
 
 # Add path to the file under test so that we can load it
 modules_path = os.path.dirname(tests_path)


### PR DESCRIPTION
#### Description
Existing test will mix true swsscommon package with the mocked one in sonic_py_common

#### Motivation and Context
This is blocking https://github.com/Azure/sonic-buildimage/pull/7655

#### How Has This Been Tested?
Unit test

#### Additional Information (Optional)
