### PR TITLE
Mock path early so it will applied to sonic_py_common, mock platform_chassis

### DIFF
--- a/sonic-psud/tests/mocked_libs/swsscommon/swsscommon.py
+++ b/sonic-psud/tests/mocked_libs/swsscommon/swsscommon.py
@@ -2,6 +2,8 @@
     Mock implementation of swsscommon package for unit testing
 '''
 
+from swsssdk import ConfigDBConnector, SonicDBConfig, SonicV2Connector
+
 STATE_DB = ''
 
 

--- a/sonic-psud/tests/test_DaemonPsud.py
+++ b/sonic-psud/tests/test_DaemonPsud.py
@@ -10,20 +10,21 @@ if sys.version_info.major == 3:
     from unittest import mock
 else:
     import mock
-from sonic_py_common import daemon_base
 
 from .mock_platform import MockChassis, MockFan, MockPsu
 
 SYSLOG_IDENTIFIER = 'psud_test'
 NOT_AVAILABLE = 'N/A'
 
-daemon_base.db_connect = mock.MagicMock()
 
 tests_path = os.path.dirname(os.path.abspath(__file__))
 
 # Add mocked_libs path so that the file under test can load mocked modules from there
 mocked_libs_path = os.path.join(tests_path, "mocked_libs")
 sys.path.insert(0, mocked_libs_path)
+
+from sonic_py_common import daemon_base
+daemon_base.db_connect = mock.MagicMock()
 
 # Add path to the file under test so that we can load it
 modules_path = os.path.dirname(tests_path)

--- a/sonic-psud/tests/test_psud.py
+++ b/sonic-psud/tests/test_psud.py
@@ -11,7 +11,7 @@ else:
     import mock
 from sonic_py_common import daemon_base
 
-from .mock_platform import MockPsu
+from .mock_platform import MockPsu, MockChassis
 
 tests_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -179,6 +179,7 @@ def test_log_on_status_changed():
     mock_logger.log_warning.assert_called_with(abnormal_log)
 
 
+@mock.patch('psud.platform_chassis', mock.MagicMock())
 @mock.patch('psud.DaemonPsud.run')
 def test_main(mock_run):
     mock_run.return_value = False

--- a/sonic-syseepromd/tests/mocked_libs/swsscommon/swsscommon.py
+++ b/sonic-syseepromd/tests/mocked_libs/swsscommon/swsscommon.py
@@ -2,6 +2,8 @@
     Mock implementation of swsscommon package for unit testing
 '''
 
+from swsssdk import ConfigDBConnector, SonicDBConfig, SonicV2Connector
+
 STATE_DB = ''
 
 
@@ -22,6 +24,9 @@ class Table:
         if key in self.mock_dict:
             return self.mock_dict[key]
         return None
+
+    def get_size(self):
+        return (len(self.mock_dict))
 
 
 class FieldValuePairs:

--- a/sonic-syseepromd/tests/test_syseepromd.py
+++ b/sonic-syseepromd/tests/test_syseepromd.py
@@ -9,18 +9,18 @@ if sys.version_info.major == 3:
     from unittest import mock
 else:
     import mock
-from sonic_py_common import daemon_base
 
 SYSLOG_IDENTIFIER = 'syseepromd_test'
 NOT_AVAILABLE = 'N/A'
-
-daemon_base.db_connect = mock.MagicMock()
 
 tests_path = os.path.dirname(os.path.abspath(__file__))
 
 # Add mocked_libs path so that the file under test can load mocked modules from there
 mocked_libs_path = os.path.join(tests_path, 'mocked_libs')
 sys.path.insert(0, mocked_libs_path)
+
+from sonic_py_common import daemon_base
+daemon_base.db_connect = mock.MagicMock()
 
 # Add path to the file under test so that we can load it
 modules_path = os.path.dirname(tests_path)


### PR DESCRIPTION
#### Description
Following https://github.com/Azure/sonic-platform-daemons/pull/187 to fix the same issue with other packages

#### Motivation and Context
This is blocking Azure/sonic-buildimage#7655

#### How Has This Been Tested?
Unit test

#### Additional Information (Optional)
