### PR TITLE
Replace swsssdk.SonicV2Connector with swsscommon implementation

### DIFF
--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -11,7 +11,6 @@ try:
     import sys
     import threading
 
-    import swsssdk
     from sonic_py_common import daemon_base, device_info
     from swsscommon import swsscommon
 except ImportError as e:
@@ -49,7 +48,7 @@ class DaemonPcied(daemon_base.DaemonBase):
         self.timeout = PCIED_MAIN_THREAD_SLEEP_SECS
         self.stop_event = threading.Event()
 
-        self.state_db = swsssdk.SonicV2Connector(host=REDIS_HOSTIP)
+        self.state_db = swsscommon.SonicV2Connector(host=REDIS_HOSTIP)
         self.state_db.connect("STATE_DB")
         state_db = daemon_base.db_connect("STATE_DB")
         self.device_table = swsscommon.Table(state_db, PCIE_DEVICE_TABLE_NAME)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
swsssdk will be deprecated, and the python version of redis accessing classes will be replace by the same name classes in swsscommon, which are SWIG wrapped C++ code.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
