### PR TITLE
[xcvrd] initial support for integrating vendor specfic class objects for calling Y-Cable API's inside xcvrd

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -354,7 +354,9 @@ class TestXcvrdScript(object):
         mux_info_dict['version_nic_active'] = '0.8'
         mux_info_dict['version_nic_inactive'] = '0.7'
         mux_info_dict['version_nic_next'] = '0.7'
-        set_show_firmware_fields("Ethernet0", mux_info_dict, xcvrd_show_fw_res_tbl)
+        rc = set_show_firmware_fields("Ethernet0", mux_info_dict, xcvrd_show_fw_res_tbl)
+
+        assert(rc == 0)
 
     def test_get_media_settings_key(self):
         xcvr_info_dict = {

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -16,6 +16,10 @@ from .mock_swsscommon import Table
 daemon_base.db_connect = MagicMock()
 swsscommon.Table = MagicMock()
 swsscommon.ProducerStateTable = MagicMock()
+swsscommon.SubscriberStateTable = MagicMock()
+swsscommon.SonicDBConfig = MagicMock()
+#swsscommon.Select = MagicMock()
+
 sys.modules['sonic_y_cable'] = MagicMock()
 sys.modules['sonic_y_cable.y_cable'] = MagicMock()
 
@@ -217,7 +221,7 @@ class TestXcvrdScript(object):
 
     @patch('xcvrd.xcvrd_utilities.y_cable_helper.y_cable_platform_sfputil', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
-    @patch('xcvrd.xcvrd_utilities.y_cable_helper._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd_utilities.y_cable_helper.get_muxcable_info', MagicMock(return_value={'tor_active': 'self',
                                                                        'mux_direction': 'self',
                                                                        'manual_switch_count': '7',
@@ -254,9 +258,10 @@ class TestXcvrdScript(object):
         rc = post_port_mux_info_to_db(logical_port_name, mux_tbl)
         assert(rc != -1)
 
+
     @patch('xcvrd.xcvrd_utilities.y_cable_helper.y_cable_platform_sfputil', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
-    @patch('xcvrd.xcvrd_utilities.y_cable_helper._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd_utilities.y_cable_helper.get_muxcable_static_info', MagicMock(return_value={'read_side': 'self',
                                                                               'nic_lane1_precursor1': '1',
                                                                               'nic_lane1_precursor2': '-7',
@@ -293,6 +298,63 @@ class TestXcvrdScript(object):
         mux_tbl = Table("STATE_DB", y_cable_helper.MUX_CABLE_STATIC_INFO_TABLE)
         rc = post_port_mux_static_info_to_db(logical_port_name, mux_tbl)
         assert(rc != -1)
+
+    def test_y_cable_helper_format_mapping_identifier1(self):
+        rc = format_mapping_identifier("ABC        ")
+        assert(rc == "abc")
+
+    def test_y_cable_wrapper_get_transceiver_info(self):
+        with patch('xcvrd.xcvrd_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
+            patched_util.get_transceiver_info_dict.return_value = {'manufacturer': 'Microsoft',
+                                                                              'model': 'model1'}
+
+            transceiver_dict = y_cable_wrapper_get_transceiver_info(1)
+            vendor = transceiver_dict.get('manufacturer')
+            model = transceiver_dict.get('model')
+
+        assert(vendor == "Microsoft")
+        assert(model == "model1")
+
+    def test_y_cable_wrapper_get_presence(self):
+        with patch('xcvrd.xcvrd_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
+            patched_util.get_presence.return_value = True
+
+            presence = y_cable_wrapper_get_presence(1)
+
+        assert(presence == True)
+
+    @patch('xcvrd.xcvrd_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('xcvrd.xcvrd_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
+    def test_get_ycable_physical_port_from_logical_port(self):
+
+        instance = get_ycable_physical_port_from_logical_port("Ethernet0")
+
+        assert(instance == 0)
+
+    @patch('xcvrd.xcvrd_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('xcvrd.xcvrd_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
+    def test_get_ycable_port_instance_from_logical_port(self):
+
+        with patch('xcvrd.xcvrd_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
+            patched_util.get.return_value = 0
+            instance = get_ycable_port_instance_from_logical_port("Ethernet0")
+
+        assert(instance == 0)
+
+    def test_set_show_firmware_fields(self):
+
+        mux_info_dict = {}
+        xcvrd_show_fw_res_tbl = Table("STATE_DB", "XCVRD_SHOW_FW_RES")
+        mux_info_dict['version_self_active'] = '0.8'
+        mux_info_dict['version_self_inactive'] = '0.7'
+        mux_info_dict['version_self_next'] = '0.7'
+        mux_info_dict['version_peer_active'] = '0.8'
+        mux_info_dict['version_peer_inactive'] = '0.7'
+        mux_info_dict['version_peer_next'] = '0.7'
+        mux_info_dict['version_nic_active'] = '0.8'
+        mux_info_dict['version_nic_inactive'] = '0.7'
+        mux_info_dict['version_nic_next'] = '0.7'
+        set_show_firmware_fields("Ethernet0", mux_info_dict, xcvrd_show_fw_res_tbl)
 
     def test_get_media_settings_key(self):
         xcvr_info_dict = {

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -173,6 +173,8 @@ def set_show_firmware_fields(port, mux_info_dict, xcvrd_show_fw_rsp_tbl):
         ])
     xcvrd_show_fw_rsp_tbl.set(port, fvs)
 
+    return 0
+
 
 def set_result_and_delete_port(result, actual_result, command_table, response_table, port):
     fvs = swsscommon.FieldValuePairs([(result, str(actual_result))])

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -11,7 +11,6 @@ from importlib import import_module
 
 from sonic_py_common import daemon_base, logger
 from sonic_py_common import multi_asic
-from sonic_y_cable import y_cable
 from sonic_y_cable import y_cable_vendor_mapping
 from swsscommon import swsscommon
 from . import sfp_status_helper
@@ -788,7 +787,7 @@ def get_muxcable_info(physical_port, logical_port_name):
 
     with y_cable_port_locks[physical_port]:
         manual_switch_cnt = port_instance.get_switch_count_total(port_instance.SWITCH_COUNT_MANUAL)
-        auto_switch_cnt = port_instance.get_switch_count_total(y_cable.SWITCH_COUNT_AUTO)
+        auto_switch_cnt = port_instance.get_switch_count_total(port_instance.SWITCH_COUNT_AUTO)
 
     if manual_switch_cnt is not port_instance.EEPROM_ERROR:
         mux_info_dict["manual_switch_count"] = manual_switch_cnt
@@ -800,33 +799,6 @@ def get_muxcable_info(physical_port, logical_port_name):
     else:
         mux_info_dict["auto_switch_count"] = "N/A"
 
-    lane_active = y_cable.check_if_nic_lanes_active(physical_port)
-
-    if lane_active is not port_instance.EEPROM_ERROR:
-        if (lane_active & 0x1):
-            mux_info_dict["nic_lane1_active"] = "True"
-        else:
-            mux_info_dict["nic_lane1_active"] = "False"
-
-        if ((lane_active >> 1) & 0x1):
-            mux_info_dict["nic_lane2_active"] = "True"
-        else:
-            mux_info_dict["nic_lane2_active"] = "False"
-
-        if ((lane_active >> 2) & 0x1):
-            mux_info_dict["nic_lane3_active"] = "True"
-        else:
-            mux_info_dict["nic_lane3_active"] = "False"
-
-        if ((lane_active >> 3) & 0x1):
-            mux_info_dict["nic_lane4_active"] = "True"
-        else:
-            mux_info_dict["nic_lane4_active"] = "False"
-    else:
-        mux_info_dict["nic_lane1_active"] = "N/A"
-        mux_info_dict["nic_lane2_active"] = "N/A"
-        mux_info_dict["nic_lane3_active"] = "N/A"
-        mux_info_dict["nic_lane4_active"] = "N/A"
 
     if read_side == 1:
         with y_cable_port_locks[physical_port]:
@@ -1063,10 +1035,6 @@ def post_port_mux_info_to_db(logical_port_name, table):
                  ('link_status_self', mux_info_dict["link_status_self"]),
                  ('link_status_peer', mux_info_dict["link_status_peer"]),
                  ('link_status_nic', mux_info_dict["link_status_nic"]),
-                 ('nic_lane1_active', mux_info_dict["nic_lane1_active"]),
-                 ('nic_lane2_active', mux_info_dict["nic_lane2_active"]),
-                 ('nic_lane3_active', mux_info_dict["nic_lane3_active"]),
-                 ('nic_lane4_active', mux_info_dict["nic_lane4_active"]),
                  ('self_eye_height_lane1', str(mux_info_dict["self_eye_height_lane1"])),
                  ('self_eye_height_lane2', str(mux_info_dict["self_eye_height_lane2"])),
                  ('peer_eye_height_lane1', str(mux_info_dict["peer_eye_height_lane1"])),

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -91,7 +91,7 @@ def logical_port_name_to_physical_port_list(port_name):
         return [int(port_name)]
 
 
-def _wrapper_get_presence(physical_port):
+def y_cable_wrapper_get_presence(physical_port):
     if y_cable_platform_chassis is not None:
         try:
             return y_cable_platform_chassis.get_sfp(physical_port).get_presence()
@@ -100,7 +100,7 @@ def _wrapper_get_presence(physical_port):
     return y_cable_platform_sfputil.get_presence(physical_port)
 
 
-def _wrapper_get_transceiver_info(physical_port):
+def y_cable_wrapper_get_transceiver_info(physical_port):
     if y_cable_platform_chassis is not None:
         try:
             return y_cable_platform_chassis.get_sfp(physical_port).get_transceiver_info()
@@ -115,7 +115,7 @@ def get_ycable_physical_port_from_logical_port(logical_port_name):
     if len(physical_port_list) == 1:
 
         physical_port = physical_port_list[0]
-        if _wrapper_get_presence(physical_port):
+        if y_cable_wrapper_get_presence(physical_port):
 
             return physical_port
         else:
@@ -138,7 +138,7 @@ def get_ycable_port_instance_from_logical_port(logical_port_name):
     if len(physical_port_list) == 1:
 
         physical_port = physical_port_list[0]
-        if _wrapper_get_presence(physical_port):
+        if y_cable_wrapper_get_presence(physical_port):
 
             port_instance = y_cable_port_instances.get(physical_port)
             if port_instance is None:
@@ -243,7 +243,7 @@ def update_tor_active_side(read_side, state, logical_port_name):
     if len(physical_port_list) == 1:
 
         physical_port = physical_port_list[0]
-        if _wrapper_get_presence(physical_port):
+        if y_cable_wrapper_get_presence(physical_port):
             if int(read_side) == 1:
                 if state == "active":
                     return y_cable_toggle_mux_torA(physical_port)
@@ -284,7 +284,7 @@ def update_appdb_port_mux_cable_response_table(logical_port_name, asic_index, ap
     if len(physical_port_list) == 1:
 
         physical_port = physical_port_list[0]
-        if _wrapper_get_presence(physical_port):
+        if y_cable_wrapper_get_presence(physical_port):
 
             port_instance = y_cable_port_instances.get(physical_port)
             if port_instance is None:
@@ -352,7 +352,7 @@ def read_y_cable_and_update_statedb_port_tbl(logical_port_name, mux_config_tbl):
     if len(physical_port_list) == 1:
 
         physical_port = physical_port_list[0]
-        if _wrapper_get_presence(physical_port):
+        if y_cable_wrapper_get_presence(physical_port):
 
             port_instance = y_cable_port_instances.get(physical_port)
             if port_instance is None:
@@ -438,8 +438,8 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
                 if len(physical_port_list) == 1:
 
                     physical_port = physical_port_list[0]
-                    if _wrapper_get_presence(physical_port):
-                        port_info_dict = _wrapper_get_transceiver_info(
+                    if y_cable_wrapper_get_presence(physical_port):
+                        port_info_dict = y_cable_wrapper_get_transceiver_info(
                             physical_port)
                         if port_info_dict is not None:
                             vendor = port_info_dict.get('manufacturer')
@@ -450,7 +450,7 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
 
                             model = port_info_dict.get('model')
 
-                            if vendor is None:
+                            if model is None:
                                 helper_logger.log_warning(
                                     "Error: Unable to find model name for Transceiver for Y-Cable initiation {}".format(logical_port_name))
 
@@ -1099,7 +1099,7 @@ def post_port_mux_info_to_db(logical_port_name, table):
 
     for physical_port in physical_port_list:
 
-        if not _wrapper_get_presence(physical_port):
+        if not y_cable_wrapper_get_presence(physical_port):
             helper_logger.log_warning("Error: trying to post mux info without presence of port {}".format(logical_port_name))
             continue
 
@@ -1154,7 +1154,7 @@ def post_port_mux_static_info_to_db(logical_port_name, static_table):
 
     for physical_port in physical_port_list:
 
-        if not _wrapper_get_presence(physical_port):
+        if not y_cable_wrapper_get_presence(physical_port):
             continue
 
         mux_static_info_dict = get_muxcable_static_info(physical_port, logical_port_name)
@@ -1637,7 +1637,7 @@ class YCableTableUpdateTask(object):
 
                         status = 'False'
                         physical_port = get_ycable_physical_port_from_logical_port(port)
-                        if physical_port is None or physical_port is PHYSICAL_PORT_MAPPING_ERROR:
+                        if physical_port is None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
                             # error scenario update table accordingly
                             helper_logger.log_error(
                                 "Error: Could not get physical port for  cli config hwmode state cmd  Y cable port {}".format(port))
@@ -1832,7 +1832,7 @@ class YCableTableUpdateTask(object):
 
                         status = -1
                         physical_port = get_ycable_physical_port_from_logical_port(port)
-                        if physical_port is None or physical_port is PHYSICAL_PORT_MAPPING_ERROR:
+                        if physical_port is None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
                             # error scenario update table accordingly
                             helper_logger.log_error(
                                 "Error: Could not get physical port for down fw cli cmd Y cable port {}".format(port))
@@ -1880,7 +1880,7 @@ class YCableTableUpdateTask(object):
 
                         status = 'False'
                         physical_port = get_ycable_physical_port_from_logical_port(port)
-                        if physical_port is None or physical_port is PHYSICAL_PORT_MAPPING_ERROR: 
+                        if physical_port is None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
                             # error scenario update table accordingly
                             helper_logger.log_warning("Error: Could not get physical port for mux cable down fw command port {}".format(port))
                             set_result_and_delete_port('status', status, xcvrd_show_fw_cmd_sts_tbl[asic_index], xcvrd_show_fw_rsp_tbl[asic_index], port)
@@ -1947,7 +1947,7 @@ class YCableTableUpdateTask(object):
 
                         status = 'False'
                         physical_port = get_ycable_physical_port_from_logical_port(port)
-                        if physical_port is None or physical_port is PHYSICAL_PORT_MAPPING_ERROR: 
+                        if physical_port is None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
                             # error scenario update table accordingly
                             helper_logger.log_warning("Error: Could not get physical port for mux cable acti fw command port {}".format(port))
                             set_result_and_delete_port('status', status, xcvrd_acti_fw_cmd_sts_tbl[asic_index], xcvrd_acti_fw_rsp_tbl[asic_index], port)
@@ -1995,7 +1995,7 @@ class YCableTableUpdateTask(object):
 
                         status = 'False'
                         physical_port = get_ycable_physical_port_from_logical_port(port)
-                        if physical_port is None or physical_port is PHYSICAL_PORT_MAPPING_ERROR: 
+                        if physical_port is None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
                             # error scenario update table accordingly
                             helper_logger.log_warning("Error: Could not get physical port for mux cable roll fw command port {}".format(port))
                             set_result_and_delete_port('status', status, xcvrd_roll_fw_cmd_sts_tbl[asic_index], xcvrd_roll_fw_rsp_tbl[asic_index], port)

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -423,7 +423,7 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
     (status, fvs) = port_tbl[asic_index].get(logical_port_name)
     if status is False:
         helper_logger.log_warning(
-            "Could not retreive fieldvalue pairs for {}, inside config_db table {}".format(logical_port_name), port_tbl[asic_index].getTableName())
+            "Could not retreive fieldvalue pairs for {}, inside config_db table {}".format(logical_port_name, port_tbl[asic_index].getTableName()))
         return
 
     else:

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -960,14 +960,13 @@ def get_muxcable_info(physical_port, logical_port_name):
         except Exception as e:
             helper_logger.log_warning("Failed to execute the get_mux_direction API for port {} due to {}".format(physical_port,repr(e)))
 
-    if mux_dir_val is None or mux_dir_val == port_instance.EEPROM_ERROR or mux_dir_val < 0:
+    if mux_dir_val is None or mux_dir_val == port_instance.EEPROM_ERROR or mux_dir_val < 0 or read_side == -1:
         mux_direction = 'unknown'
-    elif read_side == mux_dir_val:
-        mux_direction = 'self'
-    elif read_side != mux_dir_val:
-        mux_direction = 'peer'
     else:
-        mux_direction = 'unknown'
+        if read_side == mux_dir_val:
+            mux_direction = 'self'
+        else:
+            mux_direction = 'peer'
 
     mux_info_dict["mux_direction"] = mux_direction
 

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -5,7 +5,6 @@
 
 import datetime
 import threading
-import time
 
 from importlib import import_module
 
@@ -312,7 +311,6 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
 
     global y_cable_port_instances
     global y_cable_port_locks
-    y_cable_port = {}
     (status, fvs) = port_tbl[asic_index].get(logical_port_name)
     if status is False:
         helper_logger.log_warning(
@@ -452,7 +450,6 @@ def check_identifier_presence_and_delete_mux_table_entry(state_db, port_tbl, asi
                 physical_port_list = logical_port_name_to_physical_port_list(logical_port_name)
 
                 if len(physical_port_list) == 1:
-
                     physical_port = physical_port_list[0]
                     y_cable_port_instances.pop(physical_port)
                     y_cable_port_locks.pop(physical_port)
@@ -617,7 +614,6 @@ def delete_ports_status_for_y_cable():
             physical_port_list = logical_port_name_to_physical_port_list(logical_port_name)
 
             if len(physical_port_list) == 1:
-
                 physical_port = physical_port_list[0]
                 y_cable_port_instances.pop(physical_port)
                 y_cable_port_locks.pop(physical_port)
@@ -744,8 +740,6 @@ def get_muxcable_info(physical_port, logical_port_name):
 
     mux_info_dict["mux_direction"] = mux_direction
 
-    manual_switch_cnt = "N/A"
-    auto_switch_cnt = "N/A"
     with y_cable_port_locks[physical_port]:
         manual_switch_cnt = port_instance.get_switch_count_total(port_instance.SWITCH_COUNT_MANUAL)
         auto_switch_cnt = port_instance.get_switch_count_total(y_cable.SWITCH_COUNT_AUTO)
@@ -1268,7 +1262,7 @@ class YCableTableUpdateTask(object):
                             new_status = 'unknown'
 
                         fvs_updated = swsscommon.FieldValuePairs([('state', new_status),
-                                                                  ('read_side',read_side),
+                                                                  ('read_side', read_side),
                                                                   ('active_side', str(active_side))])
                         y_cable_tbl[asic_index].set(port, fvs_updated)
                         helper_logger.log_debug("Y_CABLE_DEBUG: xcvrd successful to transition port {} from {} to {} and write back to the DB".format(port, old_status, new_status))

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -43,7 +43,7 @@ y_cable_switch_state_values = {
 MUX_CABLE_STATIC_INFO_TABLE = "MUX_CABLE_STATIC_INFO"
 MUX_CABLE_INFO_TABLE = "MUX_CABLE_INFO"
 
-def format_the_string(string):
+def format_mapping_identifier(string):
     """
     Takes an arbitrary string and creates a valid entity for port mapping file.
     The input could contain trailing and leading spaces, upper cases etc.
@@ -57,8 +57,9 @@ def format_the_string(string):
     # remove leading and trailing whitespace
     s = s.strip()
 
+    # Replace whitespace with underscores
     # Make spaces into underscores
-    s = re.sub('[\\s\\t\\n]+', '_', s)
+    s = re.sub(r'\s+', '_', s)
 
     return s
 
@@ -361,27 +362,27 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
 
                             if vendor is None:
                                 helper_logger.log_warning(
-                                    "Error: Unable to find Vendor name for Transceiver {}".format(logical_port_name))
+                                    "Error: Unable to find Vendor name for Transceiver for Y-Cable initiation {}".format(logical_port_name))
 
                             model = port_info_dict.get('model')
 
                             if vendor is None:
                                 helper_logger.log_warning(
-                                    "Error: Unable to find model name for Transceiver {}".format(logical_port_name))
+                                    "Error: Unable to find model name for Transceiver for Y-Cable initiation {}".format(logical_port_name))
 
-                            vendor = format_the_string(vendor)
-                            model = format_the_string(model)
+                            vendor = format_mapping_identifier(vendor)
+                            model = format_mapping_identifier(model)
                             module_dir = y_cable_vendor_mapping.mapping.get(vendor)
 
                             if module_dir is None:
                                 helper_logger.log_warning(
-                                    "Error: Unable to find module dir name from vendor {}".format(logical_port_name))
+                                    "Error: Unable to find module dir name from vendor for Y-Cable initiation {}".format(logical_port_name))
                                 return
 
                             module = module_dir.get(model)
                             if module is None:
                                 helper_logger.log_warning(
-                                    "Error: Unable to find module name from model {}".format(logical_port_name))
+                                    "Error: Unable to find module name from model for Y-Cable initiation {}".format(logical_port_name))
                                 return
 
                             attr_name = 'sonic_y_cable.' + module
@@ -391,7 +392,7 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
                             with y_cable_port_locks[physical_port]:
                                 vendor_name_api = y_cable_port_instances.get(physical_port).get_vendor()
 
-                            if format_the_string(vendor_name_api) != vendor:
+                            if format_mapping_identifier(vendor_name_api) != vendor:
                                 y_cable_port_instances.pop(physical_port)
                                 y_cable_port_locks.pop(physical_port)
                                 helper_logger.log_warning("Error: Y Cable api does not work for {}, {} actual vendor name {}".format(

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -289,9 +289,11 @@ def update_appdb_port_mux_cable_response_table(logical_port_name, asic_index, ap
         if y_cable_wrapper_get_presence(physical_port):
 
             port_instance = y_cable_port_instances.get(physical_port)
-            if port_instance is None:
+            if port_instance is None or port_instance == -1:
+                status = 'unknown'
+                update_table_mux_status_for_response_tbl(y_cable_response_tbl[asic_index], status, logical_port_name)
                 helper_logger.log_error(
-                    "Error: Could not get port instance for read side for  Y cable port {}".format(logical_port_name))
+                    "Error: Could not get port instance to perform update appdb for read side for Y cable port {}".format(logical_port_name))
                 return
 
             if read_side is None:
@@ -299,7 +301,7 @@ def update_appdb_port_mux_cable_response_table(logical_port_name, asic_index, ap
                 status = 'unknown'
                 update_table_mux_status_for_response_tbl(y_cable_response_tbl[asic_index], status, logical_port_name)
                 helper_logger.log_warning(
-                    "Error: Could not get read side for mux cable port probe command logical port {} and physical port {}".format(logical_port_name, physical_port))
+                    "Error: Could not get read side to perform update appdb for mux cable port probe command logical port {} and physical port {}".format(logical_port_name, physical_port))
                 return
 
             active_side = None
@@ -311,7 +313,7 @@ def update_appdb_port_mux_cable_response_table(logical_port_name, asic_index, ap
                 status = 'unknown'
                 update_table_mux_status_for_response_tbl(y_cable_response_tbl[asic_index], status, logical_port_name)
                 helper_logger.log_warning(
-                    "Error: Could not get active side for mux cable port probe command logical port {} and physical port {}".format(logical_port_name, physical_port))
+                    "Error: Could not get active side to perform update appdb for mux cable port probe command logical port {} and physical port {}".format(logical_port_name, physical_port))
                 return
 
             if read_side == active_side and (active_side == 1 or active_side == 2):
@@ -321,7 +323,7 @@ def update_appdb_port_mux_cable_response_table(logical_port_name, asic_index, ap
             else:
                 status = 'unknown'
                 helper_logger.log_warning(
-                    "Error: Could not get state for mux cable port probe command logical port {} and physical port {}".format(logical_port_name, physical_port))
+                    "Error: Could not get state to perform update appdb for mux cable port probe command logical port {} and physical port {}".format(logical_port_name, physical_port))
 
             helper_logger.log_debug("Y_CABLE_DEBUG: notifying a probe for port status {} {}".format(logical_port_name, status))
 
@@ -357,9 +359,9 @@ def read_y_cable_and_update_statedb_port_tbl(logical_port_name, mux_config_tbl):
         if y_cable_wrapper_get_presence(physical_port):
 
             port_instance = y_cable_port_instances.get(physical_port)
-            if port_instance is None:
+            if port_instance is None or port_instance == -1:
                 helper_logger.log_error(
-                    "Error: Could not get port instance for read side for  Y cable port {}".format(logical_port_name))
+                    "Error: Could not get port instance to perform read_y_cable update state db for read side for  Y cable port {}".format(logical_port_name))
                 return
 
             with y_cable_port_locks[physical_port]:
@@ -370,7 +372,7 @@ def read_y_cable_and_update_statedb_port_tbl(logical_port_name, mux_config_tbl):
                 update_table_mux_status_for_statedb_port_tbl(
                     mux_config_tbl, "unknown", read_side, active_side, logical_port_name)
                 helper_logger.log_error(
-                    "Error: Could not establish the read side for  Y cable port {}".format(logical_port_name))
+                    "Error: Could not establish the read side for Y cable port {} to perform read_y_cable update state db".format(logical_port_name))
                 return
 
             with y_cable_port_locks[physical_port]:
@@ -381,7 +383,7 @@ def read_y_cable_and_update_statedb_port_tbl(logical_port_name, mux_config_tbl):
                 update_table_mux_status_for_statedb_port_tbl(
                     mux_config_tbl, "unknown", read_side, active_side, logical_port_name)
                 helper_logger.log_error(
-                    "Error: Could not establish the active side for  Y cable port {}".format(logical_port_name))
+                    "Error: Could not establish the active side for  Y cable port {} to perform read_y_cable update state db".format(logical_port_name))
                 return
 
             if read_side == active_side and (active_side == 1 or active_side == 2):
@@ -391,7 +393,7 @@ def read_y_cable_and_update_statedb_port_tbl(logical_port_name, mux_config_tbl):
             else:
                 status = 'unknown'
                 helper_logger.log_warning(
-                    "Error: Could not establish the active status for  Y cable port {}".format(logical_port_name))
+                    "Error: Could not establish the active status for Y cable port {} to perform read_y_cable update state db".format(logical_port_name))
 
             update_table_mux_status_for_statedb_port_tbl(
                 mux_config_tbl, status, read_side, active_side, logical_port_name)
@@ -402,7 +404,7 @@ def read_y_cable_and_update_statedb_port_tbl(logical_port_name, mux_config_tbl):
             update_table_mux_status_for_statedb_port_tbl(
                 mux_config_tbl, "unknown", read_side, active_side, logical_port_name)
             helper_logger.log_warning(
-                "Error: Could not establish presence for  Y cable port {}".format(logical_port_name))
+                "Error: Could not establish presence for  Y cable port {} to perform read_y_cable update state db".format(logical_port_name))
     else:
         # Y cable ports should always have
         # one to one mapping of physical-to-logical
@@ -411,7 +413,7 @@ def read_y_cable_and_update_statedb_port_tbl(logical_port_name, mux_config_tbl):
         update_table_mux_status_for_statedb_port_tbl(
             mux_config_tbl, "unknown", read_side, active_side, logical_port_name)
         helper_logger.log_warning(
-            "Error: Retreived multiple ports for a Y cable port {}".format(logical_port_name))
+            "Error: Retreived multiple ports for a Y cable port {} to perform read_y_cable update state db".format(logical_port_name))
 
 
 def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name, y_cable_presence):
@@ -421,7 +423,7 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
     (status, fvs) = port_tbl[asic_index].get(logical_port_name)
     if status is False:
         helper_logger.log_warning(
-            "Could not retreive fieldvalue pairs for {}, inside config_db".format(logical_port_name))
+            "Could not retreive fieldvalue pairs for {}, inside config_db table {}".format(logical_port_name), port_tbl[asic_index].getTableName())
         return
 
     else:
@@ -528,6 +530,9 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
                                     logical_port_name,  mux_tbl[asic_index])
                                 post_port_mux_static_info_to_db(
                                     logical_port_name,  static_tbl[asic_index])
+                        else:
+                            helper_logger.log_warning(
+                                "Error: Could not get transceiver info dict Y cable port {} while inserting entries".format(logical_port_name))
                     else:
                         helper_logger.log_warning(
                             "Error: Could not establish transceiver presence for a Y cable port {} while inserting entries".format(logical_port_name))
@@ -537,6 +542,9 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
             else:
                 helper_logger.log_warning(
                     "Could not retreive active or auto value for state kvp for {}, inside MUX_CABLE table".format(logical_port_name))
+        else:
+            helper_logger.log_warning(
+                "Could not retreive state value inside mux_info_dict for {}, inside MUX_CABLE table".format(logical_port_name))
 
 
 def check_identifier_presence_and_delete_mux_table_entry(state_db, port_tbl, asic_index, logical_port_name, y_cable_presence, delete_change_event):
@@ -551,7 +559,7 @@ def check_identifier_presence_and_delete_mux_table_entry(state_db, port_tbl, asi
     (status, fvs) = port_tbl[asic_index].get(logical_port_name)
     if status is False:
         helper_logger.log_warning(
-            "Could not retreive fieldvalue pairs for {}, inside config_db".format(logical_port_name))
+            "Could not retreive fieldvalue pairs for {}, inside config_db table {}".format(logical_port_name, port_tbl[asic_index].getTableName()))
         return
 
     else:
@@ -598,7 +606,7 @@ def init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presen
     y_cable_platform_sfputil = platform_sfp
     y_cable_platform_chassis = platform_chassis
 
-    fvs_updated = swsscommon.FieldValuePairs([('log_verbosity', 'debug')])
+    fvs_updated = swsscommon.FieldValuePairs([('log_verbosity', 'notice')])
     # Get the namespaces in the platform
     namespaces = multi_asic.get_front_end_namespaces()
     for namespace in namespaces:
@@ -631,7 +639,7 @@ def init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presen
             # logical_ports after loading the port_mappings from port_config_file
             # This should not happen
             helper_logger.log_warning(
-                "Could not retreive port inside config_db PORT table {}".format(logical_port_name))
+                "Could not retreive port inside config_db PORT table {} for Y-Cable initiation".format(logical_port_name))
 
 
 def change_ports_status_for_y_cable_change_event(port_dict, y_cable_presence, stop_event=threading.Event()):
@@ -758,12 +766,12 @@ def check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_
     for namespace in namespaces:
         asic_id = multi_asic.get_asic_index_from_namespace(namespace)
         config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
-        port_tbl[asic_id] = swsscommon.Table(config_db[asic_id], "PORT")
+        port_tbl[asic_id] = swsscommon.Table(config_db[asic_id], "MUX_CABLE")
 
     (status, fvs) = port_tbl[asic_index].get(logical_port_name)
 
     if status is False:
-        helper_logger.log_warning("Could not retreive fieldvalue pairs for {}, inside config_db".format(logical_port_name))
+        helper_logger.log_debug("Could not retreive fieldvalue pairs for {}, inside config_db table {}".format(logical_port_name, port_tbl[asic_index].getTableName()))
         return
 
     else:
@@ -831,7 +839,7 @@ def get_muxcable_info(physical_port, logical_port_name):
 
     (status, fvs) = y_cable_tbl[asic_index].get(logical_port_name)
     if status is False:
-        helper_logger.log_warning("Could not retreive fieldvalue pairs for {}, inside state_db table {}".format(logical_port_name, y_cable_tbl[asic_index]))
+        helper_logger.log_warning("Could not retreive fieldvalue pairs for {}, inside state_db table {}".format(logical_port_name, y_cable_tbl[asic_index].getTableName()))
         return -1
 
     mux_port_dict = dict(fvs)
@@ -1019,7 +1027,7 @@ def get_muxcable_static_info(physical_port, logical_port_name):
     (status, fvs) = y_cable_tbl[asic_index].get(logical_port_name)
     if status is False:
         helper_logger.log_warning("Could not retreive fieldvalue pairs for {}, inside state_db table {}".format(
-            logical_port_name, y_cable_tbl[asic_index]))
+            logical_port_name, y_cable_tbl[asic_index].getTableName()))
         return -1
     mux_port_dict = dict(fvs)
     read_side = int(mux_port_dict.get("read_side"))
@@ -1358,7 +1366,7 @@ class YCableTableUpdateTask(object):
                         (status, fvs) = y_cable_tbl[asic_index].get(port)
                         if status is False:
                             helper_logger.log_warning("Could not retreive fieldvalue pairs for {}, inside state_db table {}".format(
-                                port, y_cable_tbl[asic_index]))
+                                port, y_cable_tbl[asic_index].getTableName()))
                             continue
                         mux_port_dict = dict(fvs)
                         old_status = mux_port_dict.get("state")
@@ -1408,7 +1416,7 @@ class YCableTableUpdateTask(object):
                             (status, fv) = y_cable_tbl[asic_index].get(port_m)
                             if status is False:
                                 helper_logger.log_warning("Could not retreive fieldvalue pairs for {}, inside state_db table {}".format(
-                                    port_m, y_cable_tbl[asic_index]))
+                                    port_m, y_cable_tbl[asic_index].getTableName()))
                                 continue
                             mux_port_dict = dict(fv)
                             read_side = mux_port_dict.get("read_side")

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -1274,7 +1274,6 @@ class YCableTableUpdateTask(object):
         y_cable_tbl_keys = {}
         mux_cable_command_tbl, y_cable_command_tbl = {}, {}
         mux_metrics_tbl = {}
-        xcvrd_log_tbl = {}
 
         sel = swsscommon.Select()
 
@@ -1406,10 +1405,8 @@ class YCableTableUpdateTask(object):
 
     def task_download_firmware_worker(self, port, physical_port, port_instance, file_full_path, xcvrd_down_fw_rsp_tbl, xcvrd_down_fw_cmd_sts_tbl, rc):
         helper_logger.log_info("worker thread for downloading physical port {} path {}".format(physical_port, file_full_path))
-        status = -1
         with y_cable_port_locks[physical_port]:
             status = port_instance.download_firmware(file_full_path)
-        fvs = swsscommon.FieldValuePairs([('status', str(status))])
         set_result_and_delete_port('status', status, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, port)
         helper_logger.log_warning(" downloading complete {} {} {}".format(physical_port, file_full_path, status))
         rc[0] = status
@@ -1420,7 +1417,6 @@ class YCableTableUpdateTask(object):
 
         # Connect to STATE_DB and APPL_DB and get both the HW_MUX_STATUS_TABLE info
         appl_db, config_db , state_db, y_cable_tbl = {}, {}, {}, {}
-        y_cable_tbl_keys = {}
         xcvrd_log_tbl = {}
         xcvrd_down_fw_cmd_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_down_fw_cmd_sts_tbl = {}, {}, {}
         xcvrd_down_fw_status_cmd_tbl, xcvrd_down_fw_status_rsp_tbl, xcvrd_down_fw_status_cmd_sts_tbl = {}, {}, {}
@@ -1568,35 +1564,33 @@ class YCableTableUpdateTask(object):
                     fvp_dict = dict(fvp)
 
                     if "state" in fvp_dict:
-                        probe = fvp_dict["state"]
 
-                        state = 'unknown'
                         physical_port = get_ycable_physical_port_from_logical_port(port)
-                        if physical_port == None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
+                        if physical_port is None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
                             state = 'cable not present'
                             # error scenario update table accordingly
                             helper_logger.log_error(
-                                "Error: Could not get physical port for cli show hwmode dir cmd  Y cable port {}".format(port))
+                                "Error: Could not get physical port for cli show hwmode muxdirection cmd  Y cable port {}".format(port))
                             set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
                             break
 
                         port_instance = get_ycable_port_instance_from_logical_port(port)
-                        if port_instance == None or port_instance in port_mapping_error_values:
+                        if port_instance is None or port_instance in port_mapping_error_values:
                             # error scenario update table accordingly
                             state = 'not Y-Cable port'
                             helper_logger.log_error(
-                                "Error: Could not get port instance for cli show hwmode dir cmd  Y cable port {}".format(port))
+                                "Error: Could not get port instance for cli show hwmode muxdirection cmd  Y cable port {}".format(port))
                             set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
                             break
 
                         read_side = None
                         with y_cable_port_locks[physical_port]:
                             read_side = port_instance.get_read_side()
-                        if read_side == None or read_side == port_instance.EEPROM_ERROR:
+                        if read_side is None or read_side == port_instance.EEPROM_ERROR:
 
                             state = 'unknown'
                             helper_logger.log_warning(
-                                "Error: Could not get read side for cli show hwmode dir cmd logical port {} and physical port {}".format(port, physical_port))
+                                "Error: Could not get read side for cli show hwmode muxdirection cmd logical port {} and physical port {}".format(port, physical_port))
                             set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
                             break
 
@@ -1604,10 +1598,10 @@ class YCableTableUpdateTask(object):
                         with y_cable_port_locks[physical_port]:
                             active_side = port_instance.get_mux_direction()
 
-                        if active_side == None or read_side == port_instance.EEPROM_ERROR:
+                        if active_side is None or read_side == port_instance.EEPROM_ERROR:
 
                             state = 'unknown'
-                            helper_logger.log_warning("Error: Could not get active side for cli show hwmode dir cmd logical port {} and physical port {}".format(port, physical_port))
+                            helper_logger.log_warning("Error: Could not get active side for cli show hwmode muxdirection cmd logical port {} and physical port {}".format(port, physical_port))
 
                             set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
                             break
@@ -1618,13 +1612,13 @@ class YCableTableUpdateTask(object):
                             state = 'standby'
                         else:
                             state = 'unknown'
-                            helper_logger.log_warning("Error: Could not get state for cli show hwmode dir logical port {} and physical port {}".format(port, physical_port))
+                            helper_logger.log_warning("Error: Could not get state for cli show hwmode muxdirection logical port {} and physical port {}".format(port, physical_port))
                             set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
                             break
 
                         set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
                     else:
-                        helper_logger.log_warning("Error: Wrong input param for cli show hwmode dir logical port {}".format(port))
+                        helper_logger.log_warning("Error: Wrong input param for cli show hwmode muxdirection logical port {}".format(port))
                         set_result_and_delete_port('state', 'unknown', xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
 
             while True:
@@ -1643,7 +1637,7 @@ class YCableTableUpdateTask(object):
 
                         status = 'False'
                         physical_port = get_ycable_physical_port_from_logical_port(port)
-                        if physical_port is None or physical_port is PHYSICAL_PORT_MAPPING_ERROR: 
+                        if physical_port is None or physical_port is PHYSICAL_PORT_MAPPING_ERROR:
                             # error scenario update table accordingly
                             helper_logger.log_error(
                                 "Error: Could not get physical port for  cli config hwmode state cmd  Y cable port {}".format(port))
@@ -1651,7 +1645,7 @@ class YCableTableUpdateTask(object):
                             break
 
                         port_instance = get_ycable_port_instance_from_logical_port(port)
-                        if port_instance == None or port_instance in port_mapping_error_values:
+                        if port_instance is None or port_instance in port_mapping_error_values:
                             # error scenario update table accordingly
                             helper_logger.log_error(
                                 "Error: Could not get port instance for  cli config hwmode state cmd  Y cable port {}".format(port))
@@ -1703,23 +1697,22 @@ class YCableTableUpdateTask(object):
                     fvp_dict = dict(fvp)
 
                     if "state" in fvp_dict:
-                        config_mode = str(fvp_dict["state"])
 
                         state = 'unknown'
                         physical_port = get_ycable_physical_port_from_logical_port(port)
-                        if physical_port == None or physical_port == PHYSICAL_PORT_MAPPING_ERROR: 
+                        if physical_port is None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
                             # error scenario update table accordingly
                             helper_logger.log_error(
-                                "Error: Could not get physical port for hwmode cli state cmd  Y cable port {}".format(port))
+                                "Error: Could not get physical port for hwmode cli switchingmode cmd  Y cable port {}".format(port))
                             state = 'cable not present'
                             set_result_and_delete_port('state', state, xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_swmode_rsp_tbl[asic_index], port)
                             break
 
                         port_instance = get_ycable_port_instance_from_logical_port(port)
-                        if port_instance == None or port_instance in port_mapping_error_values:
+                        if port_instance is None or port_instance in port_mapping_error_values:
                             # error scenario update table accordingly
                             helper_logger.log_error(
-                                "Error: Could not get port instance for hwmode cli state cmd  Y cable port {}".format(port))
+                                "Error: Could not get port instance for hwmode cli switchingmode cmd  Y cable port {}".format(port))
                             state = 'not Y-Cable port'
                             set_result_and_delete_port('state', state, xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_swmode_rsp_tbl[asic_index], port)
                             break
@@ -1727,10 +1720,10 @@ class YCableTableUpdateTask(object):
                         result = None
                         with y_cable_port_locks[physical_port]:
                             result = port_instance.get_switching_mode()
-                            if result == None or result == port_instance.EEPROM_ERROR:
+                            if result is None or result == port_instance.EEPROM_ERROR:
 
                                 helper_logger.log_warning(
-                                    "Error: Could not get read side for mux cable cli hwmode cmd logical port {} and physical port {}".format(port, physical_port))
+                                    "Error: Could not get read side for hwmode cli switchingmode cmd logical port {} and physical port {}".format(port, physical_port))
                                 set_result_and_delete_port('state', state, xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_swmode_rsp_tbl[asic_index], port)
                                 break
 
@@ -1743,7 +1736,7 @@ class YCableTableUpdateTask(object):
 
                         set_result_and_delete_port('state', state, xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_swmode_rsp_tbl[asic_index], port)
                     else:
-                        helper_logger.log_warning("Error: Incorrect input param for mux cable cli hwmode swmode logical port {}".format(port))
+                        helper_logger.log_warning("Error: Incorrect input param for mux cable cli hwmode switchingmode logical port {}".format(port))
                         set_result_and_delete_port('state', state, xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_swmode_rsp_tbl[asic_index], port)
 
 
@@ -1764,7 +1757,7 @@ class YCableTableUpdateTask(object):
 
                         status = 'False'
                         physical_port = get_ycable_physical_port_from_logical_port(port)
-                        if physical_port is None or physical_port is PHYSICAL_PORT_MAPPING_ERROR: 
+                        if physical_port is None or physical_port is PHYSICAL_PORT_MAPPING_ERROR:
                             # error scenario update table accordingly
                             helper_logger.log_error(
                                 "Error: Could not get physical port for hwmode cli state cmd  Y cable port {}".format(port))
@@ -1839,10 +1832,10 @@ class YCableTableUpdateTask(object):
 
                         status = -1
                         physical_port = get_ycable_physical_port_from_logical_port(port)
-                        if physical_port is None or physical_port is PHYSICAL_PORT_MAPPING_ERROR: 
+                        if physical_port is None or physical_port is PHYSICAL_PORT_MAPPING_ERROR:
                             # error scenario update table accordingly
                             helper_logger.log_error(
-                                "Error: Could not get physical port for down fw cli cmd  Y cable port {}".format(port))
+                                "Error: Could not get physical port for down fw cli cmd Y cable port {}".format(port))
                             set_result_and_delete_port('status', status, xcvrd_down_fw_cmd_sts_tbl[asic_index], xcvrd_down_fw_rsp_tbl[asic_index], port)
                             break
 
@@ -1884,9 +1877,6 @@ class YCableTableUpdateTask(object):
                         mux_info_dict['version_nic_active'] = 'N/A'
                         mux_info_dict['version_nic_inactive'] = 'N/A'
                         mux_info_dict['version_nic_next'] = 'N/A'
-
-                        version = fvp_dict["firmware_version"]
-
 
                         status = 'False'
                         physical_port = get_ycable_physical_port_from_logical_port(port)


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
This PR integrates vendor specific class objects inside xcvrd for Y-Cable API's to be called. 
Detailed designed document can be found https://github.com/Azure/SONiC/pull/757

 
<!--
     Describe your changes in detail
-->

#### Motivation and Context
Basically xcvrd now has  an interface for Y-Cable to interact with PMON docker and HOST
which can be uniform across all vendors. As part of this refactor, we will be moving towards a model where only xcvrd interacts with the cables/transceivers,  and host-side processes will communicate with xcvrd rather than with the devices directly with Y-Cable. 
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Ran the changes on Arista7050cx3 switch, making changes inside the container. 
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
