### PR TITLE
Introduce mgmtinit delay after transceiver reset

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -39,6 +39,9 @@ TRANSCEIVER_STATUS_TABLE = 'TRANSCEIVER_STATUS'
 
 SELECT_TIMEOUT_MSECS = 1000
 
+# Mgminit time required as per CMIS spec
+MGMT_INIT_TIME_DELAY_SECS = 2
+
 DOM_INFO_UPDATE_PERIOD_SECS = 60
 TIME_FOR_SFP_READY_SECS = 1
 XCVRD_MAIN_THREAD_SLEEP_SECS = 60
@@ -201,8 +204,16 @@ def _wrapper_get_sfp_error_description(physical_port):
         except NotImplementedError:
             pass
     return None
-# Remove unnecessary unit from the raw data
 
+def _wrapper_reset_transceiver(physical_port):
+    if platform_chassis:
+        try:
+            return platform_chassis.get_sfp(physical_port).reset()
+        except NotImplementedError:
+            pass
+    return platform_sfputil.reset(physical_port)
+
+# Remove unnecessary unit from the raw data
 
 def beautify_dom_info_dict(dom_info_dict, physical_port):
     dom_info_dict['temperature'] = strip_unit_and_beautify(dom_info_dict['temperature'], TEMP_UNIT)
@@ -260,8 +271,19 @@ def beautify_dom_threshold_info_dict(dom_info_dict):
     dom_info_dict['txbiashighwarning'] = strip_unit_and_beautify(dom_info_dict['txbiashighwarning'], BIAS_UNIT)
     dom_info_dict['txbiaslowwarning'] = strip_unit_and_beautify(dom_info_dict['txbiaslowwarning'], BIAS_UNIT)
 
-# Update port sfp info in db
+# Reset/re-initialize the transciever to its default state
 
+def reset_transceiver(logical_port_name):
+    physical_port_list = logical_port_name_to_physical_port_list(logical_port_name)
+    if physical_port_list is None:
+        helper_logger.log_error("No physical ports found for logical port '{}'".format(logical_port_name))
+        return
+
+    for physical_port in physical_port_list:
+        if _wrapper_reset_transceiver(physical_port):
+            time.sleep(MGMT_INIT_TIME_DELAY_SECS)
+
+# Update port sfp info in db
 
 def post_port_sfp_info_to_db(logical_port_name, table, transceiver_dict,
                              stop_event=threading.Event()):
@@ -1082,6 +1104,7 @@ class SfpStateUpdateTask(object):
 
                             if value == sfp_status_helper.SFP_STATUS_INSERTED:
                                 helper_logger.log_info("Got SFP inserted event")
+                                reset_transceiver(logical_port)
                                 # A plugin event will clear the error state.
                                 update_port_transceiver_status_table(
                                     logical_port, status_tbl[asic_index], sfp_status_helper.SFP_STATUS_INSERTED)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1106,8 +1106,6 @@ class SfpStateUpdateTask(object):
 
                             if value == sfp_status_helper.SFP_STATUS_INSERTED:
                                 helper_logger.log_info("Got SFP inserted event")
-                                # Delay for I2C MgmtInit to complete
-                                time.sleep(MGMT_INIT_TIME_DELAY_SECS)
                                 # A plugin event will clear the error state.
                                 update_port_transceiver_status_table(
                                     logical_port, status_tbl[asic_index], sfp_status_helper.SFP_STATUS_INSERTED)


### PR DESCRIPTION
Signed-off-by: Prince George <prgeor@microsoft.com>

#### Description

Added delay of 2 seconds for QSFP's MgmtInit after module presence is detected


#### Motivation and Context
As per CMIS spec : http://www.qsfp-dd.com/wp-content/uploads/2021/05/CMIS5p0.pdf (see D.1.3 Software Configuration and Initialization) module's resetL must be de-asserted and a delay of 2 seconds is required for MgmtInit to complete.

#### How Has This Been Tested?
TBD
Verify the eeprom dump and link comes UP under following scenarios:

1. Multiple reboots with optics from different vendors across various ports
2. OIR same optics multiple times on same port
3. Swap optics from different vendors on same port
4. Repeat 2 and 3 across multiple ports


#### Additional Information (Optional)
