### PR TITLE
Fix a bug at removing asics on not-online cards

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -248,6 +248,8 @@ class ModuleUpdater(logger.Logger):
         asics = list(self.asic_table.getKeys())
         for asic in asics:
            fvs = self.asic_table.get(asic)
+           if isinstance(fvs, list):
+              fvs = dict(fvs[-1])
            if fvs[CHASSIS_MODULE_INFO_NAME_FIELD] in notOnlineModules:
               self.asic_table._del(asic)
 


### PR DESCRIPTION
Fix a bug coming from https://github.com/Azure/sonic-platform-daemons/pull/175 when asic is removed due to card getting offline (before it was online).

The change works on real hw + unit test.