### PR TITLE
Modular chassis: Psud set master led on first run

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -175,6 +175,7 @@ class PsuChassisInfo(logger.Logger):
         super(PsuChassisInfo, self).__init__(log_identifier)
 
         self.chassis = chassis
+        self.first_run = True
         self.master_status_good = True
         self.total_consumed_power = 0.0
         self.total_supplied_power = 0.0
@@ -242,30 +243,30 @@ class PsuChassisInfo(logger.Logger):
         chassis_tbl.set(CHASSIS_INFO_POWER_KEY_TEMPLATE.format(1), fvs)
 
     def update_master_status(self):
-        if not self.total_supplied_power or not self.total_consumed_power:
-            if self.master_status_good is not True:
-                self.master_status_good = True
-            return False
+        set_led = self.first_run
+        master_status_good = False
 
-        master_status_good = (self.total_consumed_power < self.total_supplied_power)
-        if master_status_good == self.master_status_good:
-            return False
+        if self.total_supplied_power != 0.0 and self.total_consumed_power != 0.0:
+            master_status_good = (self.total_consumed_power < self.total_supplied_power)
+            if master_status_good != self.master_status_good:
+                set_led = True
 
-        self.master_status_good = master_status_good
+            self.master_status_good = master_status_good
 
-        # Update the PSU master status LED
-        # set_status_master_led() is a class method implemented in PsuBase
-        # so we do not need to catch NotImplementedError here
-        color = Psu.STATUS_LED_COLOR_GREEN if master_status_good else Psu.STATUS_LED_COLOR_RED
-        Psu.set_status_master_led(color)
+        if set_led:
+            # Update the PSU master status LED
+            # set_status_master_led() is a class method implemented in PsuBase
+            # so we do not need to catch NotImplementedError here
+            color = Psu.STATUS_LED_COLOR_GREEN if master_status_good else Psu.STATUS_LED_COLOR_RED
+            Psu.set_status_master_led(color)
 
-        log_on_status_changed(self, self.master_status_good,
-                              'PSU supplied power warning cleared: supplied power is back to normal.',
-                              'PSU supplied power warning: {}W supplied-power less than {}W consumed-power'.format(
-                                  self.total_supplied_power, self.total_consumed_power)
-                              )
+            log_on_status_changed(self, self.master_status_good,
+                                  'PSU supplied power warning cleared: supplied power is back to normal.',
+                                  'PSU supplied power warning: {}W supplied-power less than {}W consumed-power'.format(
+                                      self.total_supplied_power, self.total_consumed_power)
+                                  )
 
-        return True
+        return set_led
 
 # PSU status ===================================================================
 #
@@ -601,6 +602,9 @@ class DaemonPsud(daemon_base.DaemonBase):
 
         self.psu_chassis_info.run_power_budget(self.chassis_tbl)
         self.psu_chassis_info.update_master_status()
+
+        if self.first_run:
+            self.first_run = False
 
 
 #


### PR DESCRIPTION
On first run, the PSU master-led on supervisor of modular-chassis is not set. 

#### Description
The PSU master-led on modular chassis indicates the power-buget status. Similar to individual PSU leds that are set on first_run, the master-led also will be set to based on initial status (RED or GREEN with LED status ON).

#### Motivation and Context
Without the forced setting of first_run, the master-led status will default to per vendor default. In some cases, this could be amber blinking etc

#### How Has This Been Tested?
This has been tested on real HW and unit-tests using pytest suite.

```
tests/test_DaemonPsud.py::TestDaemonPsud::test_signal_handler PASSED                              [  3%]
tests/test_DaemonPsud.py::TestDaemonPsud::test_run PASSED                                         [  6%]
tests/test_DaemonPsud.py::TestDaemonPsud::test_update_psu_data PASSED                             [ 10%]
tests/test_DaemonPsud.py::TestDaemonPsud::test_update_single_psu_data PASSED                      [ 13%]
tests/test_DaemonPsud.py::TestDaemonPsud::test_set_psu_led PASSED                                 [ 17%]
tests/test_DaemonPsud.py::TestDaemonPsud::test_update_led_color PASSED                            [ 20%]
tests/test_DaemonPsud.py::TestDaemonPsud::test_update_psu_fan_led_status PASSED                   [ 24%]
tests/test_DaemonPsud.py::TestDaemonPsud::test_update_psu_chassis_info PASSED                     [ 27%]
tests/test_DaemonPsud.py::TestDaemonPsud::test_update_psu_entity_info PASSED                      [ 31%]
tests/test_DaemonPsud.py::TestDaemonPsud::test_update_single_psu_entity_info PASSED               [ 34%]
tests/test_DaemonPsud.py::TestDaemonPsud::test_update_psu_fan_data PASSED                         [ 37%]
tests/test_PsuChassisInfo.py::TestPsuChassisInfo::test_update_master_status PASSED                [ 41%]
tests/test_PsuChassisInfo.py::TestPsuChassisInfo::test_supplied_power PASSED                      [ 44%]
tests/test_PsuChassisInfo.py::TestPsuChassisInfo::test_consumed_power PASSED                      [ 48%]
tests/test_PsuChassisInfo.py::TestPsuChassisInfo::test_power_budget PASSED                        [ 51%]
tests/test_PsuChassisInfo.py::TestPsuChassisInfo::test_first_run PASSED                           [ 55%]
tests/test_PsuChassisInfo.py::TestPsuChassisInfo::test_get_psu_key PASSED                         [ 58%]
tests/test_PsuChassisInfo.py::TestPsuChassisInfo::test_try_get PASSED                             [ 62%]
tests/test_PsuStatus.py::TestPsuStatus::test_set_presence PASSED                                  [ 65%]
tests/test_PsuStatus.py::TestPsuStatus::test_set_power_good PASSED                                [ 68%]
tests/test_PsuStatus.py::TestPsuStatus::test_set_voltage PASSED                                   [ 72%]
tests/test_PsuStatus.py::TestPsuStatus::test_set_temperature PASSED                               [ 75%]
tests/test_PsuStatus.py::TestPsuStatus::test_is_ok PASSED                                         [ 79%]
tests/test_psud.py::test_wrapper_get_num_psus PASSED                                              [ 82%]
tests/test_psud.py::test_wrapper_get_psu_presence PASSED                                          [ 86%]
tests/test_psud.py::test_wrapper_get_psu_status PASSED                                            [ 89%]
tests/test_psud.py::test_psu_db_update PASSED                                                     [ 93%]
tests/test_psud.py::test_log_on_status_changed PASSED                                             [ 96%]
tests/test_psud.py::test_main PASSED                                                              [100%]

----------- generated xml file: /sonic/src/sonic-platform-daemons/sonic-psud/test-results.xml -----------

---------- coverage: platform linux2, python 2.7.16-final-0 ----------
Name           Stmts   Miss  Cover
----------------------------------
scripts/psud     366     10    97%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml

======================================= 29 passed in 3.29 seconds =======================================

```

#### Additional Information (Optional)
