### PR TITLE
[y-cable] fix for logging the xcvrd metrics before writing the state to the State-DB

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -15,8 +15,6 @@ from . import sfp_status_helper
 
 SELECT_TIMEOUT = 1000
 
-Y_CABLE_DIRECTION_SYNC = 3
-
 y_cable_platform_sfputil = None
 y_cable_platform_chassis = None
 
@@ -114,25 +112,16 @@ def update_tor_active_side(read_side, state, logical_port_name):
         if _wrapper_get_presence(physical_port):
             if int(read_side) == 1:
                 if state == "active":
-                    y_cable_toggle_mux_torA(physical_port)
+                    return y_cable_toggle_mux_torA(physical_port)
                 elif state == "standby":
-                    y_cable_toggle_mux_torB(physical_port)
+                    return y_cable_toggle_mux_torB(physical_port)
             elif int(read_side) == 2:
                 if state == "active":
-                    y_cable_toggle_mux_torB(physical_port)
+                    return y_cable_toggle_mux_torB(physical_port)
                 elif state == "standby":
-                    y_cable_toggle_mux_torA(physical_port)
+                    return y_cable_toggle_mux_torA(physical_port)
 
             # TODO: Should we confirm that the mux was indeed toggled?
-            # attempt to read the cable direction in 3 attempts and if still the direction is not in sync
-            # return unknown
-            for i in range(Y_CABLE_DIRECTION_SYNC):
-                active_side = y_cable.check_mux_direction(physical_port)
-                if active_side == int(read_side):
-                    return active_side
-                else:
-                    continue
-            return -1
 
         else:
             helper_logger.log_warning(

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -114,14 +114,14 @@ def update_tor_active_side(read_side, state, logical_port_name):
         if _wrapper_get_presence(physical_port):
             if int(read_side) == 1:
                 if state == "active":
-                    return y_cable_toggle_mux_torA(physical_port)
+                    y_cable_toggle_mux_torA(physical_port)
                 elif state == "standby":
-                    return y_cable_toggle_mux_torB(physical_port)
+                    y_cable_toggle_mux_torB(physical_port)
             elif int(read_side) == 2:
                 if state == "active":
-                    return y_cable_toggle_mux_torB(physical_port)
+                    y_cable_toggle_mux_torB(physical_port)
                 elif state == "standby":
-                    return y_cable_toggle_mux_torA(physical_port)
+                    y_cable_toggle_mux_torA(physical_port)
 
             # TODO: Should we confirm that the mux was indeed toggled?
             # attempt to read the cable direction in 3 attempts and if still the direction is not in sync


### PR DESCRIPTION

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description

This PR fixes the logging for mux_metrics for writing anything to the state DB for a state transition. Basically previously xcvrd would first post the query result to the DB and only then update its own metric for state transition, but now we do the reverse.

<!--
     Describe your changes in detail
-->

#### Motivation and Context


Second change was motivated by the sequence of events which happen inside state transition for mux-metrics table. Previously orchagent reports finishing the transition before xcvrd which is not the case. Ideally xcvrd does the transition first followed by orchagent followed by linkmgr
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Ran the change on Arista7050cx3 testbed.
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
