### PR TITLE
Fix occassional test_sfp_insert_events failure

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -407,10 +407,11 @@ class TestXcvrdScript(object):
         start = time.time()
         while True:
             _wrapper_soak_sfp_insert_event(sfp_insert_events, insert)
-            assert not bool(insert)
             if time.time() - start > MGMT_INIT_TIME_DELAY_SECS:
                 break
+            assert not bool(insert)
         assert insert == port_dict
+
 
     def test_sfp_remove_events(self):
         from xcvrd.xcvrd import _wrapper_soak_sfp_insert_event


### PR DESCRIPTION
Signed-off-by: Prince George <prgeor@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
Due to rare timing issue test_sfp_insert_events failure can fail. Out of 100 iterations, the test failed on 82nd iteration.

#### Motivation and Context
Fix unit test failure:-
[https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_apis/build/builds/36875/logs/20](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_apis/build/builds/36875/logs/20)

#### How Has This Been Tested?
All 100 iterations of test_xcvrd.py now pass

