### PR TITLE
[xcvrd][y_cable] refactor xcvrd to listen to port probe without locks; fix the get_firmware_version API to sync with download_firmware

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -238,17 +238,16 @@ def y_cable_toggle_mux_torA(physical_port):
     port_instance = y_cable_port_instances.get(physical_port)
     if port_instance is None:
         helper_logger.log_error(
-            "Error: Could not get port instance for read side for  Y cable port {}".format(physical_port))
+            "Error: Could not get port instance for read side for  Y cable port {} {}".format(physical_port, threading.currentThread().getName()))
         return -1
 
-    with y_cable_port_locks[physical_port]:
-        try:
-            update_status = port_instance.toggle_mux_to_tor_a()
-        except Exception as e:
-            update_status = -1
-            helper_logger.log_warning("Failed to execute the toggle mux ToR A API for port {} due to {}".format(physical_port,repr(e)))
+    try:
+        update_status = port_instance.toggle_mux_to_tor_a()
+    except Exception as e:
+        update_status = -1
+        helper_logger.log_warning("Failed to execute the toggle mux ToR A API for port {} due to {} {}".format(physical_port, repr(e) , threading.currentThread().getName()))
 
-    helper_logger.log_debug("Y_CABLE_DEBUG: Status of toggling mux to ToR A for port {} {}".format(physical_port, update_status))
+    helper_logger.log_debug("Y_CABLE_DEBUG: Status of toggling mux to ToR A for port {} status {} {}".format(physical_port, update_status, threading.currentThread().getName()))
     if update_status is True:
         return 1
     else:
@@ -260,17 +259,16 @@ def y_cable_toggle_mux_torA(physical_port):
 def y_cable_toggle_mux_torB(physical_port):
     port_instance = y_cable_port_instances.get(physical_port)
     if port_instance is None:
-        helper_logger.log_error("Error: Could not get port instance for read side for  Y cable port {}".format(physical_port))
+        helper_logger.log_error("Error: Could not get port instance for read side for  Y cable port {} {}".format(physical_port, threading.currentThread().getName()))
         return -1
 
-    with y_cable_port_locks[physical_port]:
-        try:
-            update_status = port_instance.toggle_mux_to_tor_b()
-        except Exception as e:
-            update_status = -1
-            helper_logger.log_warning("Failed to execute the toggle mux ToR B API for port {} due to {}".format(physical_port,repr(e)))
+    try:
+        update_status = port_instance.toggle_mux_to_tor_b()
+    except Exception as e:
+        update_status = -1
+        helper_logger.log_warning("Failed to execute the toggle mux ToR B API for port {} due to {} {}".format(physical_port,repr(e), threading.currentThread().getName()))
 
-    helper_logger.log_debug("Y_CABLE_DEBUG: Status of toggling mux to ToR B for port {} {}".format(physical_port, update_status))
+    helper_logger.log_debug("Y_CABLE_DEBUG: Status of toggling mux to ToR B for port {} {} {}".format(physical_port, update_status, threading.currentThread().getName()))
     if update_status is True:
         return 2
     else:
@@ -346,12 +344,11 @@ def update_appdb_port_mux_cable_response_table(logical_port_name, asic_index, ap
                 return
 
             active_side = None
-            with y_cable_port_locks[physical_port]:
-                try:
-                    active_side = port_instance.get_mux_direction()
-                except Exception as e:
-                    active_side = -1
-                    helper_logger.log_warning("Failed to execute the get_mux_direction for port {} due to {}".format(physical_port,repr(e)))
+            try:
+                active_side = port_instance.get_mux_direction()
+            except Exception as e:
+                active_side = -1
+                helper_logger.log_warning("Failed to execute the get_mux_direction for port {} due to {}".format(physical_port,repr(e)))
 
             if active_side is None or active_side == port_instance.EEPROM_ERROR or active_side < 0 :
 
@@ -778,7 +775,6 @@ def change_ports_status_for_y_cable_change_event(port_dict, y_cable_presence, st
                 elif value == sfp_status_helper.SFP_STATUS_REMOVED:
                     check_identifier_presence_and_delete_mux_table_entry(
                         state_db, port_tbl, asic_index, logical_port_name, y_cable_presence, delete_change_event)
-
                 else:
                     try:
                         # Now that the value is in bitmap format, let's convert it to number
@@ -847,8 +843,9 @@ def delete_ports_status_for_y_cable():
             if len(physical_port_list) == 1:
 
                 physical_port = physical_port_list[0]
-                y_cable_port_instances.pop(physical_port)
-                y_cable_port_locks.pop(physical_port)
+                if y_cable_port_instances.get(physical_port) is not None:
+                    y_cable_port_instances.pop(physical_port)
+                    y_cable_port_locks.pop(physical_port)
             else:
                 helper_logger.log_warning(
                     "Error: Retreived multiple ports for a Y cable port {} while deleting entries".format(logical_port_name))
@@ -897,6 +894,15 @@ def check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_
 def get_firmware_dict(physical_port, port_instance, target, side, mux_info_dict):
 
     result = {}
+    if port_instance.download_firmware_status == port_instance.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS or port_instance.download_firmware_status == port_instance.FIRMWARE_DOWNLOAD_STATUS_FAILED:
+        mux_info_dict[("version_{}_active".format(side))] = "N/A"
+        mux_info_dict[("version_{}_inactive".format(side))] = "N/A"
+        mux_info_dict[("version_{}_next".format(side))] = "N/A"
+        helper_logger.log_warning(
+            "trying to post firmware info while download in progress returning without execute {}".format(physical_port))
+
+        return
+
     with y_cable_port_locks[physical_port]:
         try:
             result = port_instance.get_firmware_version(target)
@@ -1459,7 +1465,8 @@ def task_download_firmware_worker(port, physical_port, port_instance, file_full_
 # Thread wrapper class to update y_cable status periodically
 class YCableTableUpdateTask(object):
     def __init__(self):
-        self.task_thread = None
+        self.task_mux_toggle_thread = None
+        self.task_mux_probe_thread = None
         self.task_cli_thread = None
         self.task_download_firmware_thread = {}
         self.task_stopping_event = threading.Event()
@@ -1468,12 +1475,11 @@ class YCableTableUpdateTask(object):
             # Load the namespace details first from the database_global.json file.
             swsscommon.SonicDBConfig.initializeGlobalConfig()
 
-    def task_worker(self):
+    def task_mux_toggle_worker(self):
 
         # Connect to STATE_DB and APPL_DB and get both the HW_MUX_STATUS_TABLE info
-        appl_db, state_db, config_db, status_tbl, y_cable_tbl = {}, {}, {}, {}, {}
+        appl_db, state_db, status_tbl, y_cable_tbl = {}, {}, {}, {}
         y_cable_tbl_keys = {}
-        mux_cable_command_tbl, y_cable_command_tbl = {}, {}
         mux_metrics_tbl = {}
 
         sel = swsscommon.Select()
@@ -1484,13 +1490,8 @@ class YCableTableUpdateTask(object):
             # Open a handle to the Application database, in all namespaces
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
             appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
-            config_db[asic_id] = daemon_base.db_connect("CONFIG_DB", namespace)
             status_tbl[asic_id] = swsscommon.SubscriberStateTable(
                 appl_db[asic_id], swsscommon.APP_HW_MUX_CABLE_TABLE_NAME)
-            mux_cable_command_tbl[asic_id] = swsscommon.SubscriberStateTable(
-                appl_db[asic_id], swsscommon.APP_MUX_CABLE_COMMAND_TABLE_NAME)
-            y_cable_command_tbl[asic_id] = swsscommon.Table(
-                appl_db[asic_id], swsscommon.APP_MUX_CABLE_COMMAND_TABLE_NAME)
             state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
             y_cable_tbl[asic_id] = swsscommon.Table(
                 state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
@@ -1498,7 +1499,6 @@ class YCableTableUpdateTask(object):
                 state_db[asic_id], swsscommon.STATE_MUX_METRICS_TABLE_NAME)
             y_cable_tbl_keys[asic_id] = y_cable_tbl[asic_id].getKeys()
             sel.addSelectable(status_tbl[asic_id])
-            sel.addSelectable(mux_cable_command_tbl[asic_id])
 
         # Listen indefinitely for changes to the HW_MUX_CABLE_TABLE in the Application DB's
         while True:
@@ -1530,7 +1530,7 @@ class YCableTableUpdateTask(object):
                 if not port:
                     break
 
-                helper_logger.log_debug("Y_CABLE_DEBUG: received an event for port transition {}".format(port))
+                helper_logger.log_debug("Y_CABLE_DEBUG: received an event for port transition {} {}".format(port, threading.currentThread().getName()))
 
                 # entering this section signifies a start for xcvrd state
                 # change request from swss so initiate recording in mux_metrics table
@@ -1556,14 +1556,14 @@ class YCableTableUpdateTask(object):
                         old_status = mux_port_dict.get("state")
                         read_side = mux_port_dict.get("read_side")
                         # Now whatever is the state requested, toggle the mux appropriately
-                        helper_logger.log_debug("Y_CABLE_DEBUG: xcvrd trying to transition port {} from {} to {}".format(port, old_status, new_status))
+                        helper_logger.log_debug("Y_CABLE_DEBUG: xcvrd trying to transition port {} from {} to {} {}".format(port, old_status, new_status, threading.currentThread().getName()))
                         active_side = update_tor_active_side(read_side, new_status, port)
                         if active_side == -1:
-                            helper_logger.log_warning("ERR: Got a change event for toggle but could not toggle the mux-direction for port {} state from {} to {}, writing unknown".format(
-                                port, old_status, new_status))
+                            helper_logger.log_warning("ERR: Got a change event for toggle but could not toggle the mux-direction for port {} state from {} to {}, writing unknown {}".format(
+                                port, old_status, new_status, threading.currentThread().getName()))
                             new_status = 'unknown'
 
-                        helper_logger.log_debug("Y_CABLE_DEBUG: xcvrd successful to transition port {} from {} to {} and write back to the DB".format(port, old_status, new_status))
+                        helper_logger.log_debug("Y_CABLE_DEBUG: xcvrd successful to transition port {} from {} to {} and write back to the DB {}".format(port, old_status, new_status, threading.currentThread().getName()))
                         helper_logger.log_info("Got a change event for toggle the mux-direction active side for port {} state from {} to {}".format(
                             port, old_status, new_status))
                         time_end = datetime.datetime.utcnow().strftime("%Y-%b-%d %H:%M:%S.%f")
@@ -1576,15 +1576,65 @@ class YCableTableUpdateTask(object):
                                                                   ('active_side', str(active_side))])
                         y_cable_tbl[asic_index].set(port, fvs_updated)
                     else:
-                        helper_logger.log_info("Got a change event on port {} of table {} that does not contain state".format(
-                            port, swsscommon.APP_HW_MUX_CABLE_TABLE_NAME))
+                        helper_logger.log_info("Got a change event on port {} of table {} that does not contain state {}".format(
+                            port, swsscommon.APP_HW_MUX_CABLE_TABLE_NAME, threading.currentThread().getName()))
+
+    def task_mux_probe_worker(self):
+
+        # Connect to STATE_DB and APPL_DB and get both the HW_MUX_STATUS_TABLE info
+        appl_db, state_db, y_cable_tbl = {}, {}, {}
+        y_cable_tbl_keys = {}
+        mux_cable_command_tbl, y_cable_command_tbl = {}, {}
+
+        sel = swsscommon.Select()
+
+        # Get the namespaces in the platform
+        namespaces = multi_asic.get_front_end_namespaces()
+        for namespace in namespaces:
+            # Open a handle to the Application database, in all namespaces
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
+            mux_cable_command_tbl[asic_id] = swsscommon.SubscriberStateTable(
+                appl_db[asic_id], swsscommon.APP_MUX_CABLE_COMMAND_TABLE_NAME)
+            y_cable_command_tbl[asic_id] = swsscommon.Table(
+                appl_db[asic_id], swsscommon.APP_MUX_CABLE_COMMAND_TABLE_NAME)
+            state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)
+            y_cable_tbl[asic_id] = swsscommon.Table(
+                state_db[asic_id], swsscommon.STATE_HW_MUX_CABLE_TABLE_NAME)
+            y_cable_tbl_keys[asic_id] = y_cable_tbl[asic_id].getKeys()
+            sel.addSelectable(mux_cable_command_tbl[asic_id])
+
+        # Listen indefinitely for changes to the HW_MUX_CABLE_TABLE in the Application DB's
+        while True:
+            # Use timeout to prevent ignoring the signals we want to handle
+            # in signal_handler() (e.g. SIGTERM for graceful shutdown)
+
+            if self.task_stopping_event.is_set():
+                break
+
+            (state, selectableObj) = sel.select(SELECT_TIMEOUT)
+
+            if state == swsscommon.Select.TIMEOUT:
+                # Do not flood log when select times out
+                continue
+            if state != swsscommon.Select.OBJECT:
+                helper_logger.log_warning(
+                    "sel.select() did not  return swsscommon.Select.OBJECT for sonic_y_cable updates")
+                continue
+
+            # Get the redisselect object  from selectable object
+            redisSelectObj = swsscommon.CastSelectableToRedisSelectObj(
+                selectableObj)
+            # Get the corresponding namespace from redisselect db connector object
+            namespace = redisSelectObj.getDbConnector().getNamespace()
+            asic_index = multi_asic.get_asic_index_from_namespace(namespace)
 
             while True:
                 (port_m, op_m, fvp_m) = mux_cable_command_tbl[asic_index].pop()
 
                 if not port_m:
                     break
-                helper_logger.log_debug("Y_CABLE_DEBUG: received a probe for port status {}".format(port_m))
+                helper_logger.log_debug("Y_CABLE_DEBUG: received a probe for port status {} {}".format(port_m, threading.currentThread().getName()))
 
                 if fvp_m:
 
@@ -1607,6 +1657,12 @@ class YCableTableUpdateTask(object):
                             read_side = mux_port_dict.get("read_side")
                             update_appdb_port_mux_cable_response_table(port_m, asic_index, appl_db, int(read_side))
 
+                    else:
+                        helper_logger.log_error("Got a probe event on port {} of table {} that does not contain command".format(
+                            port_m, mux_cable_command_tbl[asic_index].getTableName()))
+                else:
+                    helper_logger.log_error("Could not retreive fvp for port_m {} table {} while trying to process mux probe".format(
+                        port_m, mux_cable_command_tbl[asic_index].getTableName()))
 
     def task_cli_worker(self):
 
@@ -2275,16 +2331,19 @@ class YCableTableUpdateTask(object):
 
 
     def task_run(self):
-        self.task_thread = threading.Thread(target=self.task_worker)
+        self.task_mux_toggle_thread = threading.Thread(target=self.task_mux_toggle_worker)
+        self.task_mux_probe_thread = threading.Thread(target=self.task_mux_probe_worker)
         self.task_cli_thread = threading.Thread(target=self.task_cli_worker)
-        self.task_thread.start()
+        self.task_mux_toggle_thread.start()
+        self.task_mux_probe_thread.start()
         self.task_cli_thread.start()
 
     def task_stop(self):
 
         self.task_stopping_event.set()
         helper_logger.log_info("stopping the cli and probing task threads xcvrd")
-        self.task_thread.join()
+        self.task_mux_toggle_thread.join()
+        self.task_mux_probe_thread.join()
         self.task_cli_thread.join()
         
         for key, value in self.task_download_firmware_thread.items():

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -1535,7 +1535,7 @@ class YCableTableUpdateTask(object):
                 if not port:
                     break
 
-                helper_logger.log_debug("Y_CABLE_DEBUG: received an event for port transition {}".format(port))
+                helper_logger.log_debug("Y_CABLE_DEBUG: received an event for port transition {} {}".format(port, threading.currentThread().getName()))
 
                 # entering this section signifies a start for xcvrd state
                 # change request from swss so initiate recording in mux_metrics table
@@ -1568,9 +1568,9 @@ class YCableTableUpdateTask(object):
                                 port, old_status, new_status))
                             new_status = 'unknown'
 
-                        helper_logger.log_debug("Y_CABLE_DEBUG: xcvrd successful to transition port {} from {} to {} and write back to the DB".format(port, old_status, new_status))
-                        helper_logger.log_info("Got a change event for toggle the mux-direction active side for port {} state from {} to {}".format(
-                            port, old_status, new_status))
+                        helper_logger.log_debug("Y_CABLE_DEBUG: xcvrd successful to transition port {} from {} to {} and write back to the DB {}".format(port, old_status, new_status, threading.currentThread().getName()))
+                        helper_logger.log_notice("Got a change event for toggle the mux-direction active side for port {} state from {} to {} {}".format(
+                            port, old_status, new_status, threading.currentThread().getName()))
                         time_end = datetime.datetime.utcnow().strftime("%Y-%b-%d %H:%M:%S.%f")
                         fvs_metrics = swsscommon.FieldValuePairs([('xcvrd_switch_{}_start'.format(new_status), str(time_start)),
                                                                   ('xcvrd_switch_{}_end'.format(new_status), str(time_end))])
@@ -1589,7 +1589,7 @@ class YCableTableUpdateTask(object):
 
                 if not port_m:
                     break
-                helper_logger.log_debug("Y_CABLE_DEBUG: received a probe for port status {}".format(port_m))
+                helper_logger.log_debug("Y_CABLE_DEBUG: received a probe for port status {} {}".format(port_m, threading.currentThread().getName()))
 
                 if fvp_m:
 

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -1461,7 +1461,7 @@ def task_download_firmware_worker(port, physical_port, port_instance, file_full_
     rc[0] = status
     helper_logger.log_debug("download thread finished port {} physical_port {}".format(port, physical_port))
 
-
+# Thread wrapper class to update y_cable status periodically
 class YCableTableUpdateTask(object):
     def __init__(self):
         self.task_thread = None
@@ -2295,4 +2295,3 @@ class YCableTableUpdateTask(object):
         for key, value in self.task_download_firmware_thread.items():
             self.task_download_firmware_thread[key].join()
         helper_logger.log_info("stopped all thread")
-


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
This PR refactors the listening of port probes from linkmgr to xcvrd as so that xcvrd does not see timeout messages like these below

`Sep 27 22:24:37.490921 SONIC WARNING mux#linkmgrd: link_manager/LinkManagerStateMachine.cpp:815 handleMuxWaitTimeout: Ethernet120: xcvrd timed out responding to linkmgrd, current state: (P: Unknown, M: Wait, L: Down)`

Refactoring to a separate listener thread mode as well as removing the lock(safe because read/write transaction via eeprom for port probe) seems to handle this, and does not have the logs like this one above.
as the read write eeprom also has a mutex lock in the platform api call, optoe implementation.
https://github.com/Azure/sonic-linux-kernel/blob/889d76e36b3f012d3782a1c5e1587c32e4d1ed11/patch/driver-support-optoe.patch#L717
<!--
     Describe your changes in detail
-->

#### Motivation and Context
refactor xcvrd for listening to port probes, disable calling the get_firmware_api() while a download is in progress. 
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Ran the changes on Arista7050cx3-32s testbed
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
