### PR TITLE
[sfp-refactoring] xcvrd: add initial support for CMIS application initialization

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -610,16 +610,38 @@ class TestXcvrdScript(object):
             'ConfigStatusLane7': 'ConfigSuccess',
             'ConfigStatusLane8': 'ConfigSuccess'
         })
-        mock_xcvr_api.get_datapath_state = MagicMock(return_value={
-            'DP1State': 'DataPathInitialized',
-            'DP2State': 'DataPathInitialized',
-            'DP3State': 'DataPathInitialized',
-            'DP4State': 'DataPathInitialized',
-            'DP5State': 'DataPathInitialized',
-            'DP6State': 'DataPathInitialized',
-            'DP7State': 'DataPathInitialized',
-            'DP8State': 'DataPathInitialized'
-        })
+        mock_xcvr_api.get_datapath_state = MagicMock(side_effect=[
+            {
+                'DP1State': 'DataPathDeactivated',
+                'DP2State': 'DataPathDeactivated',
+                'DP3State': 'DataPathDeactivated',
+                'DP4State': 'DataPathDeactivated',
+                'DP5State': 'DataPathDeactivated',
+                'DP6State': 'DataPathDeactivated',
+                'DP7State': 'DataPathDeactivated',
+                'DP8State': 'DataPathDeactivated'
+            },
+            {
+                'DP1State': 'DataPathInitialized',
+                'DP2State': 'DataPathInitialized',
+                'DP3State': 'DataPathInitialized',
+                'DP4State': 'DataPathInitialized',
+                'DP5State': 'DataPathInitialized',
+                'DP6State': 'DataPathInitialized',
+                'DP7State': 'DataPathInitialized',
+                'DP8State': 'DataPathInitialized'
+            },
+            {
+                'DP1State': 'DataPathActivated',
+                'DP2State': 'DataPathActivated',
+                'DP3State': 'DataPathActivated',
+                'DP4State': 'DataPathActivated',
+                'DP5State': 'DataPathActivated',
+                'DP6State': 'DataPathActivated',
+                'DP7State': 'DataPathActivated',
+                'DP8State': 'DataPathActivated'
+            }
+        ])
 
         mock_sfp = MagicMock()
         mock_sfp.get_presence = MagicMock(return_value=True)

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -557,8 +557,8 @@ class TestXcvrdScript(object):
         assert len(task.port_dict) == 1
 
     @patch('xcvrd.xcvrd.platform_chassis')
-    @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_config_change', MagicMock(return_value=(None, None)))
-    @patch('xcvrd.xcvrd_utilities.port_mapping.handle_port_config_change', MagicMock())
+    @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_update_event', MagicMock(return_value=(None, None)))
+    @patch('xcvrd.xcvrd_utilities.port_mapping.handle_port_update_event', MagicMock())
     def test_CmisManagerTask_task_run_stop(self, mock_chassis):
         mock_object = MagicMock()
         mock_object.get_presence = MagicMock(return_value=True)
@@ -573,8 +573,8 @@ class TestXcvrdScript(object):
         assert not task.task_process.is_alive()
 
     @patch('xcvrd.xcvrd.platform_chassis')
-    @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_config_change', MagicMock(return_value=(None, None)))
-    @patch('xcvrd.xcvrd_utilities.port_mapping.handle_port_config_change', MagicMock())
+    @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_update_event', MagicMock(return_value=(None, None)))
+    @patch('xcvrd.xcvrd_utilities.port_mapping.handle_port_update_event', MagicMock())
     @patch('xcvrd.xcvrd._wrapper_get_sfp_type', MagicMock(return_value='QSFP_DD'))
     def test_CmisManagerTask_task_worker(self, mock_chassis):
         mock_sfp = MagicMock()

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -569,8 +569,9 @@ class TestXcvrdScript(object):
         task = CmisManagerTask(port_mapping)
         task.task_run([False])
         task.task_stop()
-        assert task.task_process is not None
-        assert not task.task_process.is_alive()
+        # task.task_process could be none if the feature is disabled in pmon_daemon_control.json
+        if task.task_process is not None:
+            assert not task.task_process.is_alive()
 
     @patch('xcvrd.xcvrd.platform_chassis')
     @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_update_event', MagicMock(return_value=(None, None)))

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -530,26 +530,31 @@ class TestXcvrdScript(object):
         assert mock_deinit.call_count == 1
         assert mock_init.call_count == 1
 
-    @patch('xcvrd.xcvrd.xcvr_table_helper', MagicMock())
+    @patch('xcvrd.xcvrd._wrapper_get_sfp_type', MagicMock(return_value='QSFP_DD'))
     def test_CmisManagerTask_handle_port_change_event(self):
         port_mapping = PortMapping()
         task = CmisManagerTask(port_mapping)
 
+        assert not task.isPortConfigDone
+        port_change_event = PortChangeEvent('PortConfigDone', -1, 0, PortChangeEvent.PORT_SET)
+        task.on_port_config_change(port_change_event)
+        assert task.isPortConfigDone
+
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
         task.on_port_config_change(port_change_event)
-        assert task.task_queue.empty()
+        assert len(task.port_dict) == 0
 
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_REMOVE)
         task.on_port_config_change(port_change_event)
-        assert task.task_queue.empty()
+        assert len(task.port_dict) == 0
 
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_DEL)
         task.on_port_config_change(port_change_event)
-        assert task.task_queue.empty()
+        assert len(task.port_dict) == 1
 
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_SET)
         task.on_port_config_change(port_change_event)
-        assert not task.task_queue.empty()
+        assert len(task.port_dict) == 1
 
     @patch('xcvrd.xcvrd.platform_chassis')
     @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_config_change', MagicMock(return_value=(None, None)))
@@ -564,53 +569,82 @@ class TestXcvrdScript(object):
         task = CmisManagerTask(port_mapping)
         task.task_run([False])
         task.task_stop()
-        for worker in task.task_workers:
-            assert not worker.is_alive()
+        assert task.task_process is not None
+        assert not task.task_process.is_alive()
 
     @patch('xcvrd.xcvrd.platform_chassis')
     @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_config_change', MagicMock(return_value=(None, None)))
     @patch('xcvrd.xcvrd_utilities.port_mapping.handle_port_config_change', MagicMock())
+    @patch('xcvrd.xcvrd._wrapper_get_sfp_type', MagicMock(return_value='QSFP_DD'))
     def test_CmisManagerTask_task_worker(self, mock_chassis):
-        mock_object = MagicMock()
-        mock_object.get_presence = MagicMock(return_value=True)
-        mock_object.get_port_type = MagicMock(return_value="QSFP_DD")
-        mock_object.set_cmis_application = MagicMock()
-        mock_chassis.get_all_sfps = MagicMock(return_value=[mock_object])
-        mock_chassis.get_sfp = MagicMock(return_value=mock_object)
+        mock_sfp = MagicMock()
+        mock_sfp.get_presence = MagicMock(return_value=True)
+        mock_sfp.get_port_type = MagicMock(return_value="QSFP_DD")
+        mock_sfp.get_transceiver_info = MagicMock(return_value={'type_abbrv_name':'QSFP_DD', 'memory_type':'paged'})
+        mock_sfp.get_module_state = MagicMock(return_value="ModuleReady")
+        mock_sfp.get_cmis_state = MagicMock(return_value={
+            'config_state': {
+                'ConfigStatusLane1': 'ConfigSuccess',
+                'ConfigStatusLane2': 'ConfigSuccess',
+                'ConfigStatusLane3': 'ConfigSuccess',
+                'ConfigStatusLane4': 'ConfigSuccess',
+                'ConfigStatusLane5': 'ConfigSuccess',
+                'ConfigStatusLane6': 'ConfigSuccess',
+                'ConfigStatusLane7': 'ConfigSuccess',
+                'ConfigStatusLane8': 'ConfigSuccess'
+            },
+            'datapath_state': {
+                'DP1State': 'DataPathInitialized',
+                'DP2State': 'DataPathInitialized',
+                'DP3State': 'DataPathInitialized',
+                'DP4State': 'DataPathInitialized',
+                'DP5State': 'DataPathInitialized',
+                'DP6State': 'DataPathInitialized',
+                'DP7State': 'DataPathInitialized',
+                'DP8State': 'DataPathInitialized'
+            }
+        })
+        mock_sfp.get_cmis_application_update = MagicMock(return_value=(True, 1))
+        mock_sfp.set_cmis_application_stop = MagicMock(return_value=True)
+        mock_sfp.set_cmis_application_apsel = MagicMock(return_value=True)
+        mock_sfp.set_cmis_application_start = MagicMock(return_value=True)
+        mock_sfp.set_cmis_application_txon = MagicMock(return_value=True)
+
+        mock_chassis.get_all_sfps = MagicMock(return_value=[mock_sfp])
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
 
         port_mapping = PortMapping()
-        port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_SET)
-
-        # Case 1: Both port speed and lanes are unset
         task = CmisManagerTask(port_mapping)
-        task.task_stopping_event.is_set = MagicMock(side_effect=[False, True])
-        task.on_port_config_change(port_change_event)
-        task.task_worker(False)
-        assert mock_object.set_cmis_application.call_count == 0
 
-        # Case 2: Invalid port speed while lanes is valid
-        port_change_event.port_dict = {'speed': 0, 'lanes': "1,2,3,4,5,6,7,8"}
-        task = CmisManagerTask(port_mapping)
-        task.task_stopping_event.is_set = MagicMock(side_effect=[False, True])
+        port_change_event = PortChangeEvent('PortConfigDone', -1, 0, PortChangeEvent.PORT_SET)
         task.on_port_config_change(port_change_event)
-        task.task_worker(False)
-        assert mock_object.set_cmis_application.call_count == 0
+        assert task.isPortConfigDone
 
-        # Case 3: Valid port speed with invalid lanes
-        port_change_event.port_dict = {'speed': 400000, 'lanes': None}
-        task = CmisManagerTask(port_mapping)
-        task.task_stopping_event.is_set = MagicMock(side_effect=[False, True])
+        port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_SET,
+                                            {'speed':'400000', 'lanes':'1,2,3,4,5,6,7,8'})
         task.on_port_config_change(port_change_event)
-        task.task_worker(False)
-        assert mock_object.set_cmis_application.call_count == 0
+        assert len(task.port_dict) == 1
 
-        # Case 4: valid port speed and lanes
-        port_change_event.port_dict = {'speed': 400000, 'lanes': "1,2,3,4,5,6,7,8"}
-        task = CmisManagerTask(port_mapping)
-        task.task_stopping_event.is_set = MagicMock(side_effect=[False, True])
-        task.on_port_config_change(port_change_event)
-        task.task_worker(False)
-        assert mock_object.set_cmis_application.call_count == 1
+        # Case 1: Module Inserted --> DP_DEINIT
+        task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
+        task.task_worker()
+        assert mock_sfp.get_cmis_application_update.call_count > 0
+        assert mock_sfp.set_cmis_application_stop.call_count > 0
+
+        # Case 2: DP_DEINIT --> AP Configured
+        task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
+        task.task_worker()
+        assert mock_sfp.set_cmis_application_apsel.call_count > 0
+
+        # Case 3: AP Configured --> DP_INIT
+        task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
+        task.task_worker()
+        assert mock_sfp.set_cmis_application_start.call_count > 0
+
+        # Case 4: DP_INIT --> DP_TXON
+        task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
+        task.task_worker()
+        assert mock_sfp.set_cmis_application_txon.call_count > 0
 
     @patch('xcvrd.xcvrd.xcvr_table_helper', MagicMock())
     def test_DomInfoUpdateTask_handle_port_change_event(self):

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1051,23 +1051,6 @@ class CmisManagerTask:
             self.dbg_print("Platform chassis is not available, stopping...")
             return
 
-        # Deactivate the service if none of the QSFPDD cages/ports are available
-        # Please note this check has nothing to do with the module type fetched
-        # from byte 0 or 128 of the transceiver EEPROM.
-        has_cmis = False
-        for sfp in platform_chassis.get_all_sfps():
-            try:
-                ptype = sfp.get_port_type()
-            except (NotImplementedError, ValueError):
-                ptype = 'Unknown'
-            if ptype in ['QSFP_DD', 'QSFP-DD']:
-                has_cmis = True
-                break
-
-        if not has_cmis:
-            self.dbg_print("None of QSFP-DD cages are detected, stopping...")
-            return
-
         self.task_process = multiprocessing.Process(target=self.task_worker)
         if self.task_process is not None:
             self.task_process.start()

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -987,7 +987,10 @@ class CmisManagerTask:
                         (flag, appl) = sfp.get_cmis_application_update(host_lanes, host_speed)
                         if not flag:
                             # No application updates
-                            self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_READY
+                            state = self.CMIS_STATE_READY
+                            self.dbg_print("{}: {}G, {}-lanes, state={}".format(
+                                           lport, int(speed/1000), len(host_lanes), state))
+                            self.port_dict[lport]['cmis_state'] = state
                             continue
                         self.port_dict[lport]['cmis_apsel'] = appl
                         sfp.set_cmis_application_stop(host_lanes)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1058,7 +1058,7 @@ class CmisManagerTask:
                 if ctrl.get('skip_xcvrd_cmis_manager', False):
                     self.dbg_print("service stopped administratively")
                     return
-        except AttributeError:
+        except (AttributeError, TypeError):
             pass
 
         if platform_chassis is None:

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -893,13 +893,6 @@ class CmisManagerTask:
         if not lport.startswith('Ethernet'):
             return
 
-        if port_change_event.port_dict is None:
-            speed = "0"
-            lanes = ""
-        else:
-            speed = port_change_event.port_dict.get('speed', "0")
-            lanes = port_change_event.port_dict.get('lanes', "")
-
         if pport is None:
             return
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1047,24 +1047,13 @@ class CmisManagerTask:
         self.dbg_print("Stopped")
 
     def task_run(self, y_cable_presence):
-        # Stop the service if it's disabled in pmon_daemon_control.json
-        try:
-            (platform_path, _) = device_info.get_paths_to_platform_and_hwsku_dirs()
-            pmon_daemon_control_file_path = os.path.join(platform_path, "pmon_daemon_control.json")
-            if os.path.isfile(pmon_daemon_control_file_path):
-                ctrl = {}
-                with open(pmon_daemon_control_file_path, "r") as f:
-                    ctrl = json.load(f)
-                if ctrl.get('skip_xcvrd_cmis_manager', False):
-                    self.dbg_print("service stopped administratively")
-                    return
-        except (AttributeError, TypeError):
-            pass
-
         if platform_chassis is None:
             self.dbg_print("Platform chassis is not available, stopping...")
             return
 
+        # Deactivate the service if none of the QSFPDD cages/ports are available
+        # Please note this check has nothing to do with the module type fetched
+        # from byte 0 or 128 of the transceiver EEPROM.
         has_cmis = False
         for sfp in platform_chassis.get_all_sfps():
             try:

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -875,7 +875,7 @@ class CmisManagerTask:
     def dbg_print(self, message):
         helper_logger.log_notice("CMIS: {}".format(message))
 
-    def on_port_config_change(self, port_change_event):
+    def on_port_update_event(self, port_change_event):
         if port_change_event.event_type not in [port_change_event.PORT_SET, port_change_event.PORT_DEL]:
             return
 
@@ -928,7 +928,7 @@ class CmisManagerTask:
                                                   asic_context,
                                                   self.task_stopping_event,
                                                   helper_logger,
-                                                  self.on_port_config_change)
+                                                  self.on_port_update_event)
 
             if not self.isPortConfigDone:
                 continue
@@ -985,7 +985,7 @@ class CmisManagerTask:
                                    lport, int(speed/1000), len(host_lanes), state))
 
                     if state == self.CMIS_STATE_INSERTED:
-                        (flag, appl) = sfp.get_cmis_application_update(host_lanes, host_speed)
+                        (flag, appl) = sfp.has_cmis_application_update(host_speed, host_lanes)
                         if not flag:
                             # No application updates
                             state = self.CMIS_STATE_READY
@@ -1087,7 +1087,7 @@ class CmisManagerTask:
         self.task_stopping_event.set()
         if self.task_process is not None:
             self.task_process.join()
-
+            self.task_process = None
 
 # Thread wrapper class to update dom info periodically
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -854,6 +854,7 @@ def is_fast_reboot_enabled():
 
 class CmisManagerTask:
 
+    CMIS_STATE_UNKNOWN   = 'UNKNOWN'
     CMIS_STATE_INSERTED  = 'INSERTED'
     CMIS_STATE_DP_DEINIT = 'DP_DEINIT'
     CMIS_STATE_AP_CONF   = 'AP_CONFIGURED'
@@ -946,8 +947,11 @@ class CmisManagerTask:
                 if lport not in self.port_dict:
                     continue
 
-                state = self.port_dict[lport].get('cmis_state', self.CMIS_STATE_REMOVED)
-                if state in [self.CMIS_STATE_FAILED, self.CMIS_STATE_READY, self.CMIS_STATE_REMOVED]:
+                state = self.port_dict[lport].get('cmis_state', self.CMIS_STATE_UNKNOWN)
+                if state in [self.CMIS_STATE_UNKNOWN,
+                             self.CMIS_STATE_FAILED,
+                             self.CMIS_STATE_READY,
+                             self.CMIS_STATE_REMOVED]:
                     continue
 
                 pport = int(info.get('index', "-1"))

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -871,7 +871,6 @@ class CmisManagerTask:
         self.isPortConfigDone = False
 
     def dbg_print(self, message):
-        print("CMIS: {}".format(message))
         helper_logger.log_notice("CMIS: {}".format(message))
 
     def on_port_update_event(self, port_change_event):

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/port_mapping.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/port_mapping.py
@@ -8,7 +8,10 @@ SELECT_TIMEOUT_MSECS = 1000
 class PortChangeEvent:
     PORT_ADD = 0
     PORT_REMOVE = 1
-    def __init__(self, port_name, port_index, asic_id, event_type):
+    PORT_SET = 2
+    PORT_DEL = 3
+
+    def __init__(self, port_name, port_index, asic_id, event_type, port_dict=None):
         # Logical port name, e.g. Ethernet0
         self.port_name = port_name
         # Physical port index, equals to "index" field of PORT table in CONFIG_DB
@@ -17,6 +20,8 @@ class PortChangeEvent:
         self.asic_id = asic_id
         # Port change event type
         self.event_type = event_type
+        # Port config dict
+        self.port_dict = port_dict
 
     def __str__(self):
         return '{} - name={} index={} asic_id={}'.format('Add' if self.event_type == self.PORT_ADD else 'Remove',
@@ -83,21 +88,28 @@ class PortMapping:
             else:
                 return None
 
+def subscribe_port_config_change(db_list=['CONFIG_DB']):
+    port_tbl_map = {
+        'APPL_DB': swsscommon.APP_PORT_TABLE_NAME,
+        'CONFIG_DB': swsscommon.CFG_PORT_TABLE_NAME,
+        'STATE_DB': 'TRANSCEIVER_INFO'
+    }
 
-def subscribe_port_config_change():
     sel = swsscommon.Select()
     asic_context = {}
     namespaces = multi_asic.get_front_end_namespaces()
-    for namespace in namespaces:
-        config_db = daemon_base.db_connect("CONFIG_DB", namespace=namespace)
-        asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-        port_tbl = swsscommon.SubscriberStateTable(config_db, swsscommon.CFG_PORT_TABLE_NAME)
-        asic_context[port_tbl] = asic_id
-        sel.addSelectable(port_tbl)
+    for db_name in db_list:
+        if db_name not in port_tbl_map:
+            continue
+        for namespace in namespaces:
+            db = daemon_base.db_connect(db_name, namespace=namespace)
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            port_tbl = swsscommon.SubscriberStateTable(db, port_tbl_map[db_name])
+            asic_context[port_tbl] = asic_id
+            sel.addSelectable(port_tbl)
     return sel, asic_context
 
-
-def handle_port_config_change(sel, asic_context, stop_event, port_mapping, logger, port_change_event_handler):
+def handle_port_config_change(sel, asic_context, stop_event, port_mapping, logger, port_change_event_handler, promiscuous=False):
     """Select CONFIG_DB PORT table changes, once there is a port configuration add/remove, notify observers
     """
     if not stop_event.is_set():
@@ -107,47 +119,69 @@ def handle_port_config_change(sel, asic_context, stop_event, port_mapping, logge
         if state != swsscommon.Select.OBJECT:
             logger.log_warning('sel.select() did not return swsscommon.Select.OBJECT')
             return
-        
-        read_port_config_change(asic_context, port_mapping, logger, port_change_event_handler)
-        
 
-def read_port_config_change(asic_context, port_mapping, logger, port_change_event_handler):
+        read_port_config_change(asic_context, port_mapping, logger, port_change_event_handler, promiscuous)
+
+def read_port_config_change(asic_context, port_mapping, logger, port_change_event_handler, promiscuous):
     for port_tbl in asic_context.keys():
         while True:
             (key, op, fvp) = port_tbl.pop()
             if not key:
                 break
+            fvp = dict(fvp) if fvp is not None else {}
             if op == swsscommon.SET_COMMAND:
-                fvp = dict(fvp)
                 if 'index' not in fvp:
-                    continue
-
+                    fvp['index'] = -1
                 new_physical_index = int(fvp['index'])
-                if not port_mapping.is_logical_port(key):
+
+                if promiscuous:
+                    port_change_event = PortChangeEvent(key, new_physical_index, asic_context[port_tbl], PortChangeEvent.PORT_SET, fvp)
+                    port_change_event_handler(port_change_event)
+
+                if key in ['PortConfigDone', 'PortInitDone']:
+                    continue
+                elif not port_mapping.is_logical_port(key):
                     # New logical port created
-                    port_change_event = PortChangeEvent(key, new_physical_index, asic_context[port_tbl], PortChangeEvent.PORT_ADD)
+                    port_change_event = PortChangeEvent(key, new_physical_index, asic_context[port_tbl], PortChangeEvent.PORT_ADD, fvp)
                     port_change_event_handler(port_change_event)
                 else:
                     current_physical_index = port_mapping.get_logical_to_physical(key)[0]
                     if current_physical_index != new_physical_index:
-                        port_change_event = PortChangeEvent(key, 
-                                                            current_physical_index, 
-                                                            asic_context[port_tbl], 
-                                                            PortChangeEvent.PORT_REMOVE)
+                        port_change_event = PortChangeEvent(key,
+                                                            current_physical_index,
+                                                            asic_context[port_tbl],
+                                                            PortChangeEvent.PORT_REMOVE,
+                                                            fvp)
                         port_change_event_handler(port_change_event)
 
-                        port_change_event = PortChangeEvent(key, new_physical_index, asic_context[port_tbl], PortChangeEvent.PORT_ADD)
+                        port_change_event = PortChangeEvent(key, new_physical_index, asic_context[port_tbl], PortChangeEvent.PORT_ADD, fvp)
                         port_change_event_handler(port_change_event)
             elif op == swsscommon.DEL_COMMAND:
-                if port_mapping.is_logical_port(key):
-                    port_change_event = PortChangeEvent(key, 
-                                                        port_mapping.get_logical_to_physical(key)[0], 
-                                                        asic_context[port_tbl], 
-                                                        PortChangeEvent.PORT_REMOVE)
+                if promiscuous:
+                    if 'index' in fvp:
+                        physical_index = int(fvp['index'])
+                    elif port_mapping.is_logical_port(key):
+                        physical_index = port_mapping.get_logical_to_physical(key)[0]
+                    else:
+                        physical_index = -1
+                    port_change_event = PortChangeEvent(key,
+                                                        physical_index,
+                                                        asic_context[port_tbl],
+                                                        PortChangeEvent.PORT_DEL,
+                                                        fvp)
+                    port_change_event_handler(port_change_event)
+
+                if key in ['PortConfigDone', 'PortInitDone']:
+                    continue
+                elif port_mapping.is_logical_port(key):
+                    port_change_event = PortChangeEvent(key,
+                                                        port_mapping.get_logical_to_physical(key)[0],
+                                                        asic_context[port_tbl],
+                                                        PortChangeEvent.PORT_REMOVE,
+                                                        fvp)
                     port_change_event_handler(port_change_event)
             else:
                 logger.log_warning('Invalid DB operation: {}'.format(op))
-
 
 def get_port_mapping():
     """Get port mapping from CONFIG_DB


### PR DESCRIPTION
Signed-off-by: Dante Su <dante.su@broadcom.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Add initial support for CMIS application initialization

#### How I did it

Add CmisManagerTask to handle the per-port CMIS application initialization in parallel

#### How to verify it

1. Bring up Quanta IX9 with the default configuration and CMIS 4.0/5.0 QSFPDD modules
2. Issue 'show logging xcvrd' to check if the application initialization succeeded
3. Issue 'show interfaces transceiver eeprom --dom' to verify both the static and DOM information parsers
4. Issue 'sudo sfputil show eeprom --dom' to verify both the static and DOM information parsers

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
<table>
<tr>
<th>Repo</th>
<th>PR title</th>
<th>State</th>
</tr>
<tr>
<td>SONiC</td>
<td><a href='https://github.com/Azure/SONiC/pull/876'>[sfp-refactoring] Initial support for CMIS application initialization</a></td>
<td><img src="https://img.shields.io/github/pulls/detail/state/Azure/SONiC/876"></td>
</tr>
<tr>
<td>sonic-buildimage</td>
<td><a href='https://github.com/Azure/sonic-buildimage/pull/9157'>[sfp-refactoring] Initial support for CMIS application initialization</a></td>
<td><img src="https://img.shields.io/github/pulls/detail/state/Azure/sonic-buildimage/9157"></td>
</tr>
<tr>
<td>sonic-platform-common</td>
<td><a href='https://github.com/Azure/sonic-platform-common/pull/219'>[sfp-refactoring] Initial support for CMIS application initialization</a></td>
<td><img src="https://img.shields.io/github/pulls/detail/state/Azure/sonic-platform-common/219"></td>
</tr>
<tr>
<td>sonic-platform-daemon</td>
<td><a href='https://github.com/Azure/sonic-platform-daemons/pull/217'>[sfp-refactoring] Initial support for CMIS application initialization</a></td>
<td><img src="https://img.shields.io/github/pulls/detail/state/Azure/sonic-platform-daemons/217"></td>
</tr>
<td>sonic-utilities</td>
<td><a href='https://github.com/Azure/sonic-utilities/pull/1855'>[sfp-refactoring] Initial support for CMIS application initialization</a></td>
<td><img src="https://img.shields.io/github/pulls/detail/state/Azure/sonic-utilities/1855"></td>
</table>

#### A picture of a cute animal (not mandatory but encouraged)

