### PR TITLE
[y_cable] add support for manual/standby mode in xcvrd for muxcable; fix download firmware version retrieval logic while download firmware in progress

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -492,7 +492,7 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
 
             val = mux_table_dict.get("state", None)
 
-            if val in ["active", "auto", "manual"]:
+            if val in ["active", "auto", "manual", "standby"]:
 
                 # import the module and load the port instance
                 physical_port_list = port_mapping.logical_port_name_to_physical_port_list(
@@ -853,7 +853,7 @@ def check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_
         mux_table_dict = dict(fvs)
         if "state" in mux_table_dict:
             val = mux_table_dict.get("state", None)
-            if val in ["active", "auto", "manual"]:
+            if val in ["active", "auto", "manual", "standby"]:
 
                 if mux_tbl.get(asic_index, None) is not None:
                     # fill in the newly found entry


### PR DESCRIPTION
This PR supports manual/standby mode support for mux_cable config in addition to auto/active. 
currently xcvrd would not create entries for mux_cable if the config is manual, and this PR resolves that problem.
Functionally xcvrd will remain as same if we configure it as active/auto/manual

This PR also addresses the problem when there is download firmware operation in progress and streaming_telemetry/CLI 
needs to query the firmware version. In this case we check the status of download_firmware and retreive the last known value for it for the state DB. 
If the download firmware API has failed, we will retrieve the version for cable and just log an error. 

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
Needed for manual/standby config for muxcable operation
<!--
     Describe your changes in detail
-->

#### Motivation and Context
Required for manual/standby config for muxcable operation
Also addresses the problem when there is download firmware operation in progress and ST thread/CLI 
needs to query the firmware version case. In this case we check the status of download_firmware and retreive the last known value for it for the state DB. 

If the download firmware API has failed, we will retrieve the version for cable and just log an error. 
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Ran the changes on an Arista7050cx3 testbed. 
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
