### PR TITLE
Skip loading media config from media_settings.json for fast-reboot

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1464,8 +1464,8 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         # Initialize xcvr table helper
         xcvr_table_helper = XcvrTableHelper()
 
-        output = subprocess.check_output("cat /proc/cmdline", shell=True, universal_newlines=True)
-        if "fast-reboot" in output:
+        output = subprocess.check_output("sonic-db-cli STATE_DB GET 'FAST_REBOOT|system'", shell=True, universal_newlines=True)
+        if "1" in output:
             self.log_info("Skip loading media settings for fast-reboot case")
         else:
             self.load_media_settings()

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -827,6 +827,18 @@ def init_port_sfp_status_tbl(port_mapping, stop_event=threading.Event()):
             else:
                 update_port_transceiver_status_table(logical_port_name, xcvr_table_helper.get_status_tbl(asic_index), sfp_status_helper.SFP_STATUS_INSERTED)
 
+def is_fast_reboot_enabled():
+    fastboot_enabled = False
+    state_db_host =  daemon_base.db_connect("STATE_DB")
+    fastboot_tbl = swsscommon.Table(state_db_host, 'FAST_REBOOT')
+    keys = fastboot_tbl.getKeys()
+
+    if "system" in keys:
+        output = subprocess.check_output('sonic-db-cli STATE_DB get "FAST_REBOOT|system"', shell=True, universal_newlines=True)
+        if "1" in output:
+            fastboot_enabled = True
+
+    return fastboot_enabled
 #
 # Helper classes ===============================================================
 #
@@ -1464,16 +1476,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         # Initialize xcvr table helper
         xcvr_table_helper = XcvrTableHelper()
 
-        fastboot_enabled = False
-        fastboot_tbl = swsscommon.Table(xcvr_table_helper.state_db_host, 'FAST_REBOOT')
-        keys = fastboot_tbl.getKeys()
-
-        if "system" in keys:
-            output = subprocess.check_output('sonic-db-cli STATE_DB get "FAST_REBOOT|system"', shell=True, universal_newlines=True)
-            if "1" in output:
-                fastboot_enabled = True
-
-        if fastboot_enabled == True:
+        if is_fast_reboot_enabled():
             self.log_info("Skip loading media_settings.json in case of fast-reboot")
         else:
             self.load_media_settings()
@@ -1580,7 +1583,6 @@ class XcvrTableHelper:
         self.int_tbl, self.dom_tbl, self.status_tbl, self.app_port_tbl = {}, {}, {}, {}
         self.state_db = {}
         self.namespaces = multi_asic.get_front_end_namespaces()
-        self.state_db_host =  daemon_base.db_connect("STATE_DB")
         for namespace in self.namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
             self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -16,7 +16,8 @@ try:
     import sys
     import threading
     import time
-
+ 
+    from swsssdk import SonicV2Connector
     from sonic_py_common import daemon_base, device_info, logger
     from sonic_py_common import multi_asic
     from swsscommon import swsscommon
@@ -1463,10 +1464,10 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         # Initialize xcvr table helper
         xcvr_table_helper = XcvrTableHelper()
 
-        fastboot_tbl = swsscommon.Table(xcvr_table_helper.state_db_host, 'FAST_REBOOT')
-        keys = fastboot_tbl.getKeys()
+        redisclient = xcvr_table_helper.state_db_host.get_redis_client("STATE_DB")
+        fastboot_enabled = redisclient.get('FAST_REBOOT|system')
 
-        if "system" in keys:
+        if fastboot_enabled == "1":
             self.log_info("Skip loading media_settings.json in case of fast-reboot")
         else:
             self.load_media_settings()
@@ -1573,7 +1574,8 @@ class XcvrTableHelper:
         self.int_tbl, self.dom_tbl, self.status_tbl, self.app_port_tbl = {}, {}, {}, {}
         self.state_db = {}
         self.namespaces = multi_asic.get_front_end_namespaces()
-        self.state_db_host =  daemon_base.db_connect("STATE_DB")
+        self.state_db_host =  SonicV2Connector(use_unix_socket_path=True, namespace='')
+        self.state_db_host.connect("STATE_DB")
         for namespace in self.namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
             self.state_db[asic_id] = daemon_base.db_connect("STATE_DB", namespace)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -16,6 +16,7 @@ try:
     import sys
     import threading
     import time
+    import subprocess
 
     from sonic_py_common import daemon_base, device_info, logger
     from sonic_py_common import multi_asic
@@ -1463,7 +1464,12 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         # Initialize xcvr table helper
         xcvr_table_helper = XcvrTableHelper()
 
-        self.load_media_settings()
+        output = subprocess.check_output("cat /proc/cmdline", shell=True, universal_newlines=True)
+        if "fast-reboot" in output:
+            self.log_info("Skip loading media settings for fast-reboot case")
+        else:
+            self.load_media_settings()
+
         warmstart = swsscommon.WarmStart()
         warmstart.initialize("xcvrd", "pmon")
         warmstart.checkWarmStart("xcvrd", "pmon", False)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Changes to skip loading media_settings.json in case of fast-reboot

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
During fast-reboot, delayed serdes programming done after transceiver detection results in additional interface flap and traffic loss exceeding the required 30s (Issue: https://github.com/Azure/sonic-buildimage/issues/9165). This is addressed by making a backup of media settings from appdb during fast-reboot (https://github.com/Azure/sonic-utilities/pull/1910) and loading this to redis after the switch boots up (https://github.com/Azure/sonic-buildimage/pull/9166). Configuration of serdes triggered by reading media_settings.json file is skipped in this PR

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Verified by running advanced_reboot/test_advanced_reboot.py::test_fast_reboot and ensured that the test passes.
Verified TRANSCEIVER_INFO in stateDB, SERDES objects in asicdb after bootup
Also tested coldboot and ensured no side effects.

#### Additional Information (Optional)
