### PR TITLE
[202012] Skip loading media config from media_settings.json for fast-reboot

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -14,6 +14,7 @@ try:
     import sys
     import threading
     import time
+    import subprocess
 
     from enum import Enum
     from sonic_py_common import daemon_base, device_info, logger
@@ -1339,8 +1340,14 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         state_db_host = daemon_base.db_connect("STATE_DB")
         fastboot_tbl = swsscommon.Table(state_db_host, 'FAST_REBOOT')
         keys = fastboot_tbl.getKeys()
+        fastboot_enabled = False
 
         if "system" in keys:
+            output = subprocess.check_output('sonic-db-cli STATE_DB get "FAST_REBOOT|system"', shell=True, universal_newlines=True)
+            if "1" in output:
+                fastboot_enabled = True
+
+        if fastboot_enabled == True:
             self.log_info("Skip loading media_settings.json in case of fast-reboot")
         else:
             self.load_media_settings()

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1336,7 +1336,15 @@ class DaemonXcvrd(daemon_base.DaemonBase):
             self.dom_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_DOM_SENSOR_TABLE)
             self.status_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
 
-        self.load_media_settings()
+        state_db_host = daemon_base.db_connect("STATE_DB")
+        fastboot_tbl = swsscommon.Table(state_db_host, 'FAST_REBOOT')
+        keys = fastboot_tbl.getKeys()
+
+        if "system" in keys:
+            self.log_info("Skip loading media_settings.json in case of fast-reboot")
+        else:
+            self.load_media_settings()
+
         warmstart = swsscommon.WarmStart()
         warmstart.initialize("xcvrd", "pmon")
         warmstart.checkWarmStart("xcvrd", "pmon", False)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -874,6 +874,18 @@ def init_port_sfp_status_tbl(stop_event=threading.Event()):
             else:
                 update_port_transceiver_status_table(logical_port_name, status_tbl[asic_index], SFP_STATUS_INSERTED)
 
+def is_fast_reboot_enabled():
+    fastboot_enabled = False
+    state_db_host =  daemon_base.db_connect("STATE_DB")
+    fastboot_tbl = swsscommon.Table(state_db_host, 'FAST_REBOOT')
+    keys = fastboot_tbl.getKeys()
+
+    if "system" in keys:
+        output = subprocess.check_output('sonic-db-cli STATE_DB get "FAST_REBOOT|system"', shell=True, universal_newlines=True)
+        if "1" in output:
+            fastboot_enabled = True
+
+    return fastboot_enabled
 #
 # Helper classes ===============================================================
 #
@@ -1337,17 +1349,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
             self.dom_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_DOM_SENSOR_TABLE)
             self.status_tbl[asic_id] = swsscommon.Table(state_db[asic_id], TRANSCEIVER_STATUS_TABLE)
 
-        state_db_host = daemon_base.db_connect("STATE_DB")
-        fastboot_tbl = swsscommon.Table(state_db_host, 'FAST_REBOOT')
-        keys = fastboot_tbl.getKeys()
-        fastboot_enabled = False
-
-        if "system" in keys:
-            output = subprocess.check_output('sonic-db-cli STATE_DB get "FAST_REBOOT|system"', shell=True, universal_newlines=True)
-            if "1" in output:
-                fastboot_enabled = True
-
-        if fastboot_enabled == True:
+        if is_fast_reboot_enabled():
             self.log_info("Skip loading media_settings.json in case of fast-reboot")
         else:
             self.load_media_settings()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Changes to skip loading media_settings.json in case of fast-reboot

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

During fast-reboot, delayed serdes programming done after transceiver detection results in additional interface flap and traffic loss exceeding the required 30s (Issue: Azure/sonic-buildimage#9165). This is addressed by making a backup of media settings from appdb during fast-reboot (Azure/sonic-utilities#1910) and loading this to redis after the switch boots up (Azure/sonic-buildimage#9166). Configuration of serdes triggered by reading media_settings.json file is skipped in this PR

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

Verified by running advanced_reboot/test_advanced_reboot.py::test_fast_reboot and ensured that the test passes.
Verified TRANSCEIVER_INFO in stateDB, SERDES objects in asicdb after bootup
Also tested coldboot and ensured no side effects.