### PR TITLE
Failed to set Pre-emphasis settings with new xcvr package

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -668,11 +668,11 @@ def get_media_settings_key(physical_port, transceiver_dict):
         media_key += '-' + media_compliance_code
         if _wrapper_get_sfp_type(physical_port) == 'QSFP_DD':
             if media_compliance_code == "passive_copper_media_interface":
-                if len(media_len) != 0:
-                    media_key += '-' + media_len + 'M'
+                if media_len != 0:
+                    media_key += '-' + str(media_len) + 'M'
         else:
-            if len(media_len) != 0:
-                media_key += '-' + media_len + 'M'
+            if media_len != 0:
+                media_key += '-' + str(media_len) + 'M'
     else:
         media_key += '-' + '*'
 


### PR DESCRIPTION
#### Description
With new xcvr package, xcvrd fails to set pre-emphasis settings 
#### Motivation and Context
Return types has to be handled properly in xcvrd while handling media settings.

#### How Has This Been Tested?
Tested in DellEMC Z9332f platform.
[cable_len_UT.txt](https://github.com/Azure/sonic-platform-daemons/files/7494484/cable_len_UT.txt)

#### Additional Information (Optional)
