### PR TITLE
[xcvrd] Fix Typo for initialization of post_sfp and deinit for xcvrd

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -508,7 +508,7 @@ def post_port_sfp_dom_info_to_db(is_warm_start, port_mapping, stop_event=threadi
         if asic_index is None:
             helper_logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
             continue
-        rc = post_port_sfp_info_to_db(logical_port_name, port_mapping, xcvr_table_helper.get_int_tbl(asic_index), transceiver_dict, stop_event)
+        rc = post_port_sfp_info_to_db(logical_port_name, port_mapping, xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict, stop_event)
         if rc != SFP_EEPROM_NOT_READY:
             post_port_dom_info_to_db(logical_port_name, port_mapping, xcvr_table_helper.get_dom_tbl(asic_index), stop_event)
             post_port_dom_threshold_info_to_db(logical_port_name, port_mapping, xcvr_table_helper.get_dom_tbl(asic_index), stop_event)
@@ -1522,7 +1522,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
                 helper_logger.log_warning("Got invalid asic index for {}, ignored".format(logical_port_name))
                 continue
 
-            del_port_sfp_dom_info_from_db(logical_port_name, port_mapping_data, xcvr_table_helper.get_int_tbl(asic_index), xcvr_table_helper.get_dom_tbl(asic_index))
+            del_port_sfp_dom_info_from_db(logical_port_name, port_mapping_data, xcvr_table_helper.get_intf_tbl(asic_index), xcvr_table_helper.get_dom_tbl(asic_index))
             delete_port_from_status_table(logical_port_name, xcvr_table_helper.get_status_tbl(asic_index))
 
         if self.y_cable_presence[0] is True:


### PR DESCRIPTION
while doing a submodule update there could be a regression if we init/deinit xcvrd because of typo.

In order to ensure smooth init and deini of xcvrd we need the change. 
```

Nov 16 22:41:41.721557 sonic INFO pmon#/supervisord: xcvrd   File "/usr/local/bin/xcvrd", line 8, in <module>
Nov 16 22:41:41.722365 sonic INFO pmon#/supervisord: xcvrd     sys.exit(main())
Nov 16 22:41:41.722945 sonic INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 1593, in main
Nov 16 22:41:41.723022 sonic INFO pmon#/supervisord: xcvrd     xcvrd.run()
Nov 16 22:41:41.723066 sonic INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 1519, in run
Nov 16 22:41:41.723117 sonic INFO pmon#/supervisord: xcvrd     port_mapping_data, retry_eeprom_set = self.init()
Nov 16 22:41:41.723165 sonic INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 1483, in init
Nov 16 22:41:41.723308 sonic INFO pmon#/supervisord: xcvrd     retry_eeprom_set = post_port_sfp_dom_info_to_db(is_warm_start, port_mapping_data, self.stop_event)
Nov 16 22:41:41.723359 sonic pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 515, in post_port_sfp_dom_info_to_db
Nov 16 22:41:41.723407 sonic pmon#/supervisord: xcvrd     rc = post_port_sfp_info_to_db(logical_port_name, port_mapping, xcvr_table_helper.get_int_tbl(asic_index), transceiver_dict, stop_event)
Nov 16 22:41:41.723455 sonic INFO pmon#/supervisord: xcvrd AttributeError: 'XcvrTableHelper' object has no attribute 'get_int_tbl'
```

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
Fix the typo for xcvrd
<!--
     Describe your changes in detail
-->

#### Motivation and Context
Required for smooth submodule update for xcvrd in master branch
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Ran the changes on Arista7050cx3 testbed. 
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
