### PR TITLE
[SFP-Refactor] Fix vendor  revision key issue

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -126,7 +126,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd._wrapper_is_replaceable', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd._wrapper_get_transceiver_info', MagicMock(return_value={'type': '22.75',
-                                                                                'hardware_rev': '0.5',
+                                                                                'vendor_rev': '0.5',
                                                                                 'serial': '0.7',
                                                                                 'manufacturer': '0.7',
                                                                                 'model': '0.7',
@@ -157,7 +157,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd._wrapper_is_replaceable', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd.xcvr_table_helper', MagicMock())
     @patch('xcvrd.xcvrd._wrapper_get_transceiver_info', MagicMock(return_value={'type': '22.75',
-                                                                                'hardware_rev': '0.5',
+                                                                                'vendor_rev': '0.5',
                                                                                 'serial': '0.7',
                                                                                 'manufacturer': '0.7',
                                                                                 'model': '0.7',

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -301,7 +301,7 @@ def post_port_sfp_info_to_db(logical_port_name, port_mapping, table, transceiver
                 transceiver_dict[physical_port] = port_info_dict
                 fvs = swsscommon.FieldValuePairs(
                     [('type', port_info_dict['type']),
-                     ('hardware_rev', port_info_dict['hardware_rev']),
+                     ('vendor_rev', port_info_dict['vendor_rev']),
                      ('serial', port_info_dict['serial']),
                      ('manufacturer', port_info_dict['manufacturer']),
                      ('model', port_info_dict['model']),


### PR DESCRIPTION
#### Description
With new SFP refactor, hardware_rev is replaced with Vendor_rev key.
Made the changes in alignment with https://github.com/Azure/sonic-mgmt/pull/4816
#### Motivation and Context
xcvrd may crash for platform vendors as hardware_rev key is used in place of vendor_rev key.
#### How Has This Been Tested?
Tested in DellEMC Z9332f platform.
#### Additional Information (Optional)
