### PR TITLE
[ledd] prevent ledd crash on recirc port event

### DIFF
--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -10,7 +10,7 @@ import sys
 
 from sonic_py_common import daemon_base
 from sonic_py_common import multi_asic
-from sonic_py_common.interface import backplane_prefix, inband_prefix
+from sonic_py_common.interface import backplane_prefix, inband_prefix, recirc_prefix
 from swsscommon import swsscommon
 
 #============================= Constants =============================
@@ -96,7 +96,7 @@ class DaemonLedd(daemon_base.DaemonBase):
             fvp_dict = dict(fvp)
 
             if op == "SET" and "oper_status" in fvp_dict:
-                if not key.startswith(backplane_prefix()) and not key.startswith(inband_prefix()):
+                if not key.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
                     self.led_control.port_link_state_change(key, fvp_dict["oper_status"])
         else:
             return 4


### PR DESCRIPTION
#### Description

Prevent ledd crash when an event on recirc port happens

#### Motivation and Context

A recirculation port is not a physical interface tied to a xcvr
Calling the led change event on such a port could lead to a ledd crash

#### How Has This Been Tested?

This change was applied to running switch with its dependency https://github.com/Azure/sonic-buildimage/pull/9471
Verified that ledd runs without crashing

#### Additional Information (Optional)

Cherry-pick required for 202106