### PR TITLE
[voq][pmon]xcvrd process show backtrace in the syslog on  VOQ linecard.

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -341,8 +341,8 @@ class TestXcvrdScript(object):
     @patch('swsscommon.swsscommon.Table')
     def test_get_port_mapping(self, mock_swsscommon_table):
         mock_table = MagicMock()
-        mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
-        mock_table.get = MagicMock(side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
+        mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4', 'Ethernet-IB0'])
+        mock_table.get = MagicMock(side_effect=[(True, (('index', 1), )), (True, (('index', 2), )), (True, (('index', 3), ))])
         mock_swsscommon_table.return_value = mock_table
         port_mapping = get_port_mapping()
         assert port_mapping.logical_port_list.count('Ethernet0')
@@ -355,6 +355,11 @@ class TestXcvrdScript(object):
         assert port_mapping.get_physical_to_logical(2) == ['Ethernet4']
         assert port_mapping.get_logical_to_physical('Ethernet4') == [2]
 
+        assert port_mapping.logical_port_list.count('Ethernet-IB0') == 0
+        assert port_mapping.get_asic_id_for_logical_port('Ethernet-IB0') == None
+        assert port_mapping.get_physical_to_logical(3) == None
+        assert port_mapping.get_logical_to_physical('Ethernet-IB0') == None
+                                        
     @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
     @patch('swsscommon.swsscommon.SubscriberStateTable')
     @patch('swsscommon.swsscommon.Select.select')


### PR DESCRIPTION
#### Description
xcvrd_utilities/port_mapping class returns the port_mapping_data info which includes internal ports. Internal port doesn't have transceiver. It should not be in the list for the xcvrd.
Issue -- https://github.com/Azure/sonic-buildimage/issues/9505

This commit adds code to check and skip internal port if a port is either Backplane or Inband port.  

#### Motivation and Context
This change will skip the internal port so that will trigger the exception in the XCVRD.
 https://github.com/Azure/sonic-buildimage/issues/9505
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Boot up the VOQ linecard.  Verify there is no such exception in syslog 
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
