### PR TITLE
[sonic-platform-daemons] fix dependency issue on azure-pipelines by correcting the  path to gather wheel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -114,7 +114,7 @@ jobs:
         sudo pip3 install sonic_yang_models-1.0-py3-none-any.whl
         sudo pip3 install sonic_config_engine-1.0-py3-none-any.whl
         sudo pip3 install sonic_platform_common-1.0-py3-none-any.whl
-      workingDirectory: $(Pipeline.Workspace)/target/python-wheels/
+      workingDirectory: $(Pipeline.Workspace)/target/python-wheels/buster/
       displayName: 'Install Python dependencies'
 
     - script: |


### PR DESCRIPTION
…

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
During a recent cleanup of py2 wheels the path where dependent wheels are installed has changed.
This PR corrects that issue and gathers the dependency wheels from right path. 
<!--
     Describe your changes in detail
-->

#### Motivation and Context
To make sonic-platform-daemons build pass
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
pipelines need to pass
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
