### PR TITLE
[pmon][xcvrd] Porting PR233 -- xcvrd process show backtrace on the internal port

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -484,8 +484,8 @@ class TestXcvrdScript(object):
     @patch('swsscommon.swsscommon.Table')
     def test_get_port_mapping(self, mock_swsscommon_table):
         mock_table = MagicMock()
-        mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
-        mock_table.get = MagicMock(side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
+        mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4', 'Ethernet-IB0'])
+        mock_table.get = MagicMock(side_effect=[(True, (('index', 1), )), (True, (('index', 2), )), (True, (('index', 3), ))])
         mock_swsscommon_table.return_value = mock_table
         port_mapping = get_port_mapping()
         assert port_mapping.logical_port_list.count('Ethernet0')
@@ -498,7 +498,11 @@ class TestXcvrdScript(object):
         assert port_mapping.get_physical_to_logical(2) == ['Ethernet4']
         assert port_mapping.get_logical_to_physical('Ethernet4') == [2]
 
-
+        assert port_mapping.logical_port_list.count('Ethernet-IB0') == 0
+        assert port_mapping.get_asic_id_for_logical_port('Ethernet-IB0') == None
+        assert port_mapping.get_physical_to_logical(3) == None
+        assert port_mapping.get_logical_to_physical('Ethernet-IB0') == None
+                                        
     @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
     @patch('swsscommon.swsscommon.SubscriberStateTable')
     @patch('swsscommon.swsscommon.Select.select')

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/port_mapping.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/port_mapping.py
@@ -1,5 +1,6 @@
 from sonic_py_common import daemon_base
 from sonic_py_common import multi_asic
+from sonic_py_common.interface import backplane_prefix, inband_prefix, recirc_prefix
 from swsscommon import swsscommon
 
 SELECT_TIMEOUT_MSECS = 1000
@@ -83,6 +84,10 @@ class PortMapping:
             else:
                 return None
 
+def validate_port(port):
+    if port.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
+        return False
+    return True
 
 def subscribe_port_config_change():
     sel = swsscommon.Select()
@@ -117,6 +122,8 @@ def read_port_config_change(asic_context, port_mapping, logger, port_change_even
             (key, op, fvp) = port_tbl.pop()
             if not key:
                 break
+            if not validate_port(key):
+                continue 
             if op == swsscommon.SET_COMMAND:
                 fvp = dict(fvp)
                 if 'index' not in fvp:
@@ -159,6 +166,8 @@ def get_port_mapping():
         config_db = daemon_base.db_connect("CONFIG_DB", namespace=namespace)
         port_table = swsscommon.Table(config_db, swsscommon.CFG_PORT_TABLE_NAME)
         for key in port_table.getKeys():
+            if not validate_port(key):
+                continue
             _, port_config = port_table.get(key)
             port_config_dict = dict(port_config)
             port_change_event = PortChangeEvent(key, port_config_dict['index'], asic_id, PortChangeEvent.PORT_ADD)


### PR DESCRIPTION
#### Description
(Porting PR233 to branch 202111)
xcvrd_utilities/port_mapping class returns the port_mapping_data info which includes internal ports. Internal port doesn't have transceiver. It should not be in the list for the xcvrd.

#### Motivation and Context
(Due to the code base is different, cherry-pick cannot be done) 
This change will skip the internal port so that will trigger the exception in the XCVRD.
#### How Has This Been Tested?
Boot up the VOQ linecard. Verify there is no such exception in syslog
#### Additional Information (Optional)
