### PR TITLE
[ycabled] increase UT coverage of ycabled daemon

### DIFF
--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -1,3 +1,7 @@
+from .mock_swsscommon import Table
+from sonic_platform_base.sfp_base import SfpBase
+from swsscommon import swsscommon
+from sonic_py_common import daemon_base
 from ycable.ycable_utilities.y_cable_helper import *
 from ycable.ycable import *
 import copy
@@ -9,11 +13,6 @@ if sys.version_info >= (3, 3):
     from unittest.mock import MagicMock, patch
 else:
     from mock import MagicMock, patch
-
-from sonic_py_common import daemon_base
-from swsscommon import swsscommon
-from sonic_platform_base.sfp_base import SfpBase
-from .mock_swsscommon import Table
 
 
 daemon_base.db_connect = MagicMock()
@@ -46,27 +45,27 @@ class TestYCableScript(object):
         rc = format_mapping_identifier("ABC        ")
         assert(rc == "abc")
 
-
     def test_y_cable_helper_format_mapping_identifier_no_instance(self):
         rc = format_mapping_identifier(None)
         assert(rc == None)
 
     def test_gather_arg_from_db_and_check_for_type(self):
-        
-        arg_tbl = {"Ethernet0" : (True,{"abc":"x", "def":"y"})}
-        dic = {"key" : "value"}
-        rc = gather_arg_from_db_and_check_for_type(arg_tbl,"Ethernet0","key",dic, "abc")
+
+        arg_tbl = {"Ethernet0": (True, {"abc": "x", "def": "y"})}
+        dic = {"key": "value"}
+        rc = gather_arg_from_db_and_check_for_type(
+            arg_tbl, "Ethernet0", "key", dic, "abc")
 
         assert(rc == ("x", "value", {'abc': 'x', 'def': 'y'}))
 
     def test_gather_arg_from_db_and_check_for_none_type(self):
-        
-        arg_tbl = {"Ethernet0" : (True,{"abcd":"x", "def":"y"})}
-        dic = {"key" : "value"}
-        rc = gather_arg_from_db_and_check_for_type(arg_tbl,"Ethernet0","key",dic, "abc")
+
+        arg_tbl = {"Ethernet0": (True, {"abcd": "x", "def": "y"})}
+        dic = {"key": "value"}
+        rc = gather_arg_from_db_and_check_for_type(
+            arg_tbl, "Ethernet0", "key", dic, "abc")
 
         assert(rc == (None, "value"), {'abcd': 'x', 'def': 'y'})
-
 
     def test_y_cable_wrapper_get_transceiver_info(self):
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
@@ -162,35 +161,35 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('ycable.ycable_utilities.y_cable_helper.get_muxcable_info', MagicMock(return_value={'tor_active': 'self',
-                                                                                             'mux_direction': 'self',
-                                                                                             'manual_switch_count': '7',
-                                                                                             'auto_switch_count': '71',
-                                                                                             'link_status_self': 'up',
-                                                                                             'link_status_peer': 'up',
-                                                                                             'link_status_nic': 'up',
-                                                                                             'nic_lane1_active': 'True',
-                                                                                             'nic_lane2_active': 'True',
-                                                                                             'nic_lane3_active': 'True',
-                                                                                             'nic_lane4_active': 'True',
-                                                                                             'self_eye_height_lane1': '500',
-                                                                                             'self_eye_height_lane2': '510',
-                                                                                             'peer_eye_height_lane1': '520',
-                                                                                             'peer_eye_height_lane2': '530',
-                                                                                             'nic_eye_height_lane1': '742',
-                                                                                             'nic_eye_height_lane2': '750',
-                                                                                             'internal_temperature': '28',
-                                                                                             'internal_voltage': '3.3',
-                                                                                             'nic_temperature': '20',
-                                                                                             'nic_voltage': '2.7',
-                                                                                             'version_nic_active': '1.6MS',
-                                                                                             'version_nic_inactive': '1.7MS',
-                                                                                             'version_nic_next': '1.7MS',
-                                                                                             'version_self_active': '1.6MS',
-                                                                                             'version_self_inactive': '1.7MS',
-                                                                                             'version_self_next': '1.7MS',
-                                                                                             'version_peer_active': '1.6MS',
-                                                                                             'version_peer_inactive': '1.7MS',
-                                                                                             'version_peer_next': '1.7MS'}))
+                                                                                               'mux_direction': 'self',
+                                                                                               'manual_switch_count': '7',
+                                                                                               'auto_switch_count': '71',
+                                                                                               'link_status_self': 'up',
+                                                                                               'link_status_peer': 'up',
+                                                                                               'link_status_nic': 'up',
+                                                                                               'nic_lane1_active': 'True',
+                                                                                               'nic_lane2_active': 'True',
+                                                                                               'nic_lane3_active': 'True',
+                                                                                               'nic_lane4_active': 'True',
+                                                                                               'self_eye_height_lane1': '500',
+                                                                                               'self_eye_height_lane2': '510',
+                                                                                               'peer_eye_height_lane1': '520',
+                                                                                               'peer_eye_height_lane2': '530',
+                                                                                               'nic_eye_height_lane1': '742',
+                                                                                               'nic_eye_height_lane2': '750',
+                                                                                               'internal_temperature': '28',
+                                                                                               'internal_voltage': '3.3',
+                                                                                               'nic_temperature': '20',
+                                                                                               'nic_voltage': '2.7',
+                                                                                               'version_nic_active': '1.6MS',
+                                                                                               'version_nic_inactive': '1.7MS',
+                                                                                               'version_nic_next': '1.7MS',
+                                                                                               'version_self_active': '1.6MS',
+                                                                                               'version_self_inactive': '1.7MS',
+                                                                                               'version_self_next': '1.7MS',
+                                                                                               'version_peer_active': '1.6MS',
+                                                                                               'version_peer_inactive': '1.7MS',
+                                                                                               'version_peer_next': '1.7MS'}))
     def test_post_port_mux_info_to_db(self):
         logical_port_name = "Ethernet0"
         mux_tbl = Table("STATE_DB", "Y_CABLE_INFO_TABLE")
@@ -201,36 +200,36 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('ycable.ycable_utilities.y_cable_helper.get_muxcable_static_info', MagicMock(return_value={'read_side': 'self',
-                                                                                                    'nic_lane1_precursor1': '1',
-                                                                                                    'nic_lane1_precursor2': '-7',
-                                                                                                    'nic_lane1_maincursor': '-1',
-                                                                                                    'nic_lane1_postcursor1': '11',
-                                                                                                    'nic_lane1_postcursor2': '11',
-                                                                                                    'nic_lane2_precursor1': '12',
-                                                                                                    'nic_lane2_precursor2': '7',
-                                                                                                    'nic_lane2_maincursor': '7',
-                                                                                                    'nic_lane2_postcursor1': '7',
-                                                                                                    'nic_lane2_postcursor2': '7',
-                                                                                                    'tor_self_lane1_precursor1': '17',
-                                                                                                    'tor_self_lane1_precursor2': '17',
-                                                                                                    'tor_self_lane1_maincursor': '17',
-                                                                                                    'tor_self_lane1_postcursor1': '17',
-                                                                                                    'tor_self_lane1_postcursor2': '17',
-                                                                                                    'tor_self_lane2_precursor1': '7',
-                                                                                                    'tor_self_lane2_precursor2': '7',
-                                                                                                    'tor_self_lane2_maincursor': '7',
-                                                                                                    'tor_self_lane2_postcursor1': '7',
-                                                                                                    'tor_self_lane2_postcursor2': '7',
-                                                                                                    'tor_peer_lane1_precursor1': '7',
-                                                                                                    'tor_peer_lane1_precursor2': '7',
-                                                                                                    'tor_peer_lane1_maincursor': '17',
-                                                                                                    'tor_peer_lane1_postcursor1': '7',
-                                                                                                    'tor_peer_lane1_postcursor2': '17',
-                                                                                                    'tor_peer_lane2_precursor1': '7',
-                                                                                                    'tor_peer_lane2_precursor2': '7',
-                                                                                                    'tor_peer_lane2_maincursor': '17',
-                                                                                                    'tor_peer_lane2_postcursor1': '7',
-                                                                                                    'tor_peer_lane2_postcursor2': '17'}))
+                                                                                                      'nic_lane1_precursor1': '1',
+                                                                                                      'nic_lane1_precursor2': '-7',
+                                                                                                      'nic_lane1_maincursor': '-1',
+                                                                                                      'nic_lane1_postcursor1': '11',
+                                                                                                      'nic_lane1_postcursor2': '11',
+                                                                                                      'nic_lane2_precursor1': '12',
+                                                                                                      'nic_lane2_precursor2': '7',
+                                                                                                      'nic_lane2_maincursor': '7',
+                                                                                                      'nic_lane2_postcursor1': '7',
+                                                                                                      'nic_lane2_postcursor2': '7',
+                                                                                                      'tor_self_lane1_precursor1': '17',
+                                                                                                      'tor_self_lane1_precursor2': '17',
+                                                                                                      'tor_self_lane1_maincursor': '17',
+                                                                                                      'tor_self_lane1_postcursor1': '17',
+                                                                                                      'tor_self_lane1_postcursor2': '17',
+                                                                                                      'tor_self_lane2_precursor1': '7',
+                                                                                                      'tor_self_lane2_precursor2': '7',
+                                                                                                      'tor_self_lane2_maincursor': '7',
+                                                                                                      'tor_self_lane2_postcursor1': '7',
+                                                                                                      'tor_self_lane2_postcursor2': '7',
+                                                                                                      'tor_peer_lane1_precursor1': '7',
+                                                                                                      'tor_peer_lane1_precursor2': '7',
+                                                                                                      'tor_peer_lane1_maincursor': '17',
+                                                                                                      'tor_peer_lane1_postcursor1': '7',
+                                                                                                      'tor_peer_lane1_postcursor2': '17',
+                                                                                                      'tor_peer_lane2_precursor1': '7',
+                                                                                                      'tor_peer_lane2_precursor2': '7',
+                                                                                                      'tor_peer_lane2_maincursor': '17',
+                                                                                                      'tor_peer_lane2_postcursor1': '7',
+                                                                                                      'tor_peer_lane2_postcursor2': '17'}))
     def test_post_port_mux_static_info_to_db(self):
         logical_port_name = "Ethernet0"
         mux_tbl = Table("STATE_DB", "Y_CABLE_STATIC_INFO_TABLE")
@@ -349,7 +348,8 @@ class TestYCableScript(object):
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as port_instance:
 
             port_instance.get.return_value = "simulated_port"
-            port_instance.toggle_mux_to_tor_a.return_value = Exception(NotImplementedError)
+            port_instance.toggle_mux_to_tor_a.return_value = Exception(
+                NotImplementedError)
 
             rc = y_cable_toggle_mux_torA(1)
 
@@ -380,7 +380,8 @@ class TestYCableScript(object):
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as port_instance:
 
             port_instance.get.return_value = "simulated_port"
-            port_instance.toggle_mux_to_tor_a.return_value = Exception(NotImplementedError)
+            port_instance.toggle_mux_to_tor_a.return_value = Exception(
+                NotImplementedError)
 
             rc = y_cable_toggle_mux_torB(1)
 
@@ -565,7 +566,8 @@ class TestYCableScript(object):
         status = "standby"
 
         test_table = swsscommon.Table(appl_db[asic_index], "XCVRD_TEST_TABLE")
-        update_table_mux_status_for_response_tbl(test_table, status, logical_port_name)
+        update_table_mux_status_for_response_tbl(
+            test_table, status, logical_port_name)
 
         rc = test_table.get(logical_port_name)
 
@@ -582,7 +584,8 @@ class TestYCableScript(object):
         command_table = swsscommon.Table(appl_db[0], "XCVRD_COMMAND_TABLE")
         response_table = swsscommon.Table(appl_db[1], "XCVRD_RESPONSE_TABLE")
 
-        rc = set_result_and_delete_port(result, actual_result, command_table, response_table, port)
+        rc = set_result_and_delete_port(
+            result, actual_result, command_table, response_table, port)
         assert(rc == None)
 
     def test_delete_port_from_y_cable_table(self):
@@ -781,7 +784,8 @@ class TestYCableScript(object):
         statedb_port_tbl[asic_index] = swsscommon.Table(
             appl_db[asic_index], "STATEDB_PORT_TABLE")
 
-        rc = read_y_cable_and_update_statedb_port_tbl(logical_port_name, statedb_port_tbl[asic_index])
+        rc = read_y_cable_and_update_statedb_port_tbl(
+            logical_port_name, statedb_port_tbl[asic_index])
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -802,7 +806,8 @@ class TestYCableScript(object):
                 pass
 
             patched_util.get.return_value = mock_get()
-            rc = read_y_cable_and_update_statedb_port_tbl(logical_port_name, statedb_port_tbl[asic_index])
+            rc = read_y_cable_and_update_statedb_port_tbl(
+                logical_port_name, statedb_port_tbl[asic_index])
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -823,7 +828,8 @@ class TestYCableScript(object):
                 pass
 
             patched_util.get.return_value = mock_get()
-            rc = read_y_cable_and_update_statedb_port_tbl(logical_port_name, statedb_port_tbl[asic_index])
+            rc = read_y_cable_and_update_statedb_port_tbl(
+                logical_port_name, statedb_port_tbl[asic_index])
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -850,7 +856,8 @@ class TestYCableScript(object):
                     pass
 
             patched_util.get.return_value = PortInstanceHelper()
-            rc = read_y_cable_and_update_statedb_port_tbl(logical_port_name, statedb_port_tbl[asic_index])
+            rc = read_y_cable_and_update_statedb_port_tbl(
+                logical_port_name, statedb_port_tbl[asic_index])
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -880,7 +887,8 @@ class TestYCableScript(object):
                     pass
 
             patched_util.get.return_value = PortInstanceHelper()
-            rc = read_y_cable_and_update_statedb_port_tbl(logical_port_name, statedb_port_tbl[asic_index])
+            rc = read_y_cable_and_update_statedb_port_tbl(
+                logical_port_name, statedb_port_tbl[asic_index])
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -908,7 +916,8 @@ class TestYCableScript(object):
                     return 1
 
             patched_util.get.return_value = PortInstanceHelper()
-            rc = read_y_cable_and_update_statedb_port_tbl(logical_port_name, statedb_port_tbl[asic_index])
+            rc = read_y_cable_and_update_statedb_port_tbl(
+                logical_port_name, statedb_port_tbl[asic_index])
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -936,7 +945,8 @@ class TestYCableScript(object):
                     return 2
 
             patched_util.get.return_value = PortInstanceHelper()
-            rc = read_y_cable_and_update_statedb_port_tbl(logical_port_name, statedb_port_tbl[asic_index])
+            rc = read_y_cable_and_update_statedb_port_tbl(
+                logical_port_name, statedb_port_tbl[asic_index])
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -964,7 +974,8 @@ class TestYCableScript(object):
                     return 0
 
             patched_util.get.return_value = PortInstanceHelper()
-            rc = read_y_cable_and_update_statedb_port_tbl(logical_port_name, statedb_port_tbl[asic_index])
+            rc = read_y_cable_and_update_statedb_port_tbl(
+                logical_port_name, statedb_port_tbl[asic_index])
             assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -1170,7 +1181,8 @@ class TestYCableScript(object):
         port_tbl[asic_index].get.return_value = (status, fvs)
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
-            patched_util.get_transceiver_info_dict.return_value = {'manufacturer': 'Microsoft', 'model': 'simulated'}
+            patched_util.get_transceiver_info_dict.return_value = {
+                'manufacturer': 'Microsoft', 'model': 'simulated'}
 
             rc = check_identifier_presence_and_update_mux_table_entry(
                 state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name, y_cable_presence)
@@ -1290,7 +1302,7 @@ class TestYCableScript(object):
         logical_port_name = "Ethernet0"
         status = True
         fvs = [('state', "auto"), ('read_side', 1)]
-        
+
         state_db = {}
         test_db = "TEST_DB"
         y_cable_tbl = {}
@@ -1310,7 +1322,8 @@ class TestYCableScript(object):
         port_tbl[asic_index].get.return_value = (status, fvs)
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
-            patched_util.get_transceiver_info_dict.return_value = {'manufacturer': 'Microsoft', 'model': 'bad_model1'}
+            patched_util.get_transceiver_info_dict.return_value = {
+                'manufacturer': 'Microsoft', 'model': 'bad_model1'}
 
             rc = check_identifier_presence_and_update_mux_table_entry(
                 state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name,  y_cable_presence)
@@ -1325,7 +1338,7 @@ class TestYCableScript(object):
         logical_port_name = "Ethernet0"
         status = True
         fvs = [('state', "auto"), ('read_side', 1)]
-        
+
         state_db = {}
         test_db = "TEST_DB"
         y_cable_tbl = {}
@@ -1365,7 +1378,7 @@ class TestYCableScript(object):
         logical_port_name = "Ethernet0"
         status = True
         fvs = [('state', "auto"), ('read_side', 1)]
-        
+
         state_db = {}
         test_db = "TEST_DB"
         y_cable_tbl = {}
@@ -1385,7 +1398,8 @@ class TestYCableScript(object):
         port_tbl[asic_index].get.return_value = (status, fvs)
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
-            patched_util.get_transceiver_info_dict.return_value = {'manufacturer': 'not_Microsoft', 'model': 'model1'}
+            patched_util.get_transceiver_info_dict.return_value = {
+                'manufacturer': 'not_Microsoft', 'model': 'model1'}
 
             rc = check_identifier_presence_and_update_mux_table_entry(
                 state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name,  y_cable_presence)
@@ -1401,7 +1415,7 @@ class TestYCableScript(object):
         logical_port_name = "Ethernet0"
         status = True
         fvs = [('state', "auto"), ('read_side', 1)]
-        
+
         state_db = {}
         test_db = "TEST_DB"
         y_cable_tbl = {}
@@ -1421,7 +1435,8 @@ class TestYCableScript(object):
         port_tbl[asic_index].get.return_value = (status, fvs)
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
-            patched_util.get_transceiver_info_dict.return_value = {'manufacturer': 'microsoft', 'model': 'simulated'}
+            patched_util.get_transceiver_info_dict.return_value = {
+                'manufacturer': 'microsoft', 'model': 'simulated'}
 
             sys.modules['builtins.getattr'] = MagicMock()
             rc = check_identifier_presence_and_update_mux_table_entry(
@@ -1438,7 +1453,7 @@ class TestYCableScript(object):
         logical_port_name = "Ethernet0"
         status = True
         fvs = [('state', "auto"), ('read_side', 1)]
-        
+
         state_db = {}
         test_db = "TEST_DB"
         y_cable_tbl = {}
@@ -1452,7 +1467,8 @@ class TestYCableScript(object):
         port_tbl[asic_index].get.return_value = (status, fvs)
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
-            patched_util.get_transceiver_info_dict.return_value = {'manufacturer': 'microsoft', 'model': 'simulated'}
+            patched_util.get_transceiver_info_dict.return_value = {
+                'manufacturer': 'microsoft', 'model': 'simulated'}
 
             sys.modules['builtins.getattr'] = MagicMock()
             rc = check_identifier_presence_and_update_mux_table_entry(
@@ -1467,7 +1483,7 @@ class TestYCableScript(object):
         logical_port_name = "Ethernet0"
         status = True
         fvs = [('state', "auto"), ('read_side', 1)]
-        
+
         state_db = {}
         test_db = "TEST_DB"
         y_cable_tbl = {}
@@ -1499,8 +1515,6 @@ class TestYCableScript(object):
         def mock_get_asic_id(mock_logical_port_name):
             return 0
 
-        
-
         y_cable_presence = [True]
 
         mock_table = MagicMock()
@@ -1522,14 +1536,13 @@ class TestYCableScript(object):
         def mock_get_asic_id(mock_logical_port_name):
             return 0
 
-        
-
         y_cable_presence = [True]
         logical_port_dict = {'Ethernet0': '1'}
 
         mock_table = MagicMock()
         mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
-        mock_table.get = MagicMock(side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
+        mock_table.get = MagicMock(
+            side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
         mock_swsscommon_table.return_value = mock_table
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
@@ -1551,14 +1564,13 @@ class TestYCableScript(object):
             def mock_get_asic_id(mock_logical_port_name):
                 return 0
 
-            
-
         y_cable_presence = [True]
         logical_port_dict = {'Ethernet0': '1'}
 
         mock_table = MagicMock()
         mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
-        mock_table.get = MagicMock(side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
+        mock_table.get = MagicMock(
+            side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
         mock_swsscommon_table.return_value = mock_table
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
@@ -1579,14 +1591,13 @@ class TestYCableScript(object):
         def mock_get_asic_id(mock_logical_port_name):
             return 0
 
-        
-
         y_cable_presence = [True]
         logical_port_dict = {'Ethernet0': '2'}
 
         mock_table = MagicMock()
         mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
-        mock_table.get = MagicMock(side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
+        mock_table.get = MagicMock(
+            side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
         mock_swsscommon_table.return_value = mock_table
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
@@ -1604,7 +1615,8 @@ class TestYCableScript(object):
 
         mock_table = MagicMock()
         mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
-        mock_table.get = MagicMock(side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
+        mock_table.get = MagicMock(
+            side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
         mock_swsscommon_table.return_value = mock_table
 
         mock_logical_port_name = [""]
@@ -1616,7 +1628,6 @@ class TestYCableScript(object):
 
             patched_util.logical.return_value = ['Ethernet0', 'Ethernet4']
             patched_util.get_asic_id_for_logical_port.return_value = 0
-        
 
             rc = delete_ports_status_for_y_cable()
 
@@ -1625,7 +1636,7 @@ class TestYCableScript(object):
     def test_check_identifier_presence_and_update_mux_info_entry(self):
         asic_index = 0
         logical_port_name = "Ethernet0"
-        
+
         state_db = {}
         test_db = "TEST_DB"
         mux_tbl = {}
@@ -1662,7 +1673,8 @@ class TestYCableScript(object):
             Table = MagicMock()
             Table.get.return_value = (status, fvs)
 
-            rc = get_firmware_dict(physical_port, port_instance, target, side, mux_info_dict, logical_port_name)
+            rc = get_firmware_dict(
+                physical_port, port_instance, target, side, mux_info_dict, logical_port_name)
 
             assert(mux_info_dict['version_a_active'] == None)
             assert(mux_info_dict['version_a_inactive'] == None)
@@ -1689,9 +1701,11 @@ class TestYCableScript(object):
             fvs = [('state', "auto"), ('read_side', 1)]
             Table = MagicMock()
             Table.get.return_value = (status, fvs)
-            swsscommon.Table.return_value.get.return_value = (False, {"read_side": "2"})
+            swsscommon.Table.return_value.get.return_value = (
+                False, {"read_side": "2"})
 
-            rc = get_firmware_dict(physical_port, port_instance, target, side, mux_info_dict, logical_port_name)
+            rc = get_firmware_dict(
+                physical_port, port_instance, target, side, mux_info_dict, logical_port_name)
 
             assert(mux_info_dict['version_a_active'] == "N/A")
             assert(mux_info_dict['version_a_inactive'] == "N/A")
@@ -1704,7 +1718,8 @@ class TestYCableScript(object):
         port_instance = MagicMock()
         port_instance.FIRMWARE_DOWNLOAD_STATUS_FAILED = -1
         port_instance.download_firmware_status = -1
-        port_instance.get_firmware_version = MagicMock(side_effect=NotImplementedError)
+        port_instance.get_firmware_version = MagicMock(
+            side_effect=NotImplementedError)
 
         physical_port = 1
         target = "simulated_target"
@@ -1721,7 +1736,8 @@ class TestYCableScript(object):
             Table = MagicMock()
             Table.get.return_value = (status, fvs)
 
-            rc = get_firmware_dict(physical_port, port_instance, target, side, mux_info_dict, logical_port_name)
+            rc = get_firmware_dict(
+                physical_port, port_instance, target, side, mux_info_dict, logical_port_name)
 
             assert(mux_info_dict['version_a_active'] == "N/A")
             assert(mux_info_dict['version_a_inactive'] == "N/A")
@@ -1752,7 +1768,8 @@ class TestYCableScript(object):
             Table = MagicMock()
             Table.get.return_value = (status, fvs)
 
-            rc = get_firmware_dict(physical_port, port_instance, target, side, mux_info_dict, logical_port_name)
+            rc = get_firmware_dict(
+                physical_port, port_instance, target, side, mux_info_dict, logical_port_name)
 
             assert(mux_info_dict['version_a_active'] == "2021")
             assert(mux_info_dict['version_a_inactive'] == "2020")
@@ -1762,9 +1779,10 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
     def test_get_muxcable_info(self, platform_sfputil):
         physical_port = 20
-        
+
         logical_port_name = "Ethernet20"
-        swsscommon.Table.return_value.get.return_value = (True, {"read_side": "1"})
+        swsscommon.Table.return_value.get.return_value = (
+            True, {"read_side": "1"})
         platform_sfputil.get_asic_id_for_logical_port = 0
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
@@ -1823,10 +1841,11 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
     def test_get_muxcable_info_peer_side(self, platform_sfputil):
         physical_port = 20
-        
+
         logical_port_name = "Ethernet20"
         platform_sfputil.get_asic_id_for_logical_port = 0
-        swsscommon.Table.return_value.get.return_value = (True, {"read_side": "2"})
+        swsscommon.Table.return_value.get.return_value = (
+            True, {"read_side": "2"})
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -1884,7 +1903,7 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     def test_get_muxcable_info_exceptions(self, platform_sfputil):
         physical_port = 20
-        
+
         logical_port_name = "Ethernet20"
         platform_sfputil.get_asic_id_for_logical_port = 0
 
@@ -1944,10 +1963,11 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     def test_get_muxcable_info_true_exceptions_peer_side(self, platform_sfputil):
         physical_port = 20
-        
+
         logical_port_name = "Ethernet20"
         platform_sfputil.get_asic_id_for_logical_port = 0
-        swsscommon.Table.return_value.get.return_value = (True, {"read_side": "2"})
+        swsscommon.Table.return_value.get.return_value = (
+            True, {"read_side": "2"})
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -2005,7 +2025,7 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     def test_get_muxcable_info_true_exceptions(self, platform_sfputil):
         physical_port = 20
-        
+
         logical_port_name = "Ethernet20"
         platform_sfputil.get_asic_id_for_logical_port = 0
 
@@ -2061,15 +2081,15 @@ class TestYCableScript(object):
                 assert(rc['mux_direction'] == 'unknown')
                 assert(rc['self_eye_height_lane1'] == 'N/A')
 
-
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     def test_get_muxcable_info_exceptions_peer_side(self, platform_sfputil):
         physical_port = 20
-        
+
         logical_port_name = "Ethernet20"
         platform_sfputil.get_asic_id_for_logical_port = 0
-        swsscommon.Table.return_value.get.return_value = (True, {"read_side": "2"})
+        swsscommon.Table.return_value.get.return_value = (
+            True, {"read_side": "2"})
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
 
@@ -2127,11 +2147,12 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     def test_get_muxcable_static_info(self, platform_sfputil):
         physical_port = 0
-        
+
         logical_port_name = "Ethernet0"
 
         platform_sfputil.get_asic_id_for_logical_port = 0
-        swsscommon.Table.return_value.get.return_value = (True, {"read_side": "1"})
+        swsscommon.Table.return_value.get.return_value = (
+            True, {"read_side": "1"})
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
             class PortInstanceHelper():
                 def __init__(self):
@@ -2199,13 +2220,14 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     def test_get_muxcable_static_info_read_side_peer(self, platform_sfputil):
         physical_port = 0
-        
+
         logical_port_name = "Ethernet0"
 
         #swsscommon.Table = MagicMock()
-        #this patch is already done as global instance 
+        # this patch is already done as global instance
         platform_sfputil.get_asic_id_for_logical_port = 0
-        swsscommon.Table.return_value.get.return_value = (True, {"read_side": "2"})
+        swsscommon.Table.return_value.get.return_value = (
+            True, {"read_side": "2"})
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
             class PortInstanceHelper():
                 def __init__(self):
@@ -2268,18 +2290,19 @@ class TestYCableScript(object):
                 assert (rc['tor_peer_lane2_maincursor'] == -17)
                 assert (rc['tor_peer_lane2_postcursor1'] == -17)
                 assert (rc['tor_peer_lane2_postcursor2'] == -17)
-        
+
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     def test_get_muxcable_static_info_read_side_peer_exceptions(self, platform_sfputil):
         physical_port = 0
-        
+
         logical_port_name = "Ethernet0"
 
         #swsscommon.Table = MagicMock()
-        #this patch is already done as global instance 
+        # this patch is already done as global instance
         platform_sfputil.get_asic_id_for_logical_port = 0
-        swsscommon.Table.return_value.get.return_value = (True, {"read_side": "2"})
+        swsscommon.Table.return_value.get.return_value = (
+            True, {"read_side": "2"})
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
             class PortInstanceHelper():
                 def __init__(self):
@@ -2342,7 +2365,8 @@ class TestYCableScript(object):
         mux_info_dict['version_nic_active'] = '0.8'
         mux_info_dict['version_nic_inactive'] = '0.7'
         mux_info_dict['version_nic_next'] = '0.7'
-        rc = set_show_firmware_fields("Ethernet0", mux_info_dict, xcvrd_show_fw_res_tbl)
+        rc = set_show_firmware_fields(
+            "Ethernet0", mux_info_dict, xcvrd_show_fw_res_tbl)
 
         assert(rc == 0)
 
@@ -2357,11 +2381,11 @@ class TestYCableScript(object):
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "enable", {"mode_value":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_no_port(self,port_instance, mock_swsscommon_table):
-        
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "enable", {"mode_value": "0",
+                                                                                                                                 "lane_mask": "0",
+                                                                                                                                 "direction": "0"})))
+    def test_handle_config_prbs_cmd_arg_tbl_notification_no_port(self, port_instance, mock_swsscommon_table):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2372,16 +2396,17 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_prbs": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "enable", {"mode_value":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_no_instance(self,mock_swsscommon_table):
-        
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "enable", {"mode_value": "0",
+                                                                                                                                 "lane_mask": "0",
+                                                                                                                                 "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    def test_handle_config_prbs_cmd_arg_tbl_notification_no_instance(self, mock_swsscommon_table):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2392,19 +2417,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_prbs": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "enable", {"mode_value":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "enable", {"mode_value": "0",
+                                                                                                                                 "lane_mask": "0",
+                                                                                                                                 "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_enable(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_enable(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2422,19 +2448,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_prbs": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "disable", {"mode_value":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "disable", {"mode_value": "0",
+                                                                                                                                  "lane_mask": "0",
+                                                                                                                                  "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_disable(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_disable(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2452,19 +2479,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_prbs": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "reset", {"mode_value":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "reset", {"mode_value": "0",
+                                                                                                                                "lane_mask": "0",
+                                                                                                                                "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_reset(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_reset(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2483,19 +2511,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_prbs": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "anlt", {"mode":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "anlt", {"mode": "0",
+                                                                                                                               "lane_mask": "0",
+                                                                                                                               "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_anlt_enable(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_anlt_enable(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2515,19 +2544,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_prbs": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "anlt", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "anlt", {"modex": "0",
+                                                                                                                               "lane_mask": "0",
+                                                                                                                               "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_anlt_disable(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_anlt_disable(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2547,19 +2577,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_prbs": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"mode":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"mode": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_fec_enable(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_fec_enable(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2579,19 +2610,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_prbs": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_fec_disable(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_fec_disable(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2611,19 +2643,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_prbs": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_else_value(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_prbs_cmd_arg_tbl_notification_else_value(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2643,19 +2676,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_abc": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_loop_cmd_arg_tbl_notification_else_value(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_loop_cmd_arg_tbl_notification_else_value(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2675,19 +2709,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_abc": True}
 
-        rc = handle_config_loop_cmd_arg_tbl_notification(fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
+        rc = handle_config_loop_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_loop_cmd_arg_tbl_notification_else_value(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_loop_cmd_arg_tbl_notification_else_value(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2707,17 +2742,18 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_loop": True}
 
-        rc = handle_config_loop_cmd_arg_tbl_notification(fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
+        rc = handle_config_loop_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    def test_handle_config_loop_cmd_arg_tbl_notification_no_port(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    def test_handle_config_loop_cmd_arg_tbl_notification_no_port(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2737,18 +2773,19 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_loop": True}
 
-        rc = handle_config_loop_cmd_arg_tbl_notification(fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
+        rc = handle_config_loop_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_loop_cmd_arg_tbl_notification_no_instance(self,port_instance, mock_swsscommon_table):
-        
+    def test_handle_config_loop_cmd_arg_tbl_notification_no_instance(self, port_instance, mock_swsscommon_table):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2768,20 +2805,21 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_loop": True}
 
-        rc = handle_config_loop_cmd_arg_tbl_notification(fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
+        rc = handle_config_loop_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "enable", {"enable":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "mode_value":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "enable", {"enable": "0",
+                                                                                                                                 "lane_mask": "0",
+                                                                                                                                 "mode_value": "0",
+                                                                                                                                 "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_loop_cmd_arg_tbl_notification_enable(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_loop_cmd_arg_tbl_notification_enable(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2801,20 +2839,21 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_loop": True}
 
-        rc = handle_config_loop_cmd_arg_tbl_notification(fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
+        rc = handle_config_loop_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "disable", {"disable":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "mode_value":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "disable", {"disable": "0",
+                                                                                                                                  "lane_mask": "0",
+                                                                                                                                  "mode_value": "0",
+                                                                                                                                  "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_loop_cmd_arg_tbl_notification_disable(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_loop_cmd_arg_tbl_notification_disable(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2834,19 +2873,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_loop": True}
 
-        rc = handle_config_loop_cmd_arg_tbl_notification(fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
+        rc = handle_config_loop_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_show_event_cmd_arg_tbl_notification_else_value(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_show_event_cmd_arg_tbl_notification_else_value(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2866,19 +2906,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_loop": True}
 
-        rc = handle_show_event_cmd_arg_tbl_notification(fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
+        rc = handle_show_event_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_show_event_cmd_arg_tbl_notification_get_log(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_show_event_cmd_arg_tbl_notification_get_log(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2892,19 +2933,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"show_event": True}
 
-        rc = handle_show_event_cmd_arg_tbl_notification(fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
+        rc = handle_show_event_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_show_event_cmd_arg_tbl_notification_get_actual_log(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_show_event_cmd_arg_tbl_notification_get_actual_log(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2918,19 +2960,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"show_event": True}
 
-        rc = handle_show_event_cmd_arg_tbl_notification(fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
+        rc = handle_show_event_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_show_event_cmd_arg_tbl_notification_get_no_log(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_show_event_cmd_arg_tbl_notification_get_no_log(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2938,25 +2981,26 @@ class TestYCableScript(object):
         xcvrd_show_event_rsp_tbl = mock_swsscommon_table
         xcvrd_show_event_res_tbl = mock_swsscommon_table
         port_instance = MagicMock()
-        port_instance.get_event_log.return_value = Exception(NotImplementedError)
+        port_instance.get_event_log.return_value = Exception(
+            NotImplementedError)
 
         asic_index = 0
         port = "Ethernet0"
         fvp = {"show_event": True}
 
-        rc = handle_show_event_cmd_arg_tbl_notification(fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
+        rc = handle_show_event_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
         assert(rc == None)
-
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_show_event_cmd_arg_tbl_notification_no_port(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_show_event_cmd_arg_tbl_notification_no_port(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2971,18 +3015,19 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"show_event": True}
 
-        rc = handle_show_event_cmd_arg_tbl_notification(fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
+        rc = handle_show_event_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
-    def test_handle_show_event_cmd_arg_tbl_notification_no_instance(self,port_instance, mock_swsscommon_table):
-        
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    def test_handle_show_event_cmd_arg_tbl_notification_no_instance(self, port_instance, mock_swsscommon_table):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2996,19 +3041,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"show_event": True}
 
-        rc = handle_show_event_cmd_arg_tbl_notification(fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
+        rc = handle_show_event_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_no_status(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_no_status(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3021,15 +3067,16 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"show_event": True}
 
-        rc = handle_get_fec_cmd_arg_tbl_notification(fvp,xcvrd_show_fec_rsp_tbl, xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl, asic_index, port)
+        rc = handle_get_fec_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_fec_rsp_tbl, xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_no_port(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_no_port(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3042,15 +3089,16 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"get_fec": True}
 
-        rc = handle_get_fec_cmd_arg_tbl_notification(fvp,xcvrd_show_fec_rsp_tbl, xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl, asic_index, port)
+        rc = handle_get_fec_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_fec_rsp_tbl, xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_no_instance(self,port_instance, mock_swsscommon_table):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_no_instance(self, port_instance, mock_swsscommon_table):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3064,16 +3112,17 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"get_fec": True}
 
-        rc = handle_get_fec_cmd_arg_tbl_notification(fvp,xcvrd_show_fec_rsp_tbl, xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl, asic_index, port)
+        rc = handle_get_fec_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_fec_rsp_tbl, xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_get_result(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_get_result(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3089,19 +3138,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"get_fec": True}
 
-        rc = handle_get_fec_cmd_arg_tbl_notification(fvp,xcvrd_show_fec_rsp_tbl, xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl, asic_index, port)
+        rc = handle_get_fec_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_fec_rsp_tbl, xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_no_status(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_no_status(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3115,18 +3165,19 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"show_event": True}
 
-        rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+        rc = handle_show_ber_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_no_port(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_no_port(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3140,18 +3191,19 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"get_ber": True}
 
-        rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+        rc = handle_show_ber_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_no_instance(self,port_instance, mock_swsscommon_table):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_no_instance(self, port_instance, mock_swsscommon_table):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3165,20 +3217,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"get_ber": True}
 
-        rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+        rc = handle_show_ber_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == -1)
-
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "ber", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "ber", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_get_ber(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_get_ber(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3193,19 +3245,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"get_ber": True}
 
-        rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+        rc = handle_show_ber_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "eye", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "eye", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_get_eye(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_get_eye(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3220,19 +3273,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"get_ber": True}
 
-        rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+        rc = handle_show_ber_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec_stats", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec_stats", {"modex": "0",
+                                                                                                                                    "lane_mask": "0",
+                                                                                                                                    "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_get_fec_stats(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_get_fec_stats(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3241,25 +3295,26 @@ class TestYCableScript(object):
         xcvrd_show_ber_cmd_sts_tbl = mock_swsscommon_table
         xcvrd_show_ber_res_tbl = mock_swsscommon_table
         port_instance = MagicMock()
-        port_instance.get_fec_stats.return_value = {"100":"200"}
+        port_instance.get_fec_stats.return_value = {"100": "200"}
 
         asic_index = 0
         port = "Ethernet0"
         fvp = {"get_ber": True}
 
-        rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+        rc = handle_show_ber_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "pcs_stats", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "pcs_stats", {"modex": "0",
+                                                                                                                                    "lane_mask": "0",
+                                                                                                                                    "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_get_pcs_stats(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_get_pcs_stats(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3268,25 +3323,26 @@ class TestYCableScript(object):
         xcvrd_show_ber_cmd_sts_tbl = mock_swsscommon_table
         xcvrd_show_ber_res_tbl = mock_swsscommon_table
         port_instance = MagicMock()
-        port_instance.get_pcs_stats.return_value = {"100":"200"}
+        port_instance.get_pcs_stats.return_value = {"100": "200"}
 
         asic_index = 0
         port = "Ethernet0"
         fvp = {"get_ber": True}
 
-        rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+        rc = handle_show_ber_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "cable_alive", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "cable_alive", {"modex": "0",
+                                                                                                                                      "lane_mask": "0",
+                                                                                                                                      "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_get_alive_status(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_get_alive_status(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3301,19 +3357,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"get_ber": True}
 
-        rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+        rc = handle_show_ber_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "debug_dump", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "debug_dump", {"modex": "0",
+                                                                                                                                     "lane_mask": "0",
+                                                                                                                                     "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_get_debug_dump_registers(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_get_debug_dump_registers(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3322,13 +3379,14 @@ class TestYCableScript(object):
         xcvrd_show_ber_cmd_sts_tbl = mock_swsscommon_table
         xcvrd_show_ber_res_tbl = mock_swsscommon_table
         port_instance = MagicMock()
-        port_instance.debug_dump_registers.return_value = {"register1":"100"}
+        port_instance.debug_dump_registers.return_value = {"register1": "100"}
 
         asic_index = 0
         port = "Ethernet0"
         fvp = {"get_ber": True}
 
-        rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+        rc = handle_show_ber_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == None)
     """
 
@@ -3380,12 +3438,12 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_firmware_roll_cmd_arg_tbl_notification_no_port(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_firmware_roll_cmd_arg_tbl_notification_no_port(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3397,16 +3455,17 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"rollback_firmware": "null"}
 
-        rc = handle_config_firmware_roll_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port)
+        rc = handle_config_firmware_roll_cmd_arg_tbl_notification(
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     def test_handle_config_firmware_roll_cmd_arg_tbl_notification_no_instance(self, mock_swsscommon_table):
-        
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3417,19 +3476,19 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"rollback_firmware": "null"}
 
-        rc = handle_config_firmware_roll_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port)
+        rc = handle_config_firmware_roll_cmd_arg_tbl_notification(
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port)
         assert(rc == -1)
-
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_firmware_roll_cmd_arg_tbl_notification_with_instance(self,port_instance, mock_swsscommon_table):
-        
+    def test_handle_config_firmware_roll_cmd_arg_tbl_notification_with_instance(self, port_instance, mock_swsscommon_table):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3441,19 +3500,19 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"rollback_firmware": "null"}
 
-        rc = handle_config_firmware_roll_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port)
+        rc = handle_config_firmware_roll_cmd_arg_tbl_notification(
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port)
         assert(rc == None)
-
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_firmware_roll_cmd_arg_tbl_notification_no_port_and_instance(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_firmware_roll_cmd_arg_tbl_notification_no_port_and_instance(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3465,17 +3524,18 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"rollback_firmware": "null"}
 
-        rc = handle_config_firmware_roll_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port)
+        rc = handle_config_firmware_roll_cmd_arg_tbl_notification(
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     @patch('os.path.isfile', MagicMock(return_value=True))
     def test_handle_config_firmware_down_cmd_arg_tbl_notification_no_port(self, mock_swsscommon_table):
-        
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3487,19 +3547,19 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"download_firmware": "null"}
 
-        rc = handle_config_firmware_down_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port, task_download_firmware_thread)
+        rc = handle_config_firmware_down_cmd_arg_tbl_notification(
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port, task_download_firmware_thread)
         assert(rc == -1)
 
-
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     @patch('os.path.isfile', MagicMock(return_value=True))
-    def test_handle_config_firmware_down_cmd_arg_tbl_notification_else_condition(self,mock_swsscommon_table):
-        
+    def test_handle_config_firmware_down_cmd_arg_tbl_notification_else_condition(self, mock_swsscommon_table):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3511,22 +3571,22 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"downoad_firmware": "null"}
 
-        rc = handle_config_firmware_down_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port, task_download_firmware_thread)
+        rc = handle_config_firmware_down_cmd_arg_tbl_notification(
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port, task_download_firmware_thread)
         assert(rc == None)
-
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
     @patch('threading.Thread')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     @patch('os.path.isfile', MagicMock(return_value=True))
-    def test_handle_config_firmware_down_cmd_arg_tbl_notification_with_instance(self,port_instance, mock_swsscommon_table, port_instance_helper, thread_obj):
-        
+    def test_handle_config_firmware_down_cmd_arg_tbl_notification_with_instance(self, port_instance, mock_swsscommon_table, port_instance_helper, thread_obj):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3538,25 +3598,24 @@ class TestYCableScript(object):
         thread_obj = thread_instance
         port_instance_helper = port_instance
 
-
         asic_index = 0
         task_download_firmware_thread = {}
         port = "Ethernet0"
         fvp = {"download_firmware": "null"}
 
-        rc = handle_config_firmware_down_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port, task_download_firmware_thread)
+        rc = handle_config_firmware_down_cmd_arg_tbl_notification(
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port, task_download_firmware_thread)
         assert(rc == None)
 
-
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     @patch('os.path.isfile', MagicMock(return_value=True))
-    def test_handle_config_firmware_down_cmd_arg_tbl_notification_no_instance(self,mock_swsscommon_table):
-        
+    def test_handle_config_firmware_down_cmd_arg_tbl_notification_no_instance(self, mock_swsscommon_table):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3568,18 +3627,18 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"download_firmware": "null"}
 
-        rc = handle_config_firmware_down_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port, task_download_firmware_thread)
+        rc = handle_config_firmware_down_cmd_arg_tbl_notification(
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port, task_download_firmware_thread)
         assert(rc == -1)
 
-
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     @patch('os.path.isfile', MagicMock(return_value=True))
     def test_handle_config_firmware_acti_cmd_arg_tbl_notification_no_port(self, mock_swsscommon_table):
-        
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3592,19 +3651,19 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"activate_firmware": "null"}
 
-        rc = handle_config_firmware_acti_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_acti_fw_cmd_arg_tbl, asic_index, port)
+        rc = handle_config_firmware_acti_cmd_arg_tbl_notification(
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_acti_fw_cmd_arg_tbl, asic_index, port)
         assert(rc == -1)
 
-
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     @patch('os.path.isfile', MagicMock(return_value=True))
-    def test_handle_config_firmware_acti_cmd_arg_tbl_notification_else_condition(self,mock_swsscommon_table):
-        
+    def test_handle_config_firmware_acti_cmd_arg_tbl_notification_else_condition(self, mock_swsscommon_table):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3617,22 +3676,22 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"down_firmware": "null"}
 
-        rc = handle_config_firmware_acti_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_acti_fw_cmd_arg_tbl, asic_index, port)
+        rc = handle_config_firmware_acti_cmd_arg_tbl_notification(
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_acti_fw_cmd_arg_tbl, asic_index, port)
         assert(rc == None)
-
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "activate_firmware", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "activate_firmware", {"modex": "0",
+                                                                                                                                            "lane_mask": "0",
+                                                                                                                                            "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     @patch('os.path.isfile', MagicMock(return_value=True))
     @patch('time.sleep', MagicMock(return_value=True))
-    def test_handle_config_firmware_acti_cmd_arg_tbl_notification_with_instance(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_firmware_acti_cmd_arg_tbl_notification_with_instance(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3646,25 +3705,24 @@ class TestYCableScript(object):
         thread_obj = thread_instance
         port_instance_helper = port_instance
 
-
         asic_index = 0
         task_download_firmware_thread = {}
         port = "Ethernet0"
         fvp = {"activate_firmware": "null"}
 
-        rc = handle_config_firmware_acti_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_acti_fw_cmd_arg_tbl, asic_index, port)
+        rc = handle_config_firmware_acti_cmd_arg_tbl_notification(
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_acti_fw_cmd_arg_tbl, asic_index, port)
         assert(rc == None)
 
-
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     @patch('os.path.isfile', MagicMock(return_value=True))
-    def test_handle_config_firmware_acti_cmd_arg_tbl_notification_no_instance(self,mock_swsscommon_table):
-        
+    def test_handle_config_firmware_acti_cmd_arg_tbl_notification_no_instance(self, mock_swsscommon_table):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3677,7 +3735,881 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"activate_firmware": "null"}
 
-        rc = handle_config_firmware_acti_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_acti_fw_cmd_arg_tbl, asic_index, port)
+        rc = handle_config_firmware_acti_cmd_arg_tbl_notification(
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_acti_fw_cmd_arg_tbl, asic_index, port)
         assert(rc == -1)
 
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_show_firmware_show_cmd_arg_tbl_notification_no_port(self, mock_swsscommon_table):
 
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_down_fw_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
+        xcvrd_acti_fw_cmd_arg_tbl = mock_swsscommon_table
+        xcvrd_show_fw_res_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"firmware_version": "null"}
+
+        rc = handle_show_firmware_show_cmd_arg_tbl_notification(
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port)
+        assert(rc == -1)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_show_firmware_show_cmd_arg_tbl_notification_else_condition(self, mock_swsscommon_table):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_down_fw_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
+        xcvrd_acti_fw_cmd_arg_tbl = mock_swsscommon_table
+        xcvrd_show_fw_res_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"down_firmware": "null"}
+
+        rc = handle_show_firmware_show_cmd_arg_tbl_notification(
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port)
+        assert(rc == None)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "activate_firmware", {"modex": "0",
+                                                                                                                                            "lane_mask": "0",
+                                                                                                                                            "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    @patch('time.sleep', MagicMock(return_value=True))
+    def test_handle_show_firmware_show_cmd_arg_tbl_notification_with_instance(self, mock_swsscommon_table, platform_sfputil):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_down_fw_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
+        xcvrd_acti_fw_cmd_arg_tbl = mock_swsscommon_table
+        xcvrd_show_fw_res_tbl = mock_swsscommon_table
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        platform_sfputil.get_asic_id_for_logical_port = 0
+        fvp = {"firmware_version": "null"}
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
+            class PortInstanceHelper():
+                def __init__(self):
+                    self.EEPROM_ERROR = -1
+                    self.TARGET_NIC = 1
+                    self.TARGET_TOR_A = 1
+                    self.TARGET_TOR_B = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
+                    self.download_firmware_status = 0
+                    self.SWITCH_COUNT_MANUAL = "manual"
+                    self.SWITCH_COUNT_AUTO = "auto"
+
+                def get_read_side(self):
+                    return 1
+
+                # Defining function without self argument creates an exception,
+                # which is what we want for this test.
+                def get_mux_direction():
+                    pass
+
+            patched_util.get.return_value = PortInstanceHelper()
+            rc = handle_show_firmware_show_cmd_arg_tbl_notification(
+                fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port)
+            assert(rc == None)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_show_firmware_show_cmd_arg_tbl_notification_no_instance(self, mock_swsscommon_table):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_down_fw_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
+        xcvrd_acti_fw_cmd_arg_tbl = mock_swsscommon_table
+        xcvrd_show_fw_res_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"firmware_version": "null"}
+
+        rc = handle_show_firmware_show_cmd_arg_tbl_notification(
+            fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port)
+        assert(rc == -1)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_config_mux_switchmode_cmd_arg_tbl_notification_no_port(self, mock_swsscommon_table):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_config_hwmode_swmode_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_swmode_rsp_tbl = mock_swsscommon_table
+        xcvrd_acti_fw_cmd_arg_tbl = mock_swsscommon_table
+        xcvrd_show_fw_res_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"config": "null"}
+
+        rc = handle_config_mux_switchmode_arg_tbl_notification(
+            fvp, xcvrd_config_hwmode_swmode_cmd_sts_tbl, xcvrd_config_hwmode_swmode_rsp_tbl, asic_index, port)
+        assert(rc == -1)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_config_mux_switchmode_cmd_arg_tbl_notification_else_condition(self, mock_swsscommon_table):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_config_hwmode_swmode_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_swmode_rsp_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"down_firmware": "null"}
+
+        rc = handle_config_mux_switchmode_arg_tbl_notification(
+            fvp, xcvrd_config_hwmode_swmode_cmd_sts_tbl, xcvrd_config_hwmode_swmode_rsp_tbl, asic_index, port)
+        assert(rc == None)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "activate_firmware", {"modex": "0",
+                                                                                                                                            "lane_mask": "0",
+                                                                                                                                            "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    @patch('time.sleep', MagicMock(return_value=True))
+    def test_handle_config_mux_switchmode_cmd_arg_tbl_notification_with_instance_manual(self, mock_swsscommon_table, platform_sfputil):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_config_hwmode_swmode_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_swmode_rsp_tbl = mock_swsscommon_table
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        platform_sfputil.get_asic_id_for_logical_port = 0
+        fvp = {"config": "manual"}
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
+            class PortInstanceHelper():
+                def __init__(self):
+                    self.EEPROM_ERROR = -1
+                    self.TARGET_NIC = 1
+                    self.TARGET_TOR_A = 1
+                    self.TARGET_TOR_B = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
+                    self.download_firmware_status = 0
+                    self.SWITCH_COUNT_MANUAL = "manual"
+                    self.SWITCH_COUNT_AUTO = "auto"
+                    self.SWITCHING_MODE_MANUAL = "manual"
+
+                def get_read_side(self):
+                    return 1
+
+                def set_switching_mode(self, mode):
+                    return True
+
+                # Defining function without self argument creates an exception,
+                # which is what we want for this test.
+                def get_mux_direction():
+                    pass
+
+            patched_util.get.return_value = PortInstanceHelper()
+            rc = handle_config_mux_switchmode_arg_tbl_notification(
+                fvp, xcvrd_config_hwmode_swmode_cmd_sts_tbl, xcvrd_config_hwmode_swmode_rsp_tbl, asic_index, port)
+            assert(rc == None)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_config_mux_switchmode_cmd_arg_tbl_notification_no_instance(self, mock_swsscommon_table):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_config_hwmode_swmode_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_swmode_rsp_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_swmode_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_swmode_rsp_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"config": "manual"}
+
+        rc = handle_config_mux_switchmode_arg_tbl_notification(
+            fvp, xcvrd_config_hwmode_swmode_cmd_sts_tbl, xcvrd_config_hwmode_swmode_rsp_tbl, asic_index, port)
+        assert(rc == -1)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "activate_firmware", {"modex": "0",
+                                                                                                                                            "lane_mask": "0",
+                                                                                                                                            "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    @patch('time.sleep', MagicMock(return_value=True))
+    def test_handle_config_mux_switchmode_cmd_arg_tbl_notification_with_instance_auto(self, mock_swsscommon_table, platform_sfputil):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_config_hwmode_swmode_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_swmode_rsp_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_swmode_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_swmode_rsp_tbl = mock_swsscommon_table
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        platform_sfputil.get_asic_id_for_logical_port = 0
+        fvp = {"config": "auto"}
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
+            class PortInstanceHelper():
+                def __init__(self):
+                    self.EEPROM_ERROR = -1
+                    self.TARGET_NIC = 1
+                    self.TARGET_TOR_A = 1
+                    self.TARGET_TOR_B = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
+                    self.download_firmware_status = 0
+                    self.SWITCH_COUNT_MANUAL = "manual"
+                    self.SWITCH_COUNT_AUTO = "auto"
+                    self.SWITCHING_MODE_MANUAL = "manual"
+                    self.SWITCHING_MODE_AUTO = "auto"
+
+                def get_read_side(self):
+                    return 1
+
+                def set_switching_mode(self, mode):
+                    return True
+
+                # Defining function without self argument creates an exception,
+                # which is what we want for this test.
+                def get_mux_direction():
+                    pass
+
+            patched_util.get.return_value = PortInstanceHelper()
+            rc = handle_config_mux_switchmode_arg_tbl_notification(
+                fvp, xcvrd_config_hwmode_swmode_cmd_sts_tbl, xcvrd_config_hwmode_swmode_rsp_tbl, asic_index, port)
+            assert(rc == None)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_show_mux_switchmode_cmd_arg_tbl_notification_no_port(self, mock_swsscommon_table):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_config_hwmode_swmode_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_swmode_rsp_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_swmode_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_swmode_rsp_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"state": "null"}
+
+        rc = handle_show_hwmode_swmode_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_hwmode_swmode_cmd_sts_tbl, xcvrd_show_hwmode_swmode_rsp_tbl, asic_index, port)
+        assert(rc == -1)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_show_mux_switchmode_cmd_arg_tbl_notification_else_condition(self, mock_swsscommon_table):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_config_hwmode_swmode_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_swmode_rsp_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_swmode_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_swmode_rsp_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"down_firmware": "null"}
+
+        rc = handle_show_hwmode_swmode_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_hwmode_swmode_cmd_sts_tbl, xcvrd_show_hwmode_swmode_rsp_tbl, asic_index, port)
+        assert(rc == None)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "activate_firmware", {"modex": "0",
+                                                                                                                                            "lane_mask": "0",
+                                                                                                                                            "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    @patch('time.sleep', MagicMock(return_value=True))
+    def test_handle_show_mux_switchmode_cmd_arg_tbl_notification_with_instance_manual(self, mock_swsscommon_table, platform_sfputil):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_config_hwmode_swmode_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_swmode_rsp_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_swmode_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_swmode_rsp_tbl = mock_swsscommon_table
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        platform_sfputil.get_asic_id_for_logical_port = 0
+        fvp = {"state": "manual"}
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
+            class PortInstanceHelper():
+                def __init__(self):
+                    self.EEPROM_ERROR = -1
+                    self.TARGET_NIC = 1
+                    self.TARGET_TOR_A = 1
+                    self.TARGET_TOR_B = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
+                    self.download_firmware_status = 0
+                    self.SWITCH_COUNT_MANUAL = "manual"
+                    self.SWITCH_COUNT_AUTO = 0
+                    self.SWITCHING_MODE_MANUAL = 0
+                    self.SWITCHING_MODE_AUTO = 1
+
+                def get_read_side(self):
+                    return 1
+
+                def get_switching_mode(self):
+                    return 0
+
+                # Defining function without self argument creates an exception,
+                # which is what we want for this test.
+                def get_mux_direction():
+                    pass
+
+            patched_util.get.return_value = PortInstanceHelper()
+            rc = handle_show_hwmode_swmode_cmd_arg_tbl_notification(
+                fvp, xcvrd_show_hwmode_swmode_cmd_sts_tbl, xcvrd_show_hwmode_swmode_rsp_tbl, asic_index, port)
+            assert(rc == None)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_show_mux_switchmode_cmd_arg_tbl_notification_no_instance(self, mock_swsscommon_table):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_config_hwmode_swmode_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_swmode_rsp_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_swmode_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_swmode_rsp_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"state": "manual"}
+
+        rc = handle_show_hwmode_swmode_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_hwmode_swmode_cmd_sts_tbl, xcvrd_show_hwmode_swmode_rsp_tbl, asic_index, port)
+        assert(rc == -1)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "activate_firmware", {"modex": "0",
+                                                                                                                                            "lane_mask": "0",
+                                                                                                                                            "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    @patch('time.sleep', MagicMock(return_value=True))
+    def test_handle_show_mux_switchmode_cmd_arg_tbl_notification_with_instance_auto(self, mock_swsscommon_table, platform_sfputil):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_config_hwmode_swmode_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_swmode_rsp_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_swmode_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_swmode_rsp_tbl = mock_swsscommon_table
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        platform_sfputil.get_asic_id_for_logical_port = 0
+        fvp = {"state": "auto"}
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
+            class PortInstanceHelper():
+                def __init__(self):
+                    self.EEPROM_ERROR = -1
+                    self.TARGET_NIC = 1
+                    self.TARGET_TOR_A = 1
+                    self.TARGET_TOR_B = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
+                    self.download_firmware_status = 0
+                    self.SWITCH_COUNT_MANUAL = "manual"
+                    self.SWITCH_COUNT_AUTO = "auto"
+                    self.SWITCHING_MODE_MANUAL = 0
+                    self.SWITCHING_MODE_AUTO = 1
+
+                def get_read_side(self):
+                    return 1
+
+                def get_switching_mode(self):
+                    return 1
+
+                # Defining function without self argument creates an exception,
+                # which is what we want for this test.
+                def get_mux_direction():
+                    pass
+
+            patched_util.get.return_value = PortInstanceHelper()
+            rc = handle_show_hwmode_swmode_cmd_arg_tbl_notification(
+                fvp, xcvrd_show_hwmode_swmode_cmd_sts_tbl, xcvrd_show_hwmode_swmode_rsp_tbl, asic_index, port)
+            assert(rc == None)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_config_mux_state_cmd_arg_tbl_notification_no_port(self, mock_swsscommon_table):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_config_hwmode_state_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_state_rsp_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"config": "active"}
+
+        rc = handle_config_hwmode_state_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, asic_index, port)
+        assert(rc == -1)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_show_mux_switchmode_cmd_arg_tbl_notification_else_condition(self, mock_swsscommon_table):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_config_hwmode_state_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_state_rsp_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"down_firmware": "null"}
+
+        rc = handle_config_hwmode_state_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, asic_index, port)
+        assert(rc == None)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "activate_firmware", {"modex": "0",
+                                                                                                                                            "lane_mask": "0",
+                                                                                                                                            "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    @patch('time.sleep', MagicMock(return_value=True))
+    def test_handle_config_mux_state_cmd_arg_tbl_notification_with_instance_manual(self, mock_swsscommon_table, platform_sfputil):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_config_hwmode_state_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_state_rsp_tbl = mock_swsscommon_table
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        platform_sfputil.get_asic_id_for_logical_port = 0
+        fvp = {"config": "active"}
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
+            class PortInstanceHelper():
+                def __init__(self):
+                    self.EEPROM_ERROR = -1
+                    self.TARGET_NIC = 1
+                    self.TARGET_TOR_A = 1
+                    self.TARGET_TOR_B = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
+                    self.download_firmware_status = 0
+                    self.SWITCH_COUNT_MANUAL = "manual"
+                    self.SWITCH_COUNT_AUTO = 0
+                    self.SWITCHING_MODE_MANUAL = 0
+                    self.SWITCHING_MODE_AUTO = 1
+
+                def get_read_side(self):
+                    return 1
+
+                def get_switching_mode(self):
+                    return 0
+
+                # Defining function without self argument creates an exception,
+                # which is what we want for this test.
+                def get_mux_direction():
+                    pass
+
+            patched_util.get.return_value = PortInstanceHelper()
+            rc = handle_config_hwmode_state_cmd_arg_tbl_notification(
+                fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, asic_index, port)
+            assert(rc == None)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_config_mux_state_cmd_arg_tbl_notification_no_instance(self, mock_swsscommon_table):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_config_hwmode_state_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_state_rsp_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"config": "active"}
+
+        rc = handle_config_hwmode_state_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, asic_index, port)
+        assert(rc == -1)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "activate_firmware", {"modex": "0",
+                                                                                                                                            "lane_mask": "0",
+                                                                                                                                            "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    @patch('time.sleep', MagicMock(return_value=True))
+    def test_handle_config_mux_state_cmd_arg_tbl_notification_with_instance_auto(self, mock_swsscommon_table, platform_sfputil):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_config_hwmode_state_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_state_rsp_tbl = mock_swsscommon_table
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        platform_sfputil.get_asic_id_for_logical_port = 0
+        fvp = {"config": "active"}
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
+            class PortInstanceHelper():
+                def __init__(self):
+                    self.EEPROM_ERROR = -1
+                    self.TARGET_NIC = 1
+                    self.TARGET_TOR_A = 1
+                    self.TARGET_TOR_B = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
+                    self.download_firmware_status = 0
+                    self.SWITCH_COUNT_MANUAL = "manual"
+                    self.SWITCH_COUNT_AUTO = "auto"
+                    self.SWITCHING_MODE_MANUAL = 0
+                    self.SWITCHING_MODE_AUTO = 1
+
+                def get_read_side(self):
+                    return 1
+
+                def get_switching_mode(self):
+                    return 1
+
+                # Defining function without self argument creates an exception,
+                # which is what we want for this test.
+                def get_mux_direction():
+                    pass
+
+            patched_util.get.return_value = PortInstanceHelper()
+            rc = handle_config_hwmode_state_cmd_arg_tbl_notification(
+                fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, asic_index, port)
+            assert(rc == None)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_show_mux_state_cmd_arg_tbl_notification_no_port(self, mock_swsscommon_table):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_show_hwmode_dir_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_dir_rsp_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_dir_res_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"state": "active"}
+
+        rc = handle_show_hwmode_state_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+        assert(rc == -1)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_show_mux_state_cmd_arg_tbl_notification_else_condition(self, mock_swsscommon_table):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_show_hwmode_dir_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_dir_rsp_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_dir_res_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_state_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_state_rsp_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"down_firmware": "null"}
+
+        rc = handle_show_hwmode_state_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+        assert(rc == None)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "activate_firmware", {"modex": "0",
+                                                                                                                                            "lane_mask": "0",
+                                                                                                                                            "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    @patch('time.sleep', MagicMock(return_value=True))
+    def test_handle_show_mux_state_cmd_arg_tbl_notification_with_instance_manual(self, mock_swsscommon_table, platform_sfputil):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_show_hwmode_dir_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_dir_rsp_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_dir_res_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_state_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_state_rsp_tbl = mock_swsscommon_table
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        platform_sfputil.get_asic_id_for_logical_port = 0
+        fvp = {"state": "active"}
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
+            class PortInstanceHelper():
+                def __init__(self):
+                    self.EEPROM_ERROR = -1
+                    self.TARGET_NIC = 1
+                    self.TARGET_TOR_A = 1
+                    self.TARGET_TOR_B = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
+                    self.download_firmware_status = 0
+                    self.SWITCH_COUNT_MANUAL = "manual"
+                    self.SWITCH_COUNT_AUTO = 0
+                    self.SWITCHING_MODE_MANUAL = 0
+                    self.SWITCHING_MODE_AUTO = 1
+
+                def get_read_side(self):
+                    return 1
+
+                def get_mux_direction(self):
+                    return 1
+
+                def get_switching_mode(self):
+                    return 0
+
+            patched_util.get.return_value = PortInstanceHelper()
+            rc = handle_show_hwmode_state_cmd_arg_tbl_notification(
+                fvp, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+            assert(rc == None)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_show_mux_state_cmd_arg_tbl_notification_no_instance(self, mock_swsscommon_table):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_show_hwmode_dir_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_dir_rsp_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_dir_res_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"state": "active"}
+
+        rc = handle_show_hwmode_state_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+        assert(rc == -1)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "activate_firmware", {"modex": "0",
+                                                                                                                                            "lane_mask": "0",
+                                                                                                                                            "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    @patch('time.sleep', MagicMock(return_value=True))
+    def test_handle_show_mux_state_cmd_arg_tbl_notification_with_instance_auto(self, mock_swsscommon_table, platform_sfputil):
+
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_config_hwmode_state_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_state_rsp_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_dir_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_dir_rsp_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_dir_res_tbl = mock_swsscommon_table
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        platform_sfputil.get_asic_id_for_logical_port = 0
+        fvp = {"state": "active"}
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
+            class PortInstanceHelper():
+                def __init__(self):
+                    self.EEPROM_ERROR = -1
+                    self.TARGET_NIC = 1
+                    self.TARGET_TOR_A = 1
+                    self.TARGET_TOR_B = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
+                    self.download_firmware_status = 0
+                    self.SWITCH_COUNT_MANUAL = "manual"
+                    self.SWITCH_COUNT_AUTO = "auto"
+                    self.SWITCHING_MODE_MANUAL = 0
+                    self.SWITCHING_MODE_AUTO = 1
+
+                def get_read_side(self):
+                    return 1
+
+                def get_switching_mode(self):
+                    return 1
+
+                def get_mux_direction(self):
+                    return 2
+
+            patched_util.get.return_value = PortInstanceHelper()
+            rc = handle_show_hwmode_state_cmd_arg_tbl_notification(
+                fvp, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+            assert(rc == None)

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -3330,4 +3330,247 @@ class TestYCableScript(object):
 
         rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == None)
+    """
+
+    def handle_config_firmware_roll_cmd_arg_tbl_notification(fvp, xcvrd_roll_fw_cmd_sts_tbl, xcvrd_roll_fw_rsp_tbl, asic_index, port):
+
+            fvp_dict = dict(fvp)
+
+
+            if "rollback_firmware" in fvp_dict:
+                file_name = fvp_dict["rollback_firmware"]
+                status = 'False'
+
+                if file_name == 'null':
+                    file_full_path = None
+                else:
+                    file_full_path = '/usr/share/sonic/firmware/{}'.format(file_name)
+                    if not os.path.isfile(file_full_path):
+                        helper_logger.log_error("Error: cli cmd mux rollback firmware file does not exist port {} file {}".format(port, file_name))
+                        set_result_and_delete_port('status', status, xcvrd_roll_fw_cmd_sts_tbl[asic_index], xcvrd_roll_fw_rsp_tbl[asic_index], port)
+                        break
+
+
+
+                physical_port = get_ycable_physical_port_from_logical_port(port)
+                if physical_port is None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
+                    # error scenario update table accordingly
+                    helper_logger.log_warning("Error: Could not get physical port for cli cmd mux rollback firmware port {}".format(port))
+                    set_result_and_delete_port('status', status, xcvrd_roll_fw_cmd_sts_tbl[asic_index], xcvrd_roll_fw_rsp_tbl[asic_index], port)
+                    break
+
+                port_instance = get_ycable_port_instance_from_logical_port(port)
+                if port_instance is None or port_instance in port_mapping_error_values:
+                    # error scenario update table accordingly
+                    helper_logger.log_warning("Error: Could not get port instance for cli cmd mux rollback firmware port {}".format(port))
+                    set_result_and_delete_port('status', status, xcvrd_roll_fw_cmd_sts_tbl[asic_index], xcvrd_roll_fw_rsp_tbl[asic_index], port)
+
+                with y_cable_port_locks[physical_port]:
+                    try:
+                        status = port_instance.rollback_firmware(file_full_path)
+                    except Exception as e:
+                        status = -1
+                        helper_logger.log_warning("Failed to execute the rollback_firmware API for port {} due to {}".format(physical_port,repr(e)))
+                set_result_and_delete_port('status', status, xcvrd_roll_fw_cmd_sts_tbl[asic_index], xcvrd_roll_fw_rsp_tbl[asic_index], port)
+            else:
+                helper_logger.log_error("Wrong param for cli cmd mux rollback firmware port {}".format(port))
+                set_result_and_delete_port('status', 'False', xcvrd_roll_fw_cmd_sts_tbl[asic_index], xcvrd_roll_fw_rsp_tbl[asic_index], port)
+    """
+
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
+                                                                                                                                "lane_mask":"0",
+                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    def test_handle_config_firmware_roll_cmd_arg_tbl_notification_no_port(self,port_instance, mock_swsscommon_table, port_instance_helper):
+        
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_down_fw_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
+        port_instance = MagicMock()
+
+        asic_index = 0
+        port = "Ethernet0"
+        fvp = {"rollback_firmware": "null"}
+
+        rc = handle_config_firmware_roll_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port)
+        assert(rc == -1)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
+                                                                                                                                "lane_mask":"0",
+                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    def test_handle_config_firmware_roll_cmd_arg_tbl_notification_no_instance(self, mock_swsscommon_table):
+        
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_down_fw_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        port = "Ethernet0"
+        fvp = {"rollback_firmware": "null"}
+
+        rc = handle_config_firmware_roll_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port)
+        assert(rc == -1)
+
+
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
+                                                                                                                                "lane_mask":"0",
+                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    def test_handle_config_firmware_roll_cmd_arg_tbl_notification_with_instance(self,port_instance, mock_swsscommon_table):
+        
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_down_fw_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
+        port_instance = MagicMock()
+
+        asic_index = 0
+        port = "Ethernet0"
+        fvp = {"rollback_firmware": "null"}
+
+        rc = handle_config_firmware_roll_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port)
+        assert(rc == None)
+
+
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
+                                                                                                                                "lane_mask":"0",
+                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    def test_handle_config_firmware_roll_cmd_arg_tbl_notification_no_port_and_instance(self,port_instance, mock_swsscommon_table, port_instance_helper):
+        
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_down_fw_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
+        port_instance = MagicMock()
+
+        asic_index = 0
+        port = "Ethernet0"
+        fvp = {"rollback_firmware": "null"}
+
+        rc = handle_config_firmware_roll_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port)
+        assert(rc == -1)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
+                                                                                                                                "lane_mask":"0",
+                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_config_firmware_down_cmd_arg_tbl_notification_no_port(self, mock_swsscommon_table):
+        
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_down_fw_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"download_firmware": "null"}
+
+        rc = handle_config_firmware_down_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port, task_download_firmware_thread)
+        assert(rc == -1)
+
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
+                                                                                                                                "lane_mask":"0",
+                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_config_firmware_down_cmd_arg_tbl_notification_else_condition(self,mock_swsscommon_table):
+        
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_down_fw_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"downoad_firmware": "null"}
+
+        rc = handle_config_firmware_down_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port, task_download_firmware_thread)
+        assert(rc == None)
+
+
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
+                                                                                                                                "lane_mask":"0",
+                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    @patch('threading.Thread', MagicMock(return_value=True))
+    @patch('threading.Thread.start', MagicMock(return_value=True))
+    def test_handle_config_firmware_down_cmd_arg_tbl_notification_with_instance(self,port_instance, mock_swsscommon_table, port_instance_helper):
+        
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_down_fw_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
+        port_instance = MagicMock()
+        port_instance.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
+        port_instance.PRBS_DIRECTION_BOTH = 2
+        port_instance.enable_prbs_mode.return_value = True
+        port_instance.disable_prbs_mode.return_value = True
+        port_instance_helper = port_instance
+
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"downoad_firmware": "null"}
+
+        rc = handle_config_firmware_down_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port, task_download_firmware_thread)
+        assert(rc == None)
+
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
+                                                                                                                                "lane_mask":"0",
+                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_config_firmware_down_cmd_arg_tbl_notification_no_instance(self,mock_swsscommon_table):
+        
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_down_fw_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"download_firmware": "null"}
+
+        rc = handle_config_firmware_down_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port, task_download_firmware_thread)
+        assert(rc == -1)
+
 

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -3518,15 +3518,14 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
+    @patch('threading.Thread')
     @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
                                                                                                                                 "lane_mask":"0",
                                                                                                                                 "direction":"0"})))
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     @patch('os.path.isfile', MagicMock(return_value=True))
-    @patch('threading.Thread', MagicMock(return_value=True))
-    @patch('threading.Thread.start', MagicMock(return_value=True))
-    def test_handle_config_firmware_down_cmd_arg_tbl_notification_with_instance(self,port_instance, mock_swsscommon_table, port_instance_helper):
+    def test_handle_config_firmware_down_cmd_arg_tbl_notification_with_instance(self,port_instance, mock_swsscommon_table, port_instance_helper, thread_obj):
         
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
@@ -3534,17 +3533,16 @@ class TestYCableScript(object):
         xcvrd_down_fw_cmd_sts_tbl = mock_swsscommon_table
         xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
         port_instance = MagicMock()
-        port_instance.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
-        port_instance.PRBS_DIRECTION_BOTH = 2
-        port_instance.enable_prbs_mode.return_value = True
-        port_instance.disable_prbs_mode.return_value = True
+        thread_instance = MagicMock()
+        thread_instance.start = MagicMock()
+        thread_obj = thread_instance
         port_instance_helper = port_instance
 
 
         asic_index = 0
         task_download_firmware_thread = {}
         port = "Ethernet0"
-        fvp = {"downoad_firmware": "null"}
+        fvp = {"download_firmware": "null"}
 
         rc = handle_config_firmware_down_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port, task_download_firmware_thread)
         assert(rc == None)
@@ -3571,6 +3569,115 @@ class TestYCableScript(object):
         fvp = {"download_firmware": "null"}
 
         rc = handle_config_firmware_down_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port, task_download_firmware_thread)
+        assert(rc == -1)
+
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
+                                                                                                                                "lane_mask":"0",
+                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_config_firmware_acti_cmd_arg_tbl_notification_no_port(self, mock_swsscommon_table):
+        
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_down_fw_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
+        xcvrd_acti_fw_cmd_arg_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"activate_firmware": "null"}
+
+        rc = handle_config_firmware_acti_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_acti_fw_cmd_arg_tbl, asic_index, port)
+        assert(rc == -1)
+
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
+                                                                                                                                "lane_mask":"0",
+                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_config_firmware_acti_cmd_arg_tbl_notification_else_condition(self,mock_swsscommon_table):
+        
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_down_fw_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
+        xcvrd_acti_fw_cmd_arg_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"down_firmware": "null"}
+
+        rc = handle_config_firmware_acti_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_acti_fw_cmd_arg_tbl, asic_index, port)
+        assert(rc == None)
+
+
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "activate_firmware", {"modex":"0",
+                                                                                                                                "lane_mask":"0",
+                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    @patch('time.sleep', MagicMock(return_value=True))
+    def test_handle_config_firmware_acti_cmd_arg_tbl_notification_with_instance(self,port_instance, mock_swsscommon_table, port_instance_helper):
+        
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_down_fw_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
+        xcvrd_acti_fw_cmd_arg_tbl = mock_swsscommon_table
+        port_instance = MagicMock()
+        port_instance.activate_firmware = MagicMock(return_value=True)
+        thread_instance = MagicMock()
+        thread_instance.start = MagicMock()
+        thread_obj = thread_instance
+        port_instance_helper = port_instance
+
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"activate_firmware": "null"}
+
+        rc = handle_config_firmware_acti_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_acti_fw_cmd_arg_tbl, asic_index, port)
+        assert(rc == None)
+
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
+                                                                                                                                "lane_mask":"0",
+                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    def test_handle_config_firmware_acti_cmd_arg_tbl_notification_no_instance(self,mock_swsscommon_table):
+        
+        mock_table = MagicMock()
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_down_fw_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_down_fw_rsp_tbl = mock_swsscommon_table
+        xcvrd_acti_fw_cmd_arg_tbl = mock_swsscommon_table
+
+        asic_index = 0
+        task_download_firmware_thread = {}
+        port = "Ethernet0"
+        fvp = {"activate_firmware": "null"}
+
+        rc = handle_config_firmware_acti_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, xcvrd_acti_fw_cmd_arg_tbl, asic_index, port)
         assert(rc == -1)
 
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -2758,7 +2758,7 @@ class YCableTableUpdateTask(object):
                     break
 
                 if fvp:
-                    handle_config_firmware_down_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port, task_download_firmware_thread)
+                    handle_config_firmware_down_cmd_arg_tbl_notification(fvp, xcvrd_down_fw_cmd_sts_tbl, xcvrd_down_fw_rsp_tbl, asic_index, port, self.task_download_firmware_thread)
                     break
 
             while True:

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -1960,6 +1960,136 @@ def handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xc
         helper_logger.log_error("Wrong param for cli cmd debug_dump/cli_event/fec_stats API port {}".format(port))
         set_result_and_delete_port('status', status, xcvrd_show_ber_cmd_sts_tbl[asic_index], xcvrd_show_ber_rsp_tbl[asic_index], port)
 
+def handle_config_mux_switchmode_arg_tbl_notification(fvp, xcvrd_config_hwmode_swmode_cmd_sts_tbl, xcvrd_config_hwmode_swmode_rsp_tbl, asic_index, port):
+        fvp_dict = dict(fvp)
+
+        if "config" in fvp_dict:
+            config_mode = str(fvp_dict["config"])
+
+            status = 'False'
+            physical_port = get_ycable_physical_port_from_logical_port(port)
+            if physical_port is None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
+                # error scenario update table accordingly
+                helper_logger.log_error(
+                    "Error: Could not get physical port for cli cmd config mux hwmode setswitchmode Y cable port {}".format(port))
+                set_result_and_delete_port('result', status, xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_swmode_rsp_tbl[asic_index], port)
+                return -1
+
+            port_instance = get_ycable_port_instance_from_logical_port(port)
+            if port_instance is None or port_instance in port_mapping_error_values:
+                # error scenario update table accordingly
+                helper_logger.log_error(
+                    "Error: Could not get port instance for cli cmd config mux hwmode setswitchmode Y cable port {}".format(port))
+                set_result_and_delete_port('result', status, xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_swmode_rsp_tbl[asic_index], port)
+                return -1
+
+            if config_mode == "auto":
+                with y_cable_port_locks[physical_port]:
+                    try:
+                        result = port_instance.set_switching_mode(port_instance.SWITCHING_MODE_AUTO)
+                    except Exception as e:
+                        result = None
+                        helper_logger.log_warning("Failed to execute the set_switching_mode auto for port {} due to {}".format(physical_port,repr(e)))
+
+                if result is None or result == port_instance.EEPROM_ERROR or result < 0:
+
+                    status = 'False'
+                    helper_logger.log_error(
+                        "Error: Could not get read side for cli cmd config mux hwmode setswitchmode logical port {} and physical port {}".format(port, physical_port))
+                    set_result_and_delete_port('result', status, xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_swmode_rsp_tbl[asic_index], port)
+                    return -1
+
+            elif config_mode == "manual":
+                with y_cable_port_locks[physical_port]:
+                    try:
+                        result = port_instance.set_switching_mode(port_instance.SWITCHING_MODE_MANUAL)
+                    except Exception as e:
+                        result = None
+                        helper_logger.log_warning("Failed to execute the set_switching_mode manual for port {} due to {}".format(physical_port,repr(e)))
+                if result is None or result is port_instance.EEPROM_ERROR or result < 0:
+
+                    status = 'False'
+                    helper_logger.log_error(
+                        "Error: Could not get read side for cli cmd config mux hwmode setswitchmode logical port {} and physical port {}".format(port, physical_port))
+                    set_result_and_delete_port('result', status, xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_swmode_rsp_tbl[asic_index], port)
+                    return -1
+            else:
+                helper_logger.log_error(
+                    "Error: Incorrect Config state for cli cmd config mux hwmode setswitchmode logical port {} and physical port {}".format(port, physical_port))
+                set_result_and_delete_port('result', status, xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_swmode_rsp_tbl[asic_index], port)
+                return -1
+
+
+            set_result_and_delete_port('result', result, xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_swmode_rsp_tbl[asic_index], port)
+
+        else:
+            helper_logger.log_error("Error: Incorrect input param for cli cmd config mux hwmode setswitchmode logical port {}".format(port))
+            set_result_and_delete_port('result', 'False', xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_swmode_rsp_tbl[asic_index], port)
+
+def handle_show_firmware_show_cmd_arg_tbl_notification(fvp, xcvrd_show_fw_cmd_sts_tbl, xcvrd_show_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port):
+        fvp_dict = dict(fvp)
+
+        mux_info_dict = {}
+        mux_info_dict['version_self_active'] = 'N/A'
+        mux_info_dict['version_self_inactive'] = 'N/A'
+        mux_info_dict['version_self_next'] = 'N/A'
+        mux_info_dict['version_peer_active'] = 'N/A'
+        mux_info_dict['version_peer_inactive'] = 'N/A'
+        mux_info_dict['version_peer_next'] = 'N/A'
+        mux_info_dict['version_nic_active'] = 'N/A'
+        mux_info_dict['version_nic_inactive'] = 'N/A'
+        mux_info_dict['version_nic_next'] = 'N/A'
+
+        if "firmware_version" in fvp_dict:
+
+
+            status = 'False'
+            physical_port = get_ycable_physical_port_from_logical_port(port)
+            if physical_port is None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
+                # error scenario update table accordingly
+                helper_logger.log_warning("Error: Could not get physical port for cli cmd show firmware port {}".format(port))
+                set_result_and_delete_port('status', status, xcvrd_show_fw_cmd_sts_tbl[asic_index], xcvrd_show_fw_rsp_tbl[asic_index], port)
+                set_show_firmware_fields(port, mux_info_dict, xcvrd_show_fw_res_tbl[asic_index])
+                return -1
+
+            port_instance = get_ycable_port_instance_from_logical_port(port)
+            if port_instance is None or port_instance in port_mapping_error_values:
+                # error scenario update table accordingly
+                helper_logger.log_warning("Error: Could not get port instance for cli cmd show firmware command port {}".format(port))
+                set_show_firmware_fields(port, mux_info_dict, xcvrd_show_fw_res_tbl[asic_index])
+                set_result_and_delete_port('status', status, xcvrd_show_fw_cmd_sts_tbl[asic_index], xcvrd_show_fw_rsp_tbl[asic_index], port)
+                return -1
+
+            with y_cable_port_locks[physical_port]:
+                try:
+                    read_side = port_instance.get_read_side()
+                except Exception as e:
+                    read_side = None
+                    helper_logger.log_warning("Failed to execute the get_read_side API for port {} due to {}".format(physical_port,repr(e)))
+            if read_side is None or read_side is port_instance.EEPROM_ERROR or read_side < 0:
+
+                status = 'False'
+                helper_logger.log_warning("Error: Could not get read side for cli cmd show firmware port {}".format(port))
+                set_show_firmware_fields(port, mux_info_dict, xcvrd_show_fw_res_tbl[asic_index])
+                set_result_and_delete_port('status', status, xcvrd_show_fw_cmd_sts_tbl[asic_index], xcvrd_show_fw_rsp_tbl[asic_index], port)
+                return -1
+
+
+            get_firmware_dict(physical_port, port_instance, port_instance.TARGET_NIC, "nic", mux_info_dict, port)
+            if read_side == port_instance.TARGET_TOR_A:
+                get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_A, "self", mux_info_dict, port)
+                get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_B, "peer", mux_info_dict, port)
+            else:
+                get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_A, "peer", mux_info_dict, port)
+                get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_B, "self", mux_info_dict, port)
+
+            status = 'True'
+            set_show_firmware_fields(port, mux_info_dict, xcvrd_show_fw_res_tbl[asic_index])
+            set_result_and_delete_port('status', status, xcvrd_show_fw_cmd_sts_tbl[asic_index], xcvrd_show_fw_rsp_tbl[asic_index], port)
+        else:
+            helper_logger.log_error("Wrong param for cli cmd show firmware port {}".format(port))
+            set_show_firmware_fields(port, mux_info_dict, xcvrd_show_fw_res_tbl[asic_index])
+            set_result_and_delete_port('status', 'False', xcvrd_show_fw_cmd_sts_tbl[asic_index], xcvrd_show_fw_rsp_tbl[asic_index], port)
 
 def handle_config_firmware_acti_cmd_arg_tbl_notification(fvp, xcvrd_acti_fw_cmd_sts_tbl, xcvrd_acti_fw_rsp_tbl, xcvrd_acti_fw_cmd_arg_tbl, asic_index, port):
 
@@ -2014,6 +2144,215 @@ def handle_config_firmware_acti_cmd_arg_tbl_notification(fvp, xcvrd_acti_fw_cmd_
     else:
         helper_logger.log_error("Wrong param for cli cmd mux activate firmware port {}".format(port))
         set_result_and_delete_port('status', 'False', xcvrd_acti_fw_cmd_sts_tbl[asic_index], xcvrd_acti_fw_rsp_tbl[asic_index], port)
+
+
+def handle_show_hwmode_swmode_cmd_arg_tbl_notification(fvp, xcvrd_show_hwmode_swmode_cmd_sts_tbl,  xcvrd_show_hwmode_swmode_rsp_tbl, asic_index, port):
+
+    fvp_dict = dict(fvp)
+
+    if "state" in fvp_dict:
+
+        state = 'unknown'
+        physical_port = get_ycable_physical_port_from_logical_port(port)
+        if physical_port is None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
+            # error scenario update table accordingly
+            helper_logger.log_error(
+                "Error: Could not get physical port for cli cmd show mux hwmode switchmode Y cable port {}".format(port))
+            state = 'cable not present'
+            set_result_and_delete_port('state', state, xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_swmode_rsp_tbl[asic_index], port)
+            return -1
+
+        port_instance = get_ycable_port_instance_from_logical_port(port)
+        if port_instance is None or port_instance in port_mapping_error_values:
+            # error scenario update table accordingly
+            helper_logger.log_error(
+                "Error: Could not get port instance for cli cmd show mux hwmode switchmode Y cable port {}".format(port))
+            state = 'not Y-Cable port'
+            set_result_and_delete_port('state', state, xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_swmode_rsp_tbl[asic_index], port)
+            return -1
+
+        with y_cable_port_locks[physical_port]:
+            try:
+                result = port_instance.get_switching_mode()
+            except Exception as e:
+                result = None
+                helper_logger.log_warning("Failed to execute the get_switching_mode for port {} due to {}".format(physical_port,repr(e)))
+
+            if result is None or result == port_instance.EEPROM_ERROR or result < 0:
+
+                helper_logger.log_error(
+                    "Error: Could not get read side for cli cmd show mux hwmode switchmode logical port {} and physical port {}".format(port, physical_port))
+                set_result_and_delete_port('state', state, xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_swmode_rsp_tbl[asic_index], port)
+                return -1
+
+        if result == port_instance.SWITCHING_MODE_AUTO:
+            state = "auto"
+        elif result == port_instance.SWITCHING_MODE_MANUAL:
+            state = "manual"
+        else:
+            state = "unknown"
+        set_result_and_delete_port('state', state, xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_swmode_rsp_tbl[asic_index], port)
+
+    else:
+        helper_logger.log_error("Error: Incorrect input param for cli cmd show mux hwmode switchmode logical port {}".format(port))
+        set_result_and_delete_port('state', 'unknown', xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_swmode_rsp_tbl[asic_index], port)
+
+def handle_config_hwmode_state_cmd_arg_tbl_notification(fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, asic_index, port):
+
+    fvp_dict = dict(fvp)
+
+    if "config" in fvp_dict:
+        config_state = str(fvp_dict["config"])
+
+        status = 'False'
+        physical_port = get_ycable_physical_port_from_logical_port(port)
+        if physical_port is None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
+            # error scenario update table accordingly
+            helper_logger.log_error(
+                "Error: Could not get physical port for cli command config mux hwmode state active/standby Y cable port {}".format(port))
+            set_result_and_delete_port('result', status, xcvrd_config_hwmode_state_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_state_rsp_tbl[asic_index], port)
+            return -1
+
+        port_instance = get_ycable_port_instance_from_logical_port(port)
+        if port_instance is None or port_instance in port_mapping_error_values:
+            # error scenario update table accordingly
+            helper_logger.log_error(
+                "Error: Could not get port instance for cli command config mux hwmode state active/standby Y cable port {}".format(port))
+            set_result_and_delete_port('result', status, xcvrd_config_hwmode_state_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_state_rsp_tbl[asic_index], port)
+            return -1
+
+        with y_cable_port_locks[physical_port]:
+            try:
+                read_side = port_instance.get_read_side()
+            except Exception as e:
+                read_side = None
+                helper_logger.log_warning("Failed to execute the get_read_side API for port {} due to {}".format(physical_port,repr(e)))
+
+        if read_side is None or read_side is port_instance.EEPROM_ERROR or read_side < 0:
+
+            status = 'False'
+            helper_logger.log_error(
+                "Error: Could not get read side for cli command config mux hwmode state active/standby Y cable port {}".format(port))
+            set_result_and_delete_port('result', status, xcvrd_config_hwmode_state_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_state_rsp_tbl[asic_index], port)
+            return -1
+
+        if read_side is port_instance.TARGET_TOR_A:
+            if config_state == "active":
+                with y_cable_port_locks[physical_port]:
+                    try:
+                        status = port_instance.toggle_mux_to_tor_a()
+                    except Exception as e:
+                        status = -1
+                        helper_logger.log_warning("Failed to execute the toggle mux ToR A API for port {} due to {}".format(physical_port,repr(e)))
+            elif config_state == "standby":
+                with y_cable_port_locks[physical_port]:
+                    try:
+                        status = port_instance.toggle_mux_to_tor_b()
+                    except Exception as e:
+                        status = -1
+                        helper_logger.log_warning("Failed to execute the toggle mux ToR B API for port {} due to {}".format(physical_port,repr(e)))
+        elif read_side is port_instance.TARGET_TOR_B:
+            if config_state == 'active':
+                with y_cable_port_locks[physical_port]:
+                    try:
+                        status = port_instance.toggle_mux_to_tor_b()
+                    except Exception as e:
+                        status = -1
+                        helper_logger.log_warning("Failed to execute the toggle mux ToR B API for port {} due to {}".format(physical_port,repr(e)))
+            elif config_state == "standby":
+                with y_cable_port_locks[physical_port]:
+                    try:
+                        status = port_instance.toggle_mux_to_tor_a()
+                    except Exception as e:
+                        status = -1
+                        helper_logger.log_warning("Failed to execute the toggle mux ToR A API for port {} due to {}".format(physical_port,repr(e)))
+        else:
+            set_result_and_delete_port('result', status, xcvrd_show_hwmode_state_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_state_rsp_tbl[asic_index], port)
+            helper_logger.log_error(
+                "Error: Could not get valid config read side for cli command config mux hwmode state active/standby Y cable port {}".format(port))
+            return -1
+
+        set_result_and_delete_port('result', status, xcvrd_config_hwmode_state_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_state_rsp_tbl[asic_index], port)
+    else:
+        helper_logger.log_error("Error: Wrong input param for cli command config mux hwmode state active/standby logical port {}".format(port))
+        set_result_and_delete_port('result', 'False', xcvrd_config_hwmode_state_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_state_rsp_tbl[asic_index], port)
+
+def handle_show_hwmode_state_cmd_arg_tbl_notification(fvp, xcvrd_show_hwmode_dir_cmd_sts_tbl,  xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port):
+    fvp_dict = dict(fvp)
+
+    if "state" in fvp_dict:
+
+        presence = "False"
+
+        physical_port = get_ycable_physical_port_from_logical_port(port)
+        if physical_port is not None and y_cable_wrapper_get_presence(physical_port):
+            presence = "True"
+
+        fvs_log = swsscommon.FieldValuePairs([(str("presence"), str(presence))])
+        xcvrd_show_hwmode_dir_res_tbl[asic_index].set(port, fvs_log)
+
+        if physical_port is None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
+            state = 'unknown'
+            # error scenario update table accordingly
+            helper_logger.log_error(
+                "Error: Could not get physical port for cli command show mux hwmode muxdirection Y cable port {}".format(port))
+            set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
+            return -1
+
+
+        port_instance = get_ycable_port_instance_from_logical_port(port)
+        if port_instance is None or port_instance in port_mapping_error_values:
+            # error scenario update table accordingly
+            state = 'not Y-Cable port'
+            helper_logger.log_error(
+                "Error: Could not get port instance for cli command show mux hwmode muxdirection Y cable port {}".format(port))
+            set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
+            return -1
+
+        with y_cable_port_locks[physical_port]:
+            try:
+                read_side = port_instance.get_read_side()
+            except Exception as e:
+                read_side = None
+                helper_logger.log_warning("Failed to execute the get_read_side API for port {} due to {}".format(physical_port,repr(e)))
+
+        if read_side is None or read_side == port_instance.EEPROM_ERROR or read_side < 0:
+
+            state = 'unknown'
+            helper_logger.log_warning(
+                "Error: Could not get read side for cli command show mux hwmode muxdirection logical port {} and physical port {}".format(port, physical_port))
+            set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
+            return -1
+
+        with y_cable_port_locks[physical_port]:
+            try:
+                active_side = port_instance.get_mux_direction()
+            except Exception as e:
+                active_side = None
+                helper_logger.log_warning("Failed to execute the get_mux_direction API for port {} due to {}".format(physical_port,repr(e)))
+
+        if active_side is None or active_side == port_instance.EEPROM_ERROR or active_side < 0:
+
+            state = 'unknown'
+            helper_logger.log_warning("Error: Could not get active side for cli command show mux hwmode muxdirection logical port {} and physical port {}".format(port, physical_port))
+
+            set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
+            return -1
+
+        if read_side == active_side and (active_side == 1 or active_side == 2):
+            state = 'active'
+        elif read_side != active_side and (active_side == 1 or active_side == 2):
+            state = 'standby'
+        else:
+            state = 'unknown'
+            helper_logger.log_warning("Error: Could not get valid state for cli command show mux hwmode muxdirection logical port {} and physical port {}".format(port, physical_port))
+            set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
+            return -1
+
+        set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
+    else:
+        helper_logger.log_warning("Error: Wrong input param for cli command show mux hwmode muxdirection logical port {}".format(port))
+        set_result_and_delete_port('state', 'unknown', xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
 
 # Thread wrapper class to update y_cable status periodically
 class YCableTableUpdateTask(object):
@@ -2375,82 +2714,8 @@ class YCableTableUpdateTask(object):
                     break
 
                 if fvp:
-
-                    fvp_dict = dict(fvp)
-
-                    if "state" in fvp_dict:
-
-                        presence = "False"
-
-                        physical_port = get_ycable_physical_port_from_logical_port(port)
-                        if physical_port is not None and y_cable_wrapper_get_presence(physical_port):
-                            presence = "True"
-
-                        fvs_log = swsscommon.FieldValuePairs([(str("presence"), str(presence))])
-                        xcvrd_show_hwmode_dir_res_tbl[asic_index].set(port, fvs_log)
-
-                        if physical_port is None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
-                            state = 'unknown'
-                            # error scenario update table accordingly
-                            helper_logger.log_error(
-                                "Error: Could not get physical port for cli command show mux hwmode muxdirection Y cable port {}".format(port))
-                            set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
-                            break
-
-
-                        port_instance = get_ycable_port_instance_from_logical_port(port)
-                        if port_instance is None or port_instance in port_mapping_error_values:
-                            # error scenario update table accordingly
-                            state = 'not Y-Cable port'
-                            helper_logger.log_error(
-                                "Error: Could not get port instance for cli command show mux hwmode muxdirection Y cable port {}".format(port))
-                            set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
-                            break
-
-                        with y_cable_port_locks[physical_port]:
-                            try:
-                                read_side = port_instance.get_read_side()
-                            except Exception as e:
-                                read_side = None
-                                helper_logger.log_warning("Failed to execute the get_read_side API for port {} due to {}".format(physical_port,repr(e)))
-
-                        if read_side is None or read_side == port_instance.EEPROM_ERROR or read_side < 0:
-
-                            state = 'unknown'
-                            helper_logger.log_warning(
-                                "Error: Could not get read side for cli command show mux hwmode muxdirection logical port {} and physical port {}".format(port, physical_port))
-                            set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
-                            break
-
-                        with y_cable_port_locks[physical_port]:
-                            try:
-                                active_side = port_instance.get_mux_direction()
-                            except Exception as e:
-                                active_side = None
-                                helper_logger.log_warning("Failed to execute the get_mux_direction API for port {} due to {}".format(physical_port,repr(e)))
-
-                        if active_side is None or active_side == port_instance.EEPROM_ERROR or active_side < 0:
-
-                            state = 'unknown'
-                            helper_logger.log_warning("Error: Could not get active side for cli command show mux hwmode muxdirection logical port {} and physical port {}".format(port, physical_port))
-
-                            set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
-                            break
-
-                        if read_side == active_side and (active_side == 1 or active_side == 2):
-                            state = 'active'
-                        elif read_side != active_side and (active_side == 1 or active_side == 2):
-                            state = 'standby'
-                        else:
-                            state = 'unknown'
-                            helper_logger.log_warning("Error: Could not get valid state for cli command show mux hwmode muxdirection logical port {} and physical port {}".format(port, physical_port))
-                            set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
-                            break
-
-                        set_result_and_delete_port('state', state, xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
-                    else:
-                        helper_logger.log_warning("Error: Wrong input param for cli command show mux hwmode muxdirection logical port {}".format(port))
-                        set_result_and_delete_port('state', 'unknown', xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
+                    handle_show_hwmode_state_cmd_arg_tbl_notification(fvp, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+                    break
 
             while True:
                 # Config muxcable hwmode state <active/standby> <port>
@@ -2460,84 +2725,9 @@ class YCableTableUpdateTask(object):
                     break
 
                 if fvp:
+                    handle_config_hwmode_state_cmd_arg_tbl_notification(fvp, xcvrd_config_hwmode_state_cmd_sts_tbl,  xcvrd_config_hwmode_state_rsp_tbl, asic_index, port)
+                    break
 
-                    fvp_dict = dict(fvp)
-
-                    if "config" in fvp_dict:
-                        config_state = str(fvp_dict["config"])
-
-                        status = 'False'
-                        physical_port = get_ycable_physical_port_from_logical_port(port)
-                        if physical_port is None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
-                            # error scenario update table accordingly
-                            helper_logger.log_error(
-                                "Error: Could not get physical port for cli command config mux hwmode state active/standby Y cable port {}".format(port))
-                            set_result_and_delete_port('result', status, xcvrd_config_hwmode_state_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_state_rsp_tbl[asic_index], port)
-                            break
-
-                        port_instance = get_ycable_port_instance_from_logical_port(port)
-                        if port_instance is None or port_instance in port_mapping_error_values:
-                            # error scenario update table accordingly
-                            helper_logger.log_error(
-                                "Error: Could not get port instance for cli command config mux hwmode state active/standby Y cable port {}".format(port))
-                            set_result_and_delete_port('result', status, xcvrd_config_hwmode_state_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_state_rsp_tbl[asic_index], port)
-                            break
-
-                        with y_cable_port_locks[physical_port]:
-                            try:
-                                read_side = port_instance.get_read_side()
-                            except Exception as e:
-                                read_side = None
-                                helper_logger.log_warning("Failed to execute the get_read_side API for port {} due to {}".format(physical_port,repr(e)))
-
-                        if read_side is None or read_side is port_instance.EEPROM_ERROR or read_side < 0:
-
-                            status = 'False'
-                            helper_logger.log_error(
-                                "Error: Could not get read side for cli command config mux hwmode state active/standby Y cable port {}".format(port))
-                            set_result_and_delete_port('result', status, xcvrd_config_hwmode_state_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_state_rsp_tbl[asic_index], port)
-                            break
-
-                        if read_side is port_instance.TARGET_TOR_A:
-                            if config_state == "active":
-                                with y_cable_port_locks[physical_port]:
-                                    try:
-                                        status = port_instance.toggle_mux_to_tor_a()
-                                    except Exception as e:
-                                        status = -1
-                                        helper_logger.log_warning("Failed to execute the toggle mux ToR A API for port {} due to {}".format(physical_port,repr(e)))
-                            elif config_state == "standby":
-                                with y_cable_port_locks[physical_port]:
-                                    try:
-                                        status = port_instance.toggle_mux_to_tor_b()
-                                    except Exception as e:
-                                        status = -1
-                                        helper_logger.log_warning("Failed to execute the toggle mux ToR B API for port {} due to {}".format(physical_port,repr(e)))
-                        elif read_side is port_instance.TARGET_TOR_B:
-                            if config_state == 'active':
-                                with y_cable_port_locks[physical_port]:
-                                    try:
-                                        status = port_instance.toggle_mux_to_tor_b()
-                                    except Exception as e:
-                                        status = -1
-                                        helper_logger.log_warning("Failed to execute the toggle mux ToR B API for port {} due to {}".format(physical_port,repr(e)))
-                            elif config_state == "standby":
-                                with y_cable_port_locks[physical_port]:
-                                    try:
-                                        status = port_instance.toggle_mux_to_tor_a()
-                                    except Exception as e:
-                                        status = -1
-                                        helper_logger.log_warning("Failed to execute the toggle mux ToR A API for port {} due to {}".format(physical_port,repr(e)))
-                        else:
-                            set_result_and_delete_port('result', status, xcvrd_show_hwmode_state_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_state_rsp_tbl[asic_index], port)
-                            helper_logger.log_error(
-                                "Error: Could not get valid config read side for cli command config mux hwmode state active/standby Y cable port {}".format(port))
-                            break
-
-                        set_result_and_delete_port('result', status, xcvrd_config_hwmode_state_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_state_rsp_tbl[asic_index], port)
-                    else:
-                        helper_logger.log_error("Error: Wrong input param for cli command config mux hwmode state active/standby logical port {}".format(port))
-                        set_result_and_delete_port('result', 'False', xcvrd_show_hwmode_state_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_state_rsp_tbl[asic_index], port)
 
             while True:
                 # Config muxcable hwmode setswitchmode <auto/manual> <port>
@@ -2547,57 +2737,8 @@ class YCableTableUpdateTask(object):
                     break
 
                 if fvp:
-
-                    fvp_dict = dict(fvp)
-
-                    if "state" in fvp_dict:
-
-                        state = 'unknown'
-                        physical_port = get_ycable_physical_port_from_logical_port(port)
-                        if physical_port is None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
-                            # error scenario update table accordingly
-                            helper_logger.log_error(
-                                "Error: Could not get physical port for cli cmd show mux hwmode switchmode Y cable port {}".format(port))
-                            state = 'cable not present'
-                            set_result_and_delete_port('state', state, xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_swmode_rsp_tbl[asic_index], port)
-                            break
-
-                        port_instance = get_ycable_port_instance_from_logical_port(port)
-                        if port_instance is None or port_instance in port_mapping_error_values:
-                            # error scenario update table accordingly
-                            helper_logger.log_error(
-                                "Error: Could not get port instance for cli cmd show mux hwmode switchmode Y cable port {}".format(port))
-                            state = 'not Y-Cable port'
-                            set_result_and_delete_port('state', state, xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_swmode_rsp_tbl[asic_index], port)
-                            break
-
-                        with y_cable_port_locks[physical_port]:
-                            try:
-                                result = port_instance.get_switching_mode()
-                            except Exception as e:
-                                result = None
-                                helper_logger.log_warning("Failed to execute the get_switching_mode for port {} due to {}".format(physical_port,repr(e)))
-
-                            if result is None or result == port_instance.EEPROM_ERROR or result < 0:
-
-                                helper_logger.log_error(
-                                    "Error: Could not get read side for cli cmd show mux hwmode switchmode logical port {} and physical port {}".format(port, physical_port))
-                                set_result_and_delete_port('state', state, xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_swmode_rsp_tbl[asic_index], port)
-                                break
-
-                        if result == port_instance.SWITCHING_MODE_AUTO:
-                            state = "auto"
-                        elif result == port_instance.SWITCHING_MODE_MANUAL:
-                            state = "manual"
-                        else:
-                            state = "unknown"
-
-                        set_result_and_delete_port('state', state, xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_swmode_rsp_tbl[asic_index], port)
-                    else:
-                        helper_logger.log_error("Error: Incorrect input param for cli cmd show mux hwmode switchmode logical port {}".format(port))
-                        set_result_and_delete_port('state', 'unknown', xcvrd_show_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_swmode_rsp_tbl[asic_index], port)
-
-
+                    handle_show_hwmode_swmode_cmd_arg_tbl_notification(fvp, xcvrd_show_hwmode_swmode_cmd_sts_tbl, xcvrd_show_hwmode_swmode_rsp_tbl, asic_index, port)
+                    break
 
             while True:
                 # Config muxcable hwmode setswitchmode <auto/manual> <port>
@@ -2607,73 +2748,8 @@ class YCableTableUpdateTask(object):
                     break
 
                 if fvp:
-
-                    fvp_dict = dict(fvp)
-
-                    if "config" in fvp_dict:
-                        config_mode = str(fvp_dict["config"])
-
-                        status = 'False'
-                        physical_port = get_ycable_physical_port_from_logical_port(port)
-                        if physical_port is None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
-                            # error scenario update table accordingly
-                            helper_logger.log_error(
-                                "Error: Could not get physical port for cli cmd config mux hwmode setswitchmode Y cable port {}".format(port))
-                            set_result_and_delete_port('result', status, xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_swmode_rsp_tbl[asic_index], port)
-                            break
-
-                        port_instance = get_ycable_port_instance_from_logical_port(port)
-                        if port_instance is None or port_instance in port_mapping_error_values:
-                            # error scenario update table accordingly
-                            helper_logger.log_error(
-                                "Error: Could not get port instance for cli cmd config mux hwmode setswitchmode Y cable port {}".format(port))
-                            set_result_and_delete_port('result', status, xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_swmode_rsp_tbl[asic_index], port)
-                            break
-
-                        if config_mode == "auto":
-                            with y_cable_port_locks[physical_port]:
-                                try:
-                                    result = port_instance.set_switching_mode(port_instance.SWITCHING_MODE_AUTO)
-                                except Exception as e:
-                                    result = None
-                                    helper_logger.log_warning("Failed to execute the set_switching_mode auto for port {} due to {}".format(physical_port,repr(e)))
-
-                            if result is None or result == port_instance.EEPROM_ERROR or result < 0:
-
-                                status = 'False'
-                                helper_logger.log_error(
-                                    "Error: Could not get read side for cli cmd config mux hwmode setswitchmode logical port {} and physical port {}".format(port, physical_port))
-                                set_result_and_delete_port('result', status, xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_swmode_rsp_tbl[asic_index], port)
-                                break
-
-                        elif config_mode == "manual":
-                            with y_cable_port_locks[physical_port]:
-                                try:
-                                    result = port_instance.set_switching_mode(port_instance.SWITCHING_MODE_MANUAL)
-                                except Exception as e:
-                                    result = None
-                                    helper_logger.log_warning("Failed to execute the set_switching_mode manual for port {} due to {}".format(physical_port,repr(e)))
-                            if result is None or result is port_instance.EEPROM_ERROR or result < 0:
-
-                                status = 'False'
-                                helper_logger.log_error(
-                                    "Error: Could not get read side for cli cmd config mux hwmode setswitchmode logical port {} and physical port {}".format(port, physical_port))
-                                set_result_and_delete_port('result', status, xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_swmode_rsp_tbl[asic_index], port)
-                                break
-                        else:
-                            helper_logger.log_error(
-                                "Error: Incorrect Config state for cli cmd config mux hwmode setswitchmode logical port {} and physical port {}".format(port, physical_port))
-                            set_result_and_delete_port('result', status, xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_swmode_rsp_tbl[asic_index], port)
-                            break
-
-
-                        set_result_and_delete_port('result', result, xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_swmode_rsp_tbl[asic_index], port)
-
-                    else:
-                        helper_logger.log_error("Error: Incorrect input param for cli cmd config mux hwmode setswitchmode logical port {}".format(port))
-                        set_result_and_delete_port('result', 'False', xcvrd_config_hwmode_swmode_cmd_sts_tbl[asic_index], xcvrd_config_hwmode_swmode_rsp_tbl[asic_index], port)
-
-
+                   handle_config_mux_switchmode_arg_tbl_notification(fvp, xcvrd_config_hwmode_swmode_cmd_sts_tbl, xcvrd_config_hwmode_swmode_rsp_tbl, asic_index, port)
+                   break
 
             while True:
                 (port, op, fvp) = xcvrd_down_fw_cmd_tbl[asic_index].pop()
@@ -2692,72 +2768,8 @@ class YCableTableUpdateTask(object):
                     break
 
                 if fvp:
-
-                    fvp_dict = dict(fvp)
-
-                    mux_info_dict = {}
-                    mux_info_dict['version_self_active'] = 'N/A'
-                    mux_info_dict['version_self_inactive'] = 'N/A'
-                    mux_info_dict['version_self_next'] = 'N/A'
-                    mux_info_dict['version_peer_active'] = 'N/A'
-                    mux_info_dict['version_peer_inactive'] = 'N/A'
-                    mux_info_dict['version_peer_next'] = 'N/A'
-                    mux_info_dict['version_nic_active'] = 'N/A'
-                    mux_info_dict['version_nic_inactive'] = 'N/A'
-                    mux_info_dict['version_nic_next'] = 'N/A'
-
-                    if "firmware_version" in fvp_dict:
-
-
-                        status = 'False'
-                        physical_port = get_ycable_physical_port_from_logical_port(port)
-                        if physical_port is None or physical_port == PHYSICAL_PORT_MAPPING_ERROR:
-                            # error scenario update table accordingly
-                            helper_logger.log_warning("Error: Could not get physical port for cli cmd show firmware port {}".format(port))
-                            set_result_and_delete_port('status', status, xcvrd_show_fw_cmd_sts_tbl[asic_index], xcvrd_show_fw_rsp_tbl[asic_index], port)
-                            set_show_firmware_fields(port, mux_info_dict, xcvrd_show_fw_res_tbl[asic_index])
-                            break
-
-                        port_instance = get_ycable_port_instance_from_logical_port(port)
-                        if port_instance is None or port_instance in port_mapping_error_values:
-                            # error scenario update table accordingly
-                            helper_logger.log_warning("Error: Could not get port instance for cli cmd show firmware command port {}".format(port))
-                            set_show_firmware_fields(port, mux_info_dict, xcvrd_show_fw_res_tbl[asic_index])
-                            set_result_and_delete_port('status', status, xcvrd_show_fw_cmd_sts_tbl[asic_index], xcvrd_show_fw_rsp_tbl[asic_index], port)
-                            break
-
-                        with y_cable_port_locks[physical_port]:
-                            try:
-                                read_side = port_instance.get_read_side()
-                            except Exception as e:
-                                read_side = None
-                                helper_logger.log_warning("Failed to execute the get_read_side API for port {} due to {}".format(physical_port,repr(e)))
-                        if read_side is None or read_side is port_instance.EEPROM_ERROR or read_side < 0:
-
-                            status = 'False'
-                            helper_logger.log_warning("Error: Could not get read side for cli cmd show firmware port {}".format(port))
-                            set_show_firmware_fields(port, mux_info_dict, xcvrd_show_fw_res_tbl[asic_index])
-                            set_result_and_delete_port('status', status, xcvrd_show_fw_cmd_sts_tbl[asic_index], xcvrd_show_fw_rsp_tbl[asic_index], port)
-                            break
-
-
-                        get_firmware_dict(physical_port, port_instance, port_instance.TARGET_NIC, "nic", mux_info_dict, port)
-                        if read_side == port_instance.TARGET_TOR_A:
-                            get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_A, "self", mux_info_dict, port)
-                            get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_B, "peer", mux_info_dict, port)
-                        else:
-                            get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_A, "peer", mux_info_dict, port)
-                            get_firmware_dict(physical_port, port_instance, port_instance.TARGET_TOR_B, "self", mux_info_dict, port)
-
-                        status = 'True'
-                        set_show_firmware_fields(port, mux_info_dict, xcvrd_show_fw_res_tbl[asic_index])
-                        set_result_and_delete_port('status', status, xcvrd_show_fw_cmd_sts_tbl[asic_index], xcvrd_show_fw_rsp_tbl[asic_index], port)
-                    else:
-                        helper_logger.log_error("Wrong param for cli cmd show firmware port {}".format(port))
-                        set_show_firmware_fields(port, mux_info_dict, xcvrd_show_fw_res_tbl[asic_index])
-                        set_result_and_delete_port('status', 'False', xcvrd_show_fw_cmd_sts_tbl[asic_index], xcvrd_show_fw_rsp_tbl[asic_index], port)
-
-
+                    handle_show_firmware_show_cmd_arg_tbl_notification(fvp, xcvrd_show_fw_cmd_sts_tbl, xcvrd_show_fw_rsp_tbl, xcvrd_show_fw_res_tbl, asic_index, port)
+                    break
 
             while True:
                 (port, op, fvp) = xcvrd_acti_fw_cmd_tbl[asic_index].pop()


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
This PR refactores some of the message handling for CLI transacations by ycabled for muxcable
Particularly these CLI commands handling is refactored
```
show mux hwmode mux <port>
show mux hwmode switchmode <port>
config mux hwmode state <port>
config mux hwmode setswitchmode <port>
config mux firmware download/activate/rollback <port>
show mux firmware version <port>
```
With this PR all these notifications will be covered by Unit-Tests in our code

<!--
     Describe your changes in detail
-->

#### Motivation and Context
This PR is required to increase the code coverage of ycabled and attain a coverage of > 75%
This PR also removes refactors some code blocks which were not covered by UT
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Ran the Unit-tests to the corresponding changes
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
