### PR TITLE
[Y-Cable] Further increased unit test coverage of y_cable_helper.py

### DIFF
--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -46,27 +46,25 @@ class TestYCableScript(object):
         rc = format_mapping_identifier("ABC        ")
         assert(rc == "abc")
 
-
     def test_y_cable_helper_format_mapping_identifier_no_instance(self):
         rc = format_mapping_identifier(None)
         assert(rc == None)
 
     def test_gather_arg_from_db_and_check_for_type(self):
-        
-        arg_tbl = {"Ethernet0" : (True,{"abc":"x", "def":"y"})}
-        dic = {"key" : "value"}
-        rc = gather_arg_from_db_and_check_for_type(arg_tbl,"Ethernet0","key",dic, "abc")
+
+        arg_tbl = {"Ethernet0": (True, {"abc": "x", "def": "y"})}
+        dic = {"key": "value"}
+        rc = gather_arg_from_db_and_check_for_type(arg_tbl, "Ethernet0", "key", dic, "abc")
 
         assert(rc == ("x", "value", {'abc': 'x', 'def': 'y'}))
 
     def test_gather_arg_from_db_and_check_for_none_type(self):
-        
-        arg_tbl = {"Ethernet0" : (True,{"abcd":"x", "def":"y"})}
-        dic = {"key" : "value"}
-        rc = gather_arg_from_db_and_check_for_type(arg_tbl,"Ethernet0","key",dic, "abc")
+
+        arg_tbl = {"Ethernet0": (True, {"abcd": "x", "def": "y"})}
+        dic = {"key": "value"}
+        rc = gather_arg_from_db_and_check_for_type(arg_tbl, "Ethernet0", "key", dic, "abc")
 
         assert(rc == (None, "value"), {'abcd': 'x', 'def': 'y'})
-
 
     def test_y_cable_wrapper_get_transceiver_info(self):
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
@@ -136,6 +134,12 @@ class TestYCableScript(object):
 
         assert(presence == True)
 
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_is_platform_vs', True)
+    def test_y_cable_wrapper_get_presence_platform_vs_true(self):
+
+        presence = y_cable_wrapper_get_presence(1)
+        assert(presence == True)
+
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_chassis')
     def test_y_cable_wrapper_get_presence_with_platform_chassis(self, mock_chassis):
 
@@ -162,35 +166,35 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('ycable.ycable_utilities.y_cable_helper.get_muxcable_info', MagicMock(return_value={'tor_active': 'self',
-                                                                                             'mux_direction': 'self',
-                                                                                             'manual_switch_count': '7',
-                                                                                             'auto_switch_count': '71',
-                                                                                             'link_status_self': 'up',
-                                                                                             'link_status_peer': 'up',
-                                                                                             'link_status_nic': 'up',
-                                                                                             'nic_lane1_active': 'True',
-                                                                                             'nic_lane2_active': 'True',
-                                                                                             'nic_lane3_active': 'True',
-                                                                                             'nic_lane4_active': 'True',
-                                                                                             'self_eye_height_lane1': '500',
-                                                                                             'self_eye_height_lane2': '510',
-                                                                                             'peer_eye_height_lane1': '520',
-                                                                                             'peer_eye_height_lane2': '530',
-                                                                                             'nic_eye_height_lane1': '742',
-                                                                                             'nic_eye_height_lane2': '750',
-                                                                                             'internal_temperature': '28',
-                                                                                             'internal_voltage': '3.3',
-                                                                                             'nic_temperature': '20',
-                                                                                             'nic_voltage': '2.7',
-                                                                                             'version_nic_active': '1.6MS',
-                                                                                             'version_nic_inactive': '1.7MS',
-                                                                                             'version_nic_next': '1.7MS',
-                                                                                             'version_self_active': '1.6MS',
-                                                                                             'version_self_inactive': '1.7MS',
-                                                                                             'version_self_next': '1.7MS',
-                                                                                             'version_peer_active': '1.6MS',
-                                                                                             'version_peer_inactive': '1.7MS',
-                                                                                             'version_peer_next': '1.7MS'}))
+                                                                                               'mux_direction': 'self',
+                                                                                               'manual_switch_count': '7',
+                                                                                               'auto_switch_count': '71',
+                                                                                               'link_status_self': 'up',
+                                                                                               'link_status_peer': 'up',
+                                                                                               'link_status_nic': 'up',
+                                                                                               'nic_lane1_active': 'True',
+                                                                                               'nic_lane2_active': 'True',
+                                                                                               'nic_lane3_active': 'True',
+                                                                                               'nic_lane4_active': 'True',
+                                                                                               'self_eye_height_lane1': '500',
+                                                                                               'self_eye_height_lane2': '510',
+                                                                                               'peer_eye_height_lane1': '520',
+                                                                                               'peer_eye_height_lane2': '530',
+                                                                                               'nic_eye_height_lane1': '742',
+                                                                                               'nic_eye_height_lane2': '750',
+                                                                                               'internal_temperature': '28',
+                                                                                               'internal_voltage': '3.3',
+                                                                                               'nic_temperature': '20',
+                                                                                               'nic_voltage': '2.7',
+                                                                                               'version_nic_active': '1.6MS',
+                                                                                               'version_nic_inactive': '1.7MS',
+                                                                                               'version_nic_next': '1.7MS',
+                                                                                               'version_self_active': '1.6MS',
+                                                                                               'version_self_inactive': '1.7MS',
+                                                                                               'version_self_next': '1.7MS',
+                                                                                               'version_peer_active': '1.6MS',
+                                                                                               'version_peer_inactive': '1.7MS',
+                                                                                               'version_peer_next': '1.7MS'}))
     def test_post_port_mux_info_to_db(self):
         logical_port_name = "Ethernet0"
         mux_tbl = Table("STATE_DB", "Y_CABLE_INFO_TABLE")
@@ -199,43 +203,98 @@ class TestYCableScript(object):
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil', MagicMock(return_value=[0]))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=None))
+    def test_post_port_mux_info_to_db_physical_port_list_none(self):
+        logical_port_name = "Ethernet0"
+        mux_tbl = Table("STATE_DB", "Y_CABLE_INFO_TABLE")
+        rc = post_port_mux_info_to_db(logical_port_name, mux_tbl)
+        assert(rc == -1)
+
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0, 1]))
+    def test_post_port_mux_info_to_db_physical_port_list_multiple(self):
+        logical_port_name = "Ethernet0"
+        mux_tbl = Table("STATE_DB", "Y_CABLE_INFO_TABLE")
+        rc = post_port_mux_info_to_db(logical_port_name, mux_tbl)
+        assert(rc == -1)
+
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=False))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    def test_post_port_mux_info_to_db_no_ycable_presence(self):
+        logical_port_name = "Ethernet0"
+        mux_tbl = Table("STATE_DB", "Y_CABLE_INFO_TABLE")
+        rc = post_port_mux_info_to_db(logical_port_name, mux_tbl)
+        assert(rc == None)
+
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('ycable.ycable_utilities.y_cable_helper.get_muxcable_static_info', MagicMock(return_value={'read_side': 'self',
-                                                                                                    'nic_lane1_precursor1': '1',
-                                                                                                    'nic_lane1_precursor2': '-7',
-                                                                                                    'nic_lane1_maincursor': '-1',
-                                                                                                    'nic_lane1_postcursor1': '11',
-                                                                                                    'nic_lane1_postcursor2': '11',
-                                                                                                    'nic_lane2_precursor1': '12',
-                                                                                                    'nic_lane2_precursor2': '7',
-                                                                                                    'nic_lane2_maincursor': '7',
-                                                                                                    'nic_lane2_postcursor1': '7',
-                                                                                                    'nic_lane2_postcursor2': '7',
-                                                                                                    'tor_self_lane1_precursor1': '17',
-                                                                                                    'tor_self_lane1_precursor2': '17',
-                                                                                                    'tor_self_lane1_maincursor': '17',
-                                                                                                    'tor_self_lane1_postcursor1': '17',
-                                                                                                    'tor_self_lane1_postcursor2': '17',
-                                                                                                    'tor_self_lane2_precursor1': '7',
-                                                                                                    'tor_self_lane2_precursor2': '7',
-                                                                                                    'tor_self_lane2_maincursor': '7',
-                                                                                                    'tor_self_lane2_postcursor1': '7',
-                                                                                                    'tor_self_lane2_postcursor2': '7',
-                                                                                                    'tor_peer_lane1_precursor1': '7',
-                                                                                                    'tor_peer_lane1_precursor2': '7',
-                                                                                                    'tor_peer_lane1_maincursor': '17',
-                                                                                                    'tor_peer_lane1_postcursor1': '7',
-                                                                                                    'tor_peer_lane1_postcursor2': '17',
-                                                                                                    'tor_peer_lane2_precursor1': '7',
-                                                                                                    'tor_peer_lane2_precursor2': '7',
-                                                                                                    'tor_peer_lane2_maincursor': '17',
-                                                                                                    'tor_peer_lane2_postcursor1': '7',
-                                                                                                    'tor_peer_lane2_postcursor2': '17'}))
+                                                                                                      'nic_lane1_precursor1': '1',
+                                                                                                      'nic_lane1_precursor2': '-7',
+                                                                                                      'nic_lane1_maincursor': '-1',
+                                                                                                      'nic_lane1_postcursor1': '11',
+                                                                                                      'nic_lane1_postcursor2': '11',
+                                                                                                      'nic_lane2_precursor1': '12',
+                                                                                                      'nic_lane2_precursor2': '7',
+                                                                                                      'nic_lane2_maincursor': '7',
+                                                                                                      'nic_lane2_postcursor1': '7',
+                                                                                                      'nic_lane2_postcursor2': '7',
+                                                                                                      'tor_self_lane1_precursor1': '17',
+                                                                                                      'tor_self_lane1_precursor2': '17',
+                                                                                                      'tor_self_lane1_maincursor': '17',
+                                                                                                      'tor_self_lane1_postcursor1': '17',
+                                                                                                      'tor_self_lane1_postcursor2': '17',
+                                                                                                      'tor_self_lane2_precursor1': '7',
+                                                                                                      'tor_self_lane2_precursor2': '7',
+                                                                                                      'tor_self_lane2_maincursor': '7',
+                                                                                                      'tor_self_lane2_postcursor1': '7',
+                                                                                                      'tor_self_lane2_postcursor2': '7',
+                                                                                                      'tor_peer_lane1_precursor1': '7',
+                                                                                                      'tor_peer_lane1_precursor2': '7',
+                                                                                                      'tor_peer_lane1_maincursor': '17',
+                                                                                                      'tor_peer_lane1_postcursor1': '7',
+                                                                                                      'tor_peer_lane1_postcursor2': '17',
+                                                                                                      'tor_peer_lane2_precursor1': '7',
+                                                                                                      'tor_peer_lane2_precursor2': '7',
+                                                                                                      'tor_peer_lane2_maincursor': '17',
+                                                                                                      'tor_peer_lane2_postcursor1': '7',
+                                                                                                      'tor_peer_lane2_postcursor2': '17'}))
     def test_post_port_mux_static_info_to_db(self):
         logical_port_name = "Ethernet0"
         mux_tbl = Table("STATE_DB", "Y_CABLE_STATIC_INFO_TABLE")
         rc = post_port_mux_static_info_to_db(logical_port_name, mux_tbl)
         assert(rc != -1)
+
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=None))
+    def test_post_port_mux_static_info_to_db_physical_port_list_none(self):
+        logical_port_name = "Ethernet0"
+        mux_tbl = Table("STATE_DB", "Y_CABLE_STATIC_INFO_TABLE")
+        rc = post_port_mux_static_info_to_db(logical_port_name, mux_tbl)
+        assert(rc == -1)
+
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0, 1]))
+    def test_post_port_mux_static_info_to_db_physical_port_list_multiple(self):
+        logical_port_name = "Ethernet0"
+        mux_tbl = Table("STATE_DB", "Y_CABLE_STATIC_INFO_TABLE")
+        rc = post_port_mux_static_info_to_db(logical_port_name, mux_tbl)
+        assert(rc == -1)
+
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=False))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_muxcable_static_info', MagicMock(return_value=-1))
+    def test_post_port_mux_static_info_to_db_no_ycable_presence(self):
+        logical_port_name = "Ethernet0"
+        mux_tbl = Table("STATE_DB", "Y_CABLE_STATIC_INFO_TABLE")
+        rc = post_port_mux_static_info_to_db(logical_port_name, mux_tbl)
+        assert(rc == None)
 
     def test_y_cable_helper_format_mapping_identifier1(self):
         rc = format_mapping_identifier("ABC        ")
@@ -1290,7 +1349,7 @@ class TestYCableScript(object):
         logical_port_name = "Ethernet0"
         status = True
         fvs = [('state', "auto"), ('read_side', 1)]
-        
+
         state_db = {}
         test_db = "TEST_DB"
         y_cable_tbl = {}
@@ -1325,7 +1384,7 @@ class TestYCableScript(object):
         logical_port_name = "Ethernet0"
         status = True
         fvs = [('state', "auto"), ('read_side', 1)]
-        
+
         state_db = {}
         test_db = "TEST_DB"
         y_cable_tbl = {}
@@ -1365,7 +1424,7 @@ class TestYCableScript(object):
         logical_port_name = "Ethernet0"
         status = True
         fvs = [('state', "auto"), ('read_side', 1)]
-        
+
         state_db = {}
         test_db = "TEST_DB"
         y_cable_tbl = {}
@@ -1401,7 +1460,7 @@ class TestYCableScript(object):
         logical_port_name = "Ethernet0"
         status = True
         fvs = [('state', "auto"), ('read_side', 1)]
-        
+
         state_db = {}
         test_db = "TEST_DB"
         y_cable_tbl = {}
@@ -1423,10 +1482,12 @@ class TestYCableScript(object):
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
             patched_util.get_transceiver_info_dict.return_value = {'manufacturer': 'microsoft', 'model': 'simulated'}
 
-            sys.modules['builtins.getattr'] = MagicMock()
-            rc = check_identifier_presence_and_update_mux_table_entry(
-                state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name,  y_cable_presence)
-            assert(rc == None)
+            module_obj = {'YCable': None}
+            with patch('ycable.ycable_utilities.y_cable_helper.import_module', new=module_obj.get):
+
+                rc = check_identifier_presence_and_update_mux_table_entry(
+                    state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name,  y_cable_presence)
+                assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
@@ -1438,7 +1499,7 @@ class TestYCableScript(object):
         logical_port_name = "Ethernet0"
         status = True
         fvs = [('state', "auto"), ('read_side', 1)]
-        
+
         state_db = {}
         test_db = "TEST_DB"
         y_cable_tbl = {}
@@ -1454,10 +1515,12 @@ class TestYCableScript(object):
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
             patched_util.get_transceiver_info_dict.return_value = {'manufacturer': 'microsoft', 'model': 'simulated'}
 
-            sys.modules['builtins.getattr'] = MagicMock()
-            rc = check_identifier_presence_and_update_mux_table_entry(
-                state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name,  y_cable_presence)
-            assert(rc == None)
+            module_obj = {'YCable': None}
+            with patch('ycable.ycable_utilities.y_cable_helper.import_module', new=module_obj.get):
+
+                rc = check_identifier_presence_and_update_mux_table_entry(
+                    state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name,  y_cable_presence)
+                assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
@@ -1467,7 +1530,7 @@ class TestYCableScript(object):
         logical_port_name = "Ethernet0"
         status = True
         fvs = [('state', "auto"), ('read_side', 1)]
-        
+
         state_db = {}
         test_db = "TEST_DB"
         y_cable_tbl = {}
@@ -1486,23 +1549,80 @@ class TestYCableScript(object):
                 state_db, port_tbl, asic_index, logical_port_name, y_cable_presence,  delete_change_event)
             assert(rc == None)
 
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    def test_check_identifier_presence_and_delete_mux_table_entry_no_y_cable(self):
+        asic_index = 0
+        logical_port_name = "Ethernet0"
+        status = True
+        fvs = [('state', "auto"), ('read_side', 1)]
+
+        state_db = {}
+        test_db = "TEST_DB"
+        y_cable_tbl = {}
+        static_tbl = {}
+        mux_tbl = {}
+        port_tbl = {}
+        y_cable_presence = [False]
+        delete_change_event = [True]
+
+        port_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        port_tbl[asic_index].get.return_value = (status, fvs)
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as port_instance:
+            rc = check_identifier_presence_and_delete_mux_table_entry(
+                state_db, port_tbl, asic_index, logical_port_name, y_cable_presence,  delete_change_event)
+            assert(rc == None)
+
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    def test_check_identifier_presence_and_delete_mux_table_entry_status_false(self):
+        asic_index = 0
+        logical_port_name = "Ethernet0"
+        status = False
+        fvs = [('state', "auto"), ('read_side', 1)]
+
+        state_db = {}
+        test_db = "TEST_DB"
+        y_cable_tbl = {}
+        static_tbl = {}
+        mux_tbl = {}
+        port_tbl = {}
+        y_cable_presence = [True]
+        delete_change_event = [True]
+
+        port_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        port_tbl[asic_index].get.return_value = (False, fvs)
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as port_instance:
+            rc = check_identifier_presence_and_delete_mux_table_entry(
+                state_db, port_tbl, asic_index, logical_port_name, y_cable_presence,  delete_change_event)
+            assert(rc == None)
+
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_chassis')
-    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
     @patch('swsscommon.swsscommon.Table')
-    def test_init_ports_status_for_y_cable(self, platform_chassis, platform_sfp, mock_swsscommon_table):
+    def test_init_ports_status_for_y_cable(self, platform_chassis, mock_swsscommon_table):
 
-        platform_sfp = MagicMock()
         platform_chassis = MagicMock()
+        #platform_sfp = MagicMock()
 
+        class platform_sfp_helper():
+            def __init__(self):
+                self.logical = [0]
+
+            def get_asic_id_for_logical_port(self, logical_port_name):
+                return None
+
+        platform_sfp = platform_sfp_helper()
         mock_logical_port_name = [""]
 
         def mock_get_asic_id(mock_logical_port_name):
             return 0
 
-        
-
         y_cable_presence = [True]
-
+        delete_change_event = [True]
         mock_table = MagicMock()
         mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
         mock_swsscommon_table.return_value = mock_table
@@ -1522,9 +1642,8 @@ class TestYCableScript(object):
         def mock_get_asic_id(mock_logical_port_name):
             return 0
 
-        
-
         y_cable_presence = [True]
+        delete_change_event = [True]
         logical_port_dict = {'Ethernet0': '1'}
 
         mock_table = MagicMock()
@@ -1534,27 +1653,25 @@ class TestYCableScript(object):
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
-            patched_util.get_asic_id_for_logical_port.return_value = 0
+            patched_util.get_asic_id_for_logical_port.return_value = None
 
             change_ports_status_for_y_cable_change_event(
                 logical_port_dict,  y_cable_presence, stop_event=threading.Event())
 
             mock_swsscommon_table.assert_called()
 
-        @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
-        @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-        @patch('swsscommon.swsscommon.Table')
-        def test_change_ports_status_for_y_cable_change_event_sfp_removed(self, mock_swsscommon_table):
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('swsscommon.swsscommon.Table')
+    def test_change_ports_status_for_y_cable_change_event_sfp_removed(self, mock_swsscommon_table):
 
-            mock_logical_port_name = [""]
+        mock_logical_port_name = [""]
 
-            def mock_get_asic_id(mock_logical_port_name):
-                return 0
-
-            
+        def mock_get_asic_id(mock_logical_port_name):
+            return 0
 
         y_cable_presence = [True]
-        logical_port_dict = {'Ethernet0': '1'}
+        logical_port_dict = {'Ethernet0': '0'}
 
         mock_table = MagicMock()
         mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
@@ -1578,8 +1695,6 @@ class TestYCableScript(object):
 
         def mock_get_asic_id(mock_logical_port_name):
             return 0
-
-        
 
         y_cable_presence = [True]
         logical_port_dict = {'Ethernet0': '2'}
@@ -1614,9 +1729,32 @@ class TestYCableScript(object):
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
-            patched_util.logical.return_value = ['Ethernet0', 'Ethernet4']
+            patched_util.logical = ['Ethernet0', 'Ethernet4']
+            patched_util.get_asic_id_for_logical_port.return_value = None
+
+            rc = delete_ports_status_for_y_cable()
+
+            mock_swsscommon_table.assert_called()
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    def test_delete_ports_status_for_y_cable_valid_asic_index(self, mock_swsscommon_table):
+
+        mock_table = MagicMock()
+        mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4'])
+        mock_table.get = MagicMock(side_effect=[(True, (('index', 1), )), (True, (('index', 2), ))])
+        mock_swsscommon_table.return_value = mock_table
+
+        mock_logical_port_name = [""]
+
+        def mock_get_asic_id(mock_logical_port_name):
+            return 0
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
+
+            patched_util.logical = ['Ethernet0', 'Ethernet4']
             patched_util.get_asic_id_for_logical_port.return_value = 0
-        
 
             rc = delete_ports_status_for_y_cable()
 
@@ -1625,17 +1763,37 @@ class TestYCableScript(object):
     def test_check_identifier_presence_and_update_mux_info_entry(self):
         asic_index = 0
         logical_port_name = "Ethernet0"
-        
+
         state_db = {}
         test_db = "TEST_DB"
         mux_tbl = {}
 
+        swsscommon.Table.return_value.get.return_value = (True, {"state": "auto"})
         mux_tbl[asic_index] = swsscommon.Table(
             test_db[asic_index], MUX_CABLE_INFO_TABLE)
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
 
-            patched_util.logical.return_value = ['Ethernet0', 'Ethernet4']
+            patched_util.logical = ['Ethernet0', 'Ethernet4']
+            rc = check_identifier_presence_and_update_mux_info_entry(
+                state_db, mux_tbl, asic_index, logical_port_name)
+            assert(rc == None)
+
+    def test_check_identifier_presence_and_update_mux_info_entry_invalid_state(self):
+        asic_index = 0
+        logical_port_name = "Ethernet0"
+
+        state_db = {}
+        test_db = "TEST_DB"
+        mux_tbl = {}
+
+        swsscommon.Table.return_value.get.return_value = (True, {"state": "invalid"})
+        mux_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], MUX_CABLE_INFO_TABLE)
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
+
+            patched_util.logical = ['Ethernet0', 'Ethernet4']
             rc = check_identifier_presence_and_update_mux_info_entry(
                 state_db, mux_tbl, asic_index, logical_port_name)
             assert(rc == None)
@@ -1762,7 +1920,7 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
     def test_get_muxcable_info(self, platform_sfputil):
         physical_port = 20
-        
+
         logical_port_name = "Ethernet20"
         swsscommon.Table.return_value.get.return_value = (True, {"read_side": "1"})
         platform_sfputil.get_asic_id_for_logical_port = 0
@@ -1821,9 +1979,82 @@ class TestYCableScript(object):
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
+    def test_get_muxcable_info_port_instance_none(self, platform_sfputil):
+        physical_port = 20
+
+        logical_port_name = "Ethernet20"
+        platform_sfputil.get_asic_id_for_logical_port = 0
+        swsscommon.Table.return_value.get.return_value = (True, {"read_side": "2"})
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
+            patched_util.get.return_value = None
+            rc = get_muxcable_info(physical_port, logical_port_name)
+            assert rc == -1
+
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
+    def test_get_muxcable_info_status_false(self, platform_sfputil):
+        physical_port = 20
+
+        logical_port_name = "Ethernet20"
+        platform_sfputil.get_asic_id_for_logical_port = 0
+        swsscommon.Table.return_value.get.return_value = (False, {"read_side": "2"})
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
+
+            class PortInstanceHelper():
+                def __init__(self):
+                    self.EEPROM_ERROR = -1
+                    self.TARGET_NIC = 1
+                    self.TARGET_TOR_A = 1
+                    self.TARGET_TOR_B = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
+                    self.download_firmware_status = 0
+                    self.SWITCH_COUNT_MANUAL = "manual"
+                    self.SWITCH_COUNT_AUTO = "auto"
+
+                def get_active_linked_tor_side(self):
+                    return 1
+
+                def get_mux_direction(self):
+                    return 1
+
+                def get_switch_count_total(self, switch_count):
+                    return 1
+
+                def get_eye_heights(self, tgt_tor):
+                    return 500
+
+                def is_link_active(self, tgt_nic):
+                    return True
+
+                def get_local_temperature(self):
+                    return 22.75
+
+                def get_local_voltage(self):
+                    return 0.5
+
+                def get_nic_voltage(self):
+                    return 2.7
+
+                def get_nic_temperature(self):
+                    return 20
+
+            patched_util.get.return_value = PortInstanceHelper()
+
+            with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
+                patched_util.get_asic_id_for_logical_port.return_value = 0
+
+                rc = get_muxcable_info(physical_port, logical_port_name)
+
+                assert(rc == -1)
+
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
     def test_get_muxcable_info_peer_side(self, platform_sfputil):
         physical_port = 20
-        
+
         logical_port_name = "Ethernet20"
         platform_sfputil.get_asic_id_for_logical_port = 0
         swsscommon.Table.return_value.get.return_value = (True, {"read_side": "2"})
@@ -1884,7 +2115,7 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     def test_get_muxcable_info_exceptions(self, platform_sfputil):
         physical_port = 20
-        
+
         logical_port_name = "Ethernet20"
         platform_sfputil.get_asic_id_for_logical_port = 0
 
@@ -1939,134 +2170,12 @@ class TestYCableScript(object):
                 assert(rc['tor_active'] == 'unknown')
                 assert(rc['mux_direction'] == 'unknown')
                 assert(rc['self_eye_height_lane1'] == 'N/A')
-
-    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
-    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_get_muxcable_info_true_exceptions_peer_side(self, platform_sfputil):
-        physical_port = 20
-        
-        logical_port_name = "Ethernet20"
-        platform_sfputil.get_asic_id_for_logical_port = 0
-        swsscommon.Table.return_value.get.return_value = (True, {"read_side": "2"})
-
-        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
-
-            class PortInstanceHelper():
-                def __init__(self):
-                    self.EEPROM_ERROR = -1
-                    self.TARGET_NIC = 1
-                    self.TARGET_TOR_A = 1
-                    self.TARGET_TOR_B = 1
-                    self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
-                    self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
-                    self.download_firmware_status = 0
-                    self.SWITCH_COUNT_MANUAL = "manual"
-                    self.SWITCH_COUNT_AUTO = "auto"
-
-                def get_active_linked_tor_side(self):
-                    raise NotImplementedError
-
-                def get_mux_direction(self):
-                    raise NotImplementedError
-
-                def get_switch_count_total(self, switch_count):
-                    raise NotImplementedError
-
-                def get_eye_heights(self, tgt_tor):
-                    raise NotImplementedError
-
-                def is_link_active(self, tgt_nic):
-                    return False
-
-                def get_local_temperature(self):
-                    raise NotImplementedError
-
-                def get_local_voltage(self):
-                    raise NotImplementedError
-
-                def get_nic_voltage(self):
-                    raise NotImplementedError
-
-                def get_nic_temperature(self):
-                    raise NotImplementedError
-
-            patched_util.get.return_value = PortInstanceHelper()
-
-            with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
-                patched_util.get_asic_id_for_logical_port.return_value = 0
-
-                rc = get_muxcable_info(physical_port, logical_port_name)
-
-                assert(rc['tor_active'] == 'unknown')
-                assert(rc['mux_direction'] == 'unknown')
-                assert(rc['self_eye_height_lane1'] == 'N/A')
-
-    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
-    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_get_muxcable_info_true_exceptions(self, platform_sfputil):
-        physical_port = 20
-        
-        logical_port_name = "Ethernet20"
-        platform_sfputil.get_asic_id_for_logical_port = 0
-
-        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
-
-            class PortInstanceHelper():
-                def __init__(self):
-                    self.EEPROM_ERROR = -1
-                    self.TARGET_NIC = 1
-                    self.TARGET_TOR_A = 1
-                    self.TARGET_TOR_B = 1
-                    self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
-                    self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
-                    self.download_firmware_status = 0
-                    self.SWITCH_COUNT_MANUAL = "manual"
-                    self.SWITCH_COUNT_AUTO = "auto"
-
-                def get_active_linked_tor_side(self):
-                    raise NotImplementedError
-
-                def get_mux_direction(self):
-                    raise NotImplementedError
-
-                def get_switch_count_total(self, switch_count):
-                    raise NotImplementedError
-
-                def get_eye_heights(self, tgt_tor):
-                    raise NotImplementedError
-
-                def is_link_active(self, tgt_nic):
-                    return False
-
-                def get_local_temperature(self):
-                    raise NotImplementedError
-
-                def get_local_voltage(self):
-                    raise NotImplementedError
-
-                def get_nic_voltage(self):
-                    raise NotImplementedError
-
-                def get_nic_temperature(self):
-                    raise NotImplementedError
-
-            patched_util.get.return_value = PortInstanceHelper()
-
-            with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
-                patched_util.get_asic_id_for_logical_port.return_value = 0
-
-                rc = get_muxcable_info(physical_port, logical_port_name)
-
-                assert(rc['tor_active'] == 'unknown')
-                assert(rc['mux_direction'] == 'unknown')
-                assert(rc['self_eye_height_lane1'] == 'N/A')
-
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     def test_get_muxcable_info_exceptions_peer_side(self, platform_sfputil):
         physical_port = 20
-        
+
         logical_port_name = "Ethernet20"
         platform_sfputil.get_asic_id_for_logical_port = 0
         swsscommon.Table.return_value.get.return_value = (True, {"read_side": "2"})
@@ -2125,9 +2234,68 @@ class TestYCableScript(object):
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    def test_get_muxcable_static_info_port_instance_none(self, platform_sfputil):
+        physical_port = 0
+
+        logical_port_name = "Ethernet0"
+
+        platform_sfputil.get_asic_id_for_logical_port = 0
+        swsscommon.Table.return_value.get.return_value = (True, {"read_side": "1"})
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
+            patched_util.get.return_value = None
+            rc = get_muxcable_static_info(physical_port, logical_port_name)
+            assert rc == -1
+
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    def test_get_muxcable_static_info_status_false(self, platform_sfputil):
+        physical_port = 0
+
+        logical_port_name = "Ethernet0"
+
+        platform_sfputil.get_asic_id_for_logical_port = 0
+        swsscommon.Table.return_value.get.return_value = (False, {"read_side": "1"})
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
+            class PortInstanceHelper():
+                def __init__(self):
+                    self.SWITCH_COUNT_AUTO = "auto"
+
+            patched_util.get.return_value = PortInstanceHelper()
+
+            with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
+                patched_util.get_asic_id_for_logical_port.return_value = 0
+                rc = get_muxcable_static_info(physical_port, logical_port_name)
+
+                assert (rc == -1)
+
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
+    def test_get_muxcable_static_info_asic_id_none(self, platform_sfputil):
+        physical_port = 0
+
+        logical_port_name = "Ethernet0"
+
+        platform_sfputil.get_asic_id_for_logical_port = 0
+        swsscommon.Table.return_value.get.return_value = (False, {"read_side": "1"})
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
+            class PortInstanceHelper():
+                def __init__(self):
+                    self.SWITCH_COUNT_AUTO = "auto"
+
+            patched_util.get.return_value = PortInstanceHelper()
+
+            with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as patched_util:
+                patched_util.get_asic_id_for_logical_port.return_value = None
+                rc = get_muxcable_static_info(physical_port, logical_port_name)
+
+                assert (rc == -1)
+
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     def test_get_muxcable_static_info(self, platform_sfputil):
         physical_port = 0
-        
+
         logical_port_name = "Ethernet0"
 
         platform_sfputil.get_asic_id_for_logical_port = 0
@@ -2199,11 +2367,11 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     def test_get_muxcable_static_info_read_side_peer(self, platform_sfputil):
         physical_port = 0
-        
+
         logical_port_name = "Ethernet0"
 
         #swsscommon.Table = MagicMock()
-        #this patch is already done as global instance 
+        # this patch is already done as global instance
         platform_sfputil.get_asic_id_for_logical_port = 0
         swsscommon.Table.return_value.get.return_value = (True, {"read_side": "2"})
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
@@ -2268,16 +2436,16 @@ class TestYCableScript(object):
                 assert (rc['tor_peer_lane2_maincursor'] == -17)
                 assert (rc['tor_peer_lane2_postcursor1'] == -17)
                 assert (rc['tor_peer_lane2_postcursor2'] == -17)
-        
+
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
     def test_get_muxcable_static_info_read_side_peer_exceptions(self, platform_sfputil):
         physical_port = 0
-        
+
         logical_port_name = "Ethernet0"
 
         #swsscommon.Table = MagicMock()
-        #this patch is already done as global instance 
+        # this patch is already done as global instance
         platform_sfputil.get_asic_id_for_logical_port = 0
         swsscommon.Table.return_value.get.return_value = (True, {"read_side": "2"})
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
@@ -2357,11 +2525,11 @@ class TestYCableScript(object):
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "enable", {"mode_value":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_no_port(self,port_instance, mock_swsscommon_table):
-        
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "enable", {"mode_value": "0",
+                                                                                                                                 "lane_mask": "0",
+                                                                                                                                 "direction": "0"})))
+    def test_handle_config_prbs_cmd_arg_tbl_notification_no_port(self, port_instance, mock_swsscommon_table):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2372,16 +2540,17 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_prbs": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "enable", {"mode_value":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_no_instance(self,mock_swsscommon_table):
-        
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "enable", {"mode_value": "0",
+                                                                                                                                 "lane_mask": "0",
+                                                                                                                                 "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    def test_handle_config_prbs_cmd_arg_tbl_notification_no_instance(self, mock_swsscommon_table):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2392,19 +2561,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_prbs": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "enable", {"mode_value":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "enable", {"mode_value": "0",
+                                                                                                                                 "lane_mask": "0",
+                                                                                                                                 "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_enable(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_enable(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2422,19 +2592,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_prbs": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "disable", {"mode_value":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "disable", {"mode_value": "0",
+                                                                                                                                  "lane_mask": "0",
+                                                                                                                                  "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_disable(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_disable(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2452,19 +2623,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_prbs": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "reset", {"mode_value":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "reset", {"mode_value": "0",
+                                                                                                                                "lane_mask": "0",
+                                                                                                                                "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_reset(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_reset(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2483,19 +2655,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_prbs": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "anlt", {"mode":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "anlt", {"mode": "0",
+                                                                                                                               "lane_mask": "0",
+                                                                                                                               "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_anlt_enable(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_anlt_enable(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2515,19 +2688,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_prbs": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "anlt", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "anlt", {"modex": "0",
+                                                                                                                               "lane_mask": "0",
+                                                                                                                               "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_anlt_disable(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_anlt_disable(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2547,19 +2721,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_prbs": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"mode":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"mode": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_fec_enable(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_fec_enable(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2579,19 +2754,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_prbs": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_fec_disable(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_prbs_cmd_arg_tbl_notification_with_instance_fec_disable(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2611,19 +2787,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_prbs": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_prbs_cmd_arg_tbl_notification_else_value(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_prbs_cmd_arg_tbl_notification_else_value(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2643,19 +2820,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_abc": True}
 
-        rc = handle_config_prbs_cmd_arg_tbl_notification(fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
+        rc = handle_config_prbs_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_prbs_cmd_arg_tbl, xcvrd_config_prbs_cmd_sts_tbl, xcvrd_config_prbs_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_loop_cmd_arg_tbl_notification_else_value(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_loop_cmd_arg_tbl_notification_else_value(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2675,19 +2853,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_abc": True}
 
-        rc = handle_config_loop_cmd_arg_tbl_notification(fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
+        rc = handle_config_loop_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_loop_cmd_arg_tbl_notification_else_value(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_loop_cmd_arg_tbl_notification_else_value(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2707,17 +2886,18 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_loop": True}
 
-        rc = handle_config_loop_cmd_arg_tbl_notification(fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
+        rc = handle_config_loop_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    def test_handle_config_loop_cmd_arg_tbl_notification_no_port(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    def test_handle_config_loop_cmd_arg_tbl_notification_no_port(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2737,18 +2917,19 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_loop": True}
 
-        rc = handle_config_loop_cmd_arg_tbl_notification(fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
+        rc = handle_config_loop_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_loop_cmd_arg_tbl_notification_no_instance(self,port_instance, mock_swsscommon_table):
-        
+    def test_handle_config_loop_cmd_arg_tbl_notification_no_instance(self, port_instance, mock_swsscommon_table):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2768,20 +2949,21 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_loop": True}
 
-        rc = handle_config_loop_cmd_arg_tbl_notification(fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
+        rc = handle_config_loop_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "enable", {"enable":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "mode_value":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "enable", {"enable": "0",
+                                                                                                                                 "lane_mask": "0",
+                                                                                                                                 "mode_value": "0",
+                                                                                                                                 "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_loop_cmd_arg_tbl_notification_enable(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_loop_cmd_arg_tbl_notification_enable(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2801,20 +2983,21 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_loop": True}
 
-        rc = handle_config_loop_cmd_arg_tbl_notification(fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
+        rc = handle_config_loop_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "disable", {"disable":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "mode_value":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "disable", {"disable": "0",
+                                                                                                                                  "lane_mask": "0",
+                                                                                                                                  "mode_value": "0",
+                                                                                                                                  "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_config_loop_cmd_arg_tbl_notification_disable(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_config_loop_cmd_arg_tbl_notification_disable(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2834,19 +3017,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_loop": True}
 
-        rc = handle_config_loop_cmd_arg_tbl_notification(fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
+        rc = handle_config_loop_cmd_arg_tbl_notification(
+            fvp, xcvrd_config_loop_cmd_arg_tbl, xcvrd_config_loop_cmd_sts_tbl, xcvrd_config_loop_rsp_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_show_event_cmd_arg_tbl_notification_else_value(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_show_event_cmd_arg_tbl_notification_else_value(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2866,19 +3050,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"config_loop": True}
 
-        rc = handle_show_event_cmd_arg_tbl_notification(fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
+        rc = handle_show_event_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_show_event_cmd_arg_tbl_notification_get_log(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_show_event_cmd_arg_tbl_notification_get_log(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2892,19 +3077,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"show_event": True}
 
-        rc = handle_show_event_cmd_arg_tbl_notification(fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
+        rc = handle_show_event_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_show_event_cmd_arg_tbl_notification_get_actual_log(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_show_event_cmd_arg_tbl_notification_get_actual_log(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2918,19 +3104,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"show_event": True}
 
-        rc = handle_show_event_cmd_arg_tbl_notification(fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
+        rc = handle_show_event_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_show_event_cmd_arg_tbl_notification_get_no_log(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_show_event_cmd_arg_tbl_notification_get_no_log(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2944,19 +3131,19 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"show_event": True}
 
-        rc = handle_show_event_cmd_arg_tbl_notification(fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
+        rc = handle_show_event_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
         assert(rc == None)
-
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_show_event_cmd_arg_tbl_notification_no_port(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_show_event_cmd_arg_tbl_notification_no_port(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2971,18 +3158,19 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"show_event": True}
 
-        rc = handle_show_event_cmd_arg_tbl_notification(fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
+        rc = handle_show_event_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
-    def test_handle_show_event_cmd_arg_tbl_notification_no_instance(self,port_instance, mock_swsscommon_table):
-        
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    def test_handle_show_event_cmd_arg_tbl_notification_no_instance(self, port_instance, mock_swsscommon_table):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -2996,19 +3184,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"show_event": True}
 
-        rc = handle_show_event_cmd_arg_tbl_notification(fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
+        rc = handle_show_event_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_event_cmd_sts_tbl, xcvrd_show_event_rsp_tbl, xcvrd_show_event_res_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_no_status(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_no_status(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3021,15 +3210,16 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"show_event": True}
 
-        rc = handle_get_fec_cmd_arg_tbl_notification(fvp,xcvrd_show_fec_rsp_tbl, xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl, asic_index, port)
+        rc = handle_get_fec_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_fec_rsp_tbl, xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_no_port(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_no_port(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3042,15 +3232,16 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"get_fec": True}
 
-        rc = handle_get_fec_cmd_arg_tbl_notification(fvp,xcvrd_show_fec_rsp_tbl, xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl, asic_index, port)
+        rc = handle_get_fec_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_fec_rsp_tbl, xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_no_instance(self,port_instance, mock_swsscommon_table):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_no_instance(self, port_instance, mock_swsscommon_table):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3064,16 +3255,17 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"get_fec": True}
 
-        rc = handle_get_fec_cmd_arg_tbl_notification(fvp,xcvrd_show_fec_rsp_tbl, xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl, asic_index, port)
+        rc = handle_get_fec_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_fec_rsp_tbl, xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_get_result(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_get_result(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3089,19 +3281,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"get_fec": True}
 
-        rc = handle_get_fec_cmd_arg_tbl_notification(fvp,xcvrd_show_fec_rsp_tbl, xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl, asic_index, port)
+        rc = handle_get_fec_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_fec_rsp_tbl, xcvrd_show_fec_cmd_sts_tbl, xcvrd_show_fec_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_no_status(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_no_status(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3115,18 +3308,19 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"show_event": True}
 
-        rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+        rc = handle_show_ber_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_no_port(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_no_port(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3140,18 +3334,19 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"get_ber": True}
 
-        rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+        rc = handle_show_ber_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == -1)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_no_instance(self,port_instance, mock_swsscommon_table):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_no_instance(self, port_instance, mock_swsscommon_table):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3165,20 +3360,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"get_ber": True}
 
-        rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+        rc = handle_show_ber_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == -1)
-
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "ber", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "ber", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_get_ber(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_get_ber(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3193,19 +3388,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"get_ber": True}
 
-        rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+        rc = handle_show_ber_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "eye", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "eye", {"modex": "0",
+                                                                                                                              "lane_mask": "0",
+                                                                                                                              "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_get_eye(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_get_eye(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3220,19 +3416,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"get_ber": True}
 
-        rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+        rc = handle_show_ber_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "fec_stats", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "fec_stats", {"modex": "0",
+                                                                                                                                    "lane_mask": "0",
+                                                                                                                                    "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_get_fec_stats(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_get_fec_stats(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3241,25 +3438,26 @@ class TestYCableScript(object):
         xcvrd_show_ber_cmd_sts_tbl = mock_swsscommon_table
         xcvrd_show_ber_res_tbl = mock_swsscommon_table
         port_instance = MagicMock()
-        port_instance.get_fec_stats.return_value = {"100":"200"}
+        port_instance.get_fec_stats.return_value = {"100": "200"}
 
         asic_index = 0
         port = "Ethernet0"
         fvp = {"get_ber": True}
 
-        rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+        rc = handle_show_ber_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "pcs_stats", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "pcs_stats", {"modex": "0",
+                                                                                                                                    "lane_mask": "0",
+                                                                                                                                    "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_get_pcs_stats(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_get_pcs_stats(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3268,25 +3466,26 @@ class TestYCableScript(object):
         xcvrd_show_ber_cmd_sts_tbl = mock_swsscommon_table
         xcvrd_show_ber_res_tbl = mock_swsscommon_table
         port_instance = MagicMock()
-        port_instance.get_pcs_stats.return_value = {"100":"200"}
+        port_instance.get_pcs_stats.return_value = {"100": "200"}
 
         asic_index = 0
         port = "Ethernet0"
         fvp = {"get_ber": True}
 
-        rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+        rc = handle_show_ber_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "cable_alive", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "cable_alive", {"modex": "0",
+                                                                                                                                      "lane_mask": "0",
+                                                                                                                                      "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_get_alive_status(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_get_alive_status(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3301,19 +3500,20 @@ class TestYCableScript(object):
         port = "Ethernet0"
         fvp = {"get_ber": True}
 
-        rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+        rc = handle_show_ber_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == None)
 
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances')
     @patch('swsscommon.swsscommon.Table')
     @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_port_instance_from_logical_port')
-    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type',MagicMock(return_value=(0, "debug_dump", {"modex":"0",
-                                                                                                                                "lane_mask":"0",
-                                                                                                                                "direction":"0"})))
-    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port',MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.gather_arg_from_db_and_check_for_type', MagicMock(return_value=(0, "debug_dump", {"modex": "0",
+                                                                                                                                     "lane_mask": "0",
+                                                                                                                                     "direction": "0"})))
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_locks', MagicMock(return_value=[0]))
-    def test_handle_get_fec_cmd_arg_tbl_notification_get_debug_dump_registers(self,port_instance, mock_swsscommon_table, port_instance_helper):
-        
+    def test_handle_get_fec_cmd_arg_tbl_notification_get_debug_dump_registers(self, port_instance, mock_swsscommon_table, port_instance_helper):
+
         mock_table = MagicMock()
         mock_swsscommon_table.return_value = mock_table
 
@@ -3322,12 +3522,40 @@ class TestYCableScript(object):
         xcvrd_show_ber_cmd_sts_tbl = mock_swsscommon_table
         xcvrd_show_ber_res_tbl = mock_swsscommon_table
         port_instance = MagicMock()
-        port_instance.debug_dump_registers.return_value = {"register1":"100"}
+        port_instance.debug_dump_registers.return_value = {"register1": "100"}
 
         asic_index = 0
         port = "Ethernet0"
         fvp = {"get_ber": True}
 
-        rc = handle_show_ber_cmd_arg_tbl_notification(fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
+        rc = handle_show_ber_cmd_arg_tbl_notification(
+            fvp, xcvrd_show_ber_cmd_arg_tbl, xcvrd_show_ber_rsp_tbl, xcvrd_show_ber_cmd_sts_tbl, xcvrd_show_ber_res_tbl, asic_index, port)
         assert(rc == None)
 
+    def test_logical_port_name_to_physical_port_list(self):
+        port_name = "Ethernet4"
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as mock_util:
+            mock_util.is_logical_port = MagicMock(return_value=True)
+            mock_util.get_logical_to_physical = MagicMock(return_value=4)
+
+            rc = logical_port_name_to_physical_port_list(port_name)
+
+            assert rc == 4
+
+    def test_logical_port_name_to_physical_port_list_not_logical_port(self):
+        port_name = "Ethernet4"
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil') as mock_util:
+            mock_util.is_logical_port = MagicMock(return_value=False)
+            #mock_util.get_logical_to_physical = MagicMock(return_value=4)
+
+            rc = logical_port_name_to_physical_port_list(port_name)
+
+            assert rc == None
+
+    def test_logical_port_name_to_physical_port_list_invalid_port_name(self):
+        port_name = "4"
+
+        rc = logical_port_name_to_physical_port_list(port_name)
+        assert rc == [4]

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -860,10 +860,10 @@ def delete_ports_status_for_y_cable():
             logical_port_name)
         if asic_index is not None:
             
-            # Get the y table keys
+            # Get the y cable port keys from the table
             y_cable_port_keys = y_cable_tbl_keys.get(asic_index, None)
             
-            if logical_port_name in y_cable_tbl_keys[asic_index]:
+            if logical_port_name in y_cable_port_keys:
                 delete_port_from_y_cable_table(logical_port_name, y_cable_tbl[asic_index])
                 delete_port_from_y_cable_table(logical_port_name, static_tbl[asic_index])
                 delete_port_from_y_cable_table(logical_port_name, mux_tbl[asic_index])

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -858,11 +858,11 @@ def delete_ports_status_for_y_cable():
         # Get the asic to which this port belongs
         asic_index = y_cable_platform_sfputil.get_asic_id_for_logical_port(
             logical_port_name)
-        if asic_index is None:
-            helper_logger.log_warning(
-                "Got invalid asic index for {}, ignored".format(logical_port_name))
-        
-        try:
+        if asic_index is not None:
+            
+            # Get the y table keys
+            y_cable_port_keys = y_cable_tbl_keys.get(asic_index, None)
+            
             if logical_port_name in y_cable_tbl_keys[asic_index]:
                 delete_port_from_y_cable_table(logical_port_name, y_cable_tbl[asic_index])
                 delete_port_from_y_cable_table(logical_port_name, static_tbl[asic_index])
@@ -880,9 +880,9 @@ def delete_ports_status_for_y_cable():
                 else:
                     helper_logger.log_warning(
                         "Error: Retreived multiple ports for a Y cable port {} while deleting entries".format(logical_port_name))
-        except Exception as e:
-            helper_logger.log_error("Exception: {}".format(repr(e)))
-            return
+        else:
+            helper_logger.log_warning(
+                "Got invalid asic index for {}, ignored".format(logical_port_name))
 
 
 def check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_index, logical_port_name):

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -861,24 +861,28 @@ def delete_ports_status_for_y_cable():
         if asic_index is None:
             helper_logger.log_warning(
                 "Got invalid asic index for {}, ignored".format(logical_port_name))
+        
+        try:
+            if logical_port_name in y_cable_tbl_keys[asic_index]:
+                delete_port_from_y_cable_table(logical_port_name, y_cable_tbl[asic_index])
+                delete_port_from_y_cable_table(logical_port_name, static_tbl[asic_index])
+                delete_port_from_y_cable_table(logical_port_name, mux_tbl[asic_index])
+                # delete the y_cable port instance
+                physical_port_list = logical_port_name_to_physical_port_list(logical_port_name)
 
-        if logical_port_name in y_cable_tbl_keys[asic_index]:
-            delete_port_from_y_cable_table(logical_port_name, y_cable_tbl[asic_index])
-            delete_port_from_y_cable_table(logical_port_name, static_tbl[asic_index])
-            delete_port_from_y_cable_table(logical_port_name, mux_tbl[asic_index])
-            # delete the y_cable port instance
-            physical_port_list = logical_port_name_to_physical_port_list(logical_port_name)
+                if len(physical_port_list) == 1:
 
-            if len(physical_port_list) == 1:
-
-                physical_port = physical_port_list[0]
-                if y_cable_port_instances.get(physical_port) is not None:
-                    y_cable_port_instances.pop(physical_port)
-                if y_cable_port_locks.get(physical_port) is not None:
-                    y_cable_port_locks.pop(physical_port)
-            else:
-                helper_logger.log_warning(
-                    "Error: Retreived multiple ports for a Y cable port {} while deleting entries".format(logical_port_name))
+                    physical_port = physical_port_list[0]
+                    if y_cable_port_instances.get(physical_port) is not None:
+                        y_cable_port_instances.pop(physical_port)
+                    if y_cable_port_locks.get(physical_port) is not None:
+                        y_cable_port_locks.pop(physical_port)
+                else:
+                    helper_logger.log_warning(
+                        "Error: Retreived multiple ports for a Y cable port {} while deleting entries".format(logical_port_name))
+        except Exception as e:
+            helper_logger.log_error("Exception: {}".format(repr(e)))
+            return
 
 
 def check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_index, logical_port_name):


### PR DESCRIPTION
#### Description

Added unit tests for the following methods:

- logical_port_name_to_physical_port_list
- y_cable_wrapper_get_presence
- post_port_mux_info_to_db
- post_port_mux_static_info_to_db
- check_identifier_presence_and_update_mux_table_entry
- check_identifier_presence_and_delete_mux_table_entry
- init_ports_status_for_y_cable
- change_ports_status_for_y_cable_change_event
- delete_ports_status_for_y_cable
- check_identifier_presence_and_update_mux_info_entry
- get_muxcable_info
- get_muxcable_static_info
- post_mux_static_info_to_db

#### Motivation and Context
The motivation for these changes stems from needing to increase the unit test coverage of the y_cable_helper methods to above 50%.

#### How Has This Been Tested?
This was tested by building and running the new unit tests and verifying that they contribute to and increase the code coverage as reflected in the ycable_ycable_utilities_y_cable_helper_py.html page.

#### Additional Information (Optional)
Additionally, fixed a minor issue that raises an exception if not bound by a try block.