### PR TITLE
[xcvrd] add support for link-training capability detection

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -233,6 +233,27 @@ class TestXcvrdScript(object):
         stop_event = threading.Event()
         init_port_sfp_status_tbl(port_mapping, stop_event)
 
+    def test_get_media_capability(self):
+        xcvr_info_dict = {
+            0: {
+                'manufacturer': 'Amphenol',
+                'model': 'NDAAFF-0001',
+                'specification_compliance': "{'10/40G Ethernet Compliance Code': '40GBASE-CR4', 'Extended Specification compliance': '100GBASE-CR4, 25GBASE-CR CA-25G-L or 50GBASE-CR2 with RS'}",
+                'type_abbrv_name': 'QSFP28',
+                'type': 'QSFP28 or later'
+            }
+        }
+
+        # Test a good 'specification_compliance' value
+        result = get_media_capabilities_value(xcvr_info_dict[0])
+        assert result.get('xcvr_capabilities') == 'AN,LT'
+        assert result.get('xcvr_speeds') == '1x100G,1x40G,2x50G,2x20G,4x25G,4x10G'
+
+        # Test a bad 'specification_compliance' value
+        xcvr_info_dict[0]['specification_compliance'] = 'N/A'
+        result = get_media_capabilities_value(xcvr_info_dict[0])
+        assert len(result) == 0
+
     def test_get_media_settings_key(self):
         xcvr_info_dict = {
             0: {

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -649,7 +649,7 @@ def get_media_capabilities_value(transceiver_info, key=[]):
                     if speed < 1000:
                         continue
                     spd_list.append("{}x{}G".format(int(8 / lanes), int(speed / 1000)))
-        elif type in ['QSFP', 'QSFP+', 'QSFP28', 'GBIC']:
+        elif type in ['QSFP', 'QSFP+', 'QSFP28']:
             if spd_max == 100000:
                 spd_list.append("1x100G")
                 spd_list.append("1x40G")


### PR DESCRIPTION
Signed-off-by: Dante Su <dante.su@broadcom.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Add  transceiver capability detection for the link-training controls in swss#orchagent

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
link-training only works on certain transceivers, having link-training enabled
on an inappropriate transceiver will cause the link down.
Hence this PR is to provide the transceiver capability from xcvrd into orchagent
to enable config error detection and advanced controls if necessary

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
1. Manual test
2. Ran the Unit-tests to the corresponding changes

#### Additional Information (Optional)
