### PR TITLE
Add serial_num field for chassis info in STATE_DB

### DIFF
--- a/sonic-chassisd/scripts/chassis_db_init
+++ b/sonic-chassisd/scripts/chassis_db_init
@@ -30,6 +30,7 @@ CHASSIS_INFO_TABLE = 'CHASSIS_INFO'
 CHASSIS_INFO_KEY_TEMPLATE = 'chassis {}'
 CHASSIS_INFO_CARD_NUM_FIELD = 'module_num'
 CHASSIS_INFO_SERIAL_FIELD = 'serial'
+CHASSIS_INFO_SERIAL_NUM_FIELD = 'serial_num'
 CHASSIS_INFO_MODEL_FIELD = 'model'
 CHASSIS_INFO_REV_FIELD = 'revision'
 
@@ -75,7 +76,8 @@ def provision_db(platform_chassis, log):
     fvs = swsscommon.FieldValuePairs([
                                         (CHASSIS_INFO_SERIAL_FIELD, try_get(platform_chassis.get_serial)),
                                         (CHASSIS_INFO_MODEL_FIELD, try_get(platform_chassis.get_model)),
-                                        (CHASSIS_INFO_REV_FIELD, try_get(platform_chassis.get_revision))
+                                        (CHASSIS_INFO_REV_FIELD, try_get(platform_chassis.get_revision)),
+                                        (CHASSIS_INFO_SERIAL_NUM_FIELD, try_get(platform_chassis.get_serial_num))
                                     ])
     chassis_table.set(CHASSIS_INFO_KEY_TEMPLATE.format(1), fvs)
     log.log_info("STATE_DB provisioned with chassis info.")


### PR DESCRIPTION
upload serial number to the STATE_DB under the CHASSIS_INFO table as a new chassis hardware information for users

#### Description
Expose serial number to user space so that CLI utilities have access to it.

#### Motivation and Context
The "show version" command will get "serial" field value in STATE_DB under the CHASSIS_INFO table as the "Serial Number" display. However, the platform API "get_serial" is suppose to be used to get the service tag of the chassis instead of the actual serial number. I made this change in order that the actual serial number can be exposed to SONiC user and the CLI utilities can have access to it.

#### How Has This Been Tested?
After the merge of the related CLI utilities changes, use "show version" to check the "Serial Number" field

#### Additional Information (Optional)
"show version" command result before this change:
![image](https://user-images.githubusercontent.com/81281940/160774924-6e586b00-a264-4da3-addc-7fa97f0d41fe.png)
"show version" command result after this change
![Uploading image.png…]()
