### PR TITLE
Include changes from xcvr_api in transceiver_info table

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -155,7 +155,11 @@ class TestXcvrdScript(object):
                                                                                 'active_apsel_hostlane7': 1,
                                                                                 'active_apsel_hostlane8': 1,
                                                                                 'media_interface_technology': '1',
-                                                                                'cmis_rev': '5.0'}))
+                                                                                'cmis_rev': '5.0',
+                                                                                'supported_max_tx_power': 1.0,
+                                                                                'supported_min_tx_power': -15.0,
+                                                                                'supported_max_laser_freq': 196100,
+                                                                                'supported_min_laser_freq': 191300}))
     def test_post_port_sfp_info_to_db(self):
         logical_port_name = "Ethernet0"
         port_mapping = PortMapping()

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -136,7 +136,26 @@ class TestXcvrdScript(object):
                                                                                 'nominal_bit_rate': '0.7',
                                                                                 'application_advertisement': '0.7',
                                                                                 'is_replaceable': '0.7',
-                                                                                'dom_capability': '0.7', }))
+                                                                                'dom_capability': '0.7',
+                                                                                'active_firmware': '1.1',
+                                                                                'inactive_firmware': '1.0',
+                                                                                'hardware_rev': '1.0',
+                                                                                'media_interface_code': '0.1',
+                                                                                'host_electrical_interface': '0.1',
+                                                                                'host_lane_count': 8,
+                                                                                'media_lane_count': 1,
+                                                                                'host_lane_assignment_option': 1,
+                                                                                'media_lane_assignment_option': 1,
+                                                                                'active_apsel_hostlane1': 1,
+                                                                                'active_apsel_hostlane2': 1,
+                                                                                'active_apsel_hostlane3': 1,
+                                                                                'active_apsel_hostlane4': 1,
+                                                                                'active_apsel_hostlane5': 1,
+                                                                                'active_apsel_hostlane6': 1,
+                                                                                'active_apsel_hostlane7': 1,
+                                                                                'active_apsel_hostlane8': 1,
+                                                                                'media_interface_technology': '1',
+                                                                                'cmis_rev': '5.0'}))
     def test_post_port_sfp_info_to_db(self):
         logical_port_name = "Ethernet0"
         port_mapping = PortMapping()

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -303,65 +303,99 @@ def post_port_sfp_info_to_db(logical_port_name, port_mapping, table, transceiver
             if port_info_dict is not None:
                 is_replaceable = _wrapper_is_replaceable(physical_port)
                 transceiver_dict[physical_port] = port_info_dict
-                fvs = swsscommon.FieldValuePairs(
-                    [('type', port_info_dict['type']),
-                     ('vendor_rev', port_info_dict['vendor_rev']),
-                     ('serial', port_info_dict['serial']),
-                     ('manufacturer', port_info_dict['manufacturer']),
-                     ('model', port_info_dict['model']),
-                     ('vendor_oui', port_info_dict['vendor_oui']),
-                     ('vendor_date', port_info_dict['vendor_date']),
-                     ('connector', port_info_dict['connector']),
-                     ('encoding', port_info_dict['encoding']),
-                     ('ext_identifier', port_info_dict['ext_identifier']),
-                     ('ext_rateselect_compliance', port_info_dict['ext_rateselect_compliance']),
-                     ('cable_type', port_info_dict['cable_type']),
-                     ('cable_length', str(port_info_dict['cable_length'])),
-                     ('specification_compliance', port_info_dict['specification_compliance']),
-                     ('nominal_bit_rate', str(port_info_dict['nominal_bit_rate'])),
-                     ('application_advertisement', port_info_dict['application_advertisement']
-                      if 'application_advertisement' in port_info_dict else 'N/A'),
-                     ('is_replaceable', str(is_replaceable)),
-                     ('dom_capability', port_info_dict['dom_capability']
-                      if 'dom_capability' in port_info_dict else 'N/A'),
-                     ('active_firmware', port_info_dict['active_firmware']
-                      if 'active_firmware' in port_info_dict else 'N/A'),
-                     ('inactive_firmware', port_info_dict['inactive_firmware']
-                      if 'inactive_firmware' in port_info_dict else 'N/A'),
-                     ('hardware_rev', port_info_dict['hardware_rev']
-                      if 'hardware_rev' in port_info_dict else 'N/A'),
-                     ('media_interface_code', port_info_dict['media_interface_code']
-                      if 'media_interface_code' in port_info_dict else 'N/A'),
-                     ('host_electrical_interface', port_info_dict['host_electrical_interface']
-                      if 'host_electrical_interface' in port_info_dict else 'N/A'),
-                     ('host_lane_count', str(port_info_dict['host_lane_count'])
-                      if 'host_lane_count' in port_info_dict else 'N/A'),
-                     ('media_lane_count', str(port_info_dict['media_lane_count'])
-                      if 'media_lane_count' in port_info_dict else 'N/A'),
-                     ('host_lane_assignment_option', str(port_info_dict['host_lane_assignment_option'])
-                      if 'host_lane_assignment_option' in port_info_dict else 'N/A'),
-                     ('media_lane_assignment_option', str(port_info_dict['media_lane_assignment_option'])
-                      if 'media_lane_assignment_option' in port_info_dict else 'N/A'),
-                     ('active_apsel_hostlane1', str(port_info_dict['active_apsel_hostlane1'])
-                      if 'active_apsel_hostlane1' in port_info_dict else 'N/A'),
-                     ('active_apsel_hostlane2', str(port_info_dict['active_apsel_hostlane2'])
-                      if 'active_apsel_hostlane2' in port_info_dict else 'N/A'),
-                     ('active_apsel_hostlane3', str(port_info_dict['active_apsel_hostlane3'])
-                      if 'active_apsel_hostlane3' in port_info_dict else 'N/A'),
-                     ('active_apsel_hostlane4', str(port_info_dict['active_apsel_hostlane4'])
-                      if 'active_apsel_hostlane4' in port_info_dict else 'N/A'),
-                     ('active_apsel_hostlane5', str(port_info_dict['active_apsel_hostlane5'])
-                      if 'active_apsel_hostlane5' in port_info_dict else 'N/A'),
-                     ('active_apsel_hostlane6', str(port_info_dict['active_apsel_hostlane6'])
-                      if 'active_apsel_hostlane6' in port_info_dict else 'N/A'),
-                     ('active_apsel_hostlane7', str(port_info_dict['active_apsel_hostlane7'])
-                      if 'active_apsel_hostlane7' in port_info_dict else 'N/A'),
-                     ('active_apsel_hostlane8', str(port_info_dict['active_apsel_hostlane8'])
-                      if 'active_apsel_hostlane8' in port_info_dict else 'N/A'),
-                     ('media_interface_technology', port_info_dict['media_interface_technology']
-                      if 'media_interface_technology' in port_info_dict else 'N/A'),
-                     ('cmis_rev', port_info_dict['cmis_rev'] if 'cmis_rev' in port_info_dict else 'N/A')
-                     ])
+                # if cmis is supported by the module
+                if 'cmis_rev' in port_info_dict:
+                    fvs = swsscommon.FieldValuePairs(
+                        [('type', port_info_dict['type']),
+                        ('vendor_rev', port_info_dict['vendor_rev']),
+                        ('serial', port_info_dict['serial']),
+                        ('manufacturer', port_info_dict['manufacturer']),
+                        ('model', port_info_dict['model']),
+                        ('vendor_oui', port_info_dict['vendor_oui']),
+                        ('vendor_date', port_info_dict['vendor_date']),
+                        ('connector', port_info_dict['connector']),
+                        ('encoding', port_info_dict['encoding']),
+                        ('ext_identifier', port_info_dict['ext_identifier']),
+                        ('ext_rateselect_compliance', port_info_dict['ext_rateselect_compliance']),
+                        ('cable_type', port_info_dict['cable_type']),
+                        ('cable_length', str(port_info_dict['cable_length'])),
+                        ('specification_compliance', port_info_dict['specification_compliance']),
+                        ('nominal_bit_rate', str(port_info_dict['nominal_bit_rate'])),
+                        ('application_advertisement', port_info_dict['application_advertisement']
+                        if 'application_advertisement' in port_info_dict else 'N/A'),
+                        ('is_replaceable', str(is_replaceable)),
+                        ('dom_capability', port_info_dict['dom_capability']
+                        if 'dom_capability' in port_info_dict else 'N/A'),
+                        ('cmis_rev', port_info_dict['cmis_rev'] if 'cmis_rev' in port_info_dict else 'N/A'),
+                        ('active_firmware', port_info_dict['active_firmware']
+                        if 'active_firmware' in port_info_dict else 'N/A'),
+                        ('inactive_firmware', port_info_dict['inactive_firmware']
+                        if 'inactive_firmware' in port_info_dict else 'N/A'),
+                        ('hardware_rev', port_info_dict['hardware_rev']
+                        if 'hardware_rev' in port_info_dict else 'N/A'),
+                        ('media_interface_code', port_info_dict['media_interface_code']
+                        if 'media_interface_code' in port_info_dict else 'N/A'),
+                        ('host_electrical_interface', port_info_dict['host_electrical_interface']
+                        if 'host_electrical_interface' in port_info_dict else 'N/A'),
+                        ('host_lane_count', str(port_info_dict['host_lane_count'])
+                        if 'host_lane_count' in port_info_dict else 'N/A'),
+                        ('media_lane_count', str(port_info_dict['media_lane_count'])
+                        if 'media_lane_count' in port_info_dict else 'N/A'),
+                        ('host_lane_assignment_option', str(port_info_dict['host_lane_assignment_option'])
+                        if 'host_lane_assignment_option' in port_info_dict else 'N/A'),
+                        ('media_lane_assignment_option', str(port_info_dict['media_lane_assignment_option'])
+                        if 'media_lane_assignment_option' in port_info_dict else 'N/A'),
+                        ('active_apsel_hostlane1', str(port_info_dict['active_apsel_hostlane1'])
+                        if 'active_apsel_hostlane1' in port_info_dict else 'N/A'),
+                        ('active_apsel_hostlane2', str(port_info_dict['active_apsel_hostlane2'])
+                        if 'active_apsel_hostlane2' in port_info_dict else 'N/A'),
+                        ('active_apsel_hostlane3', str(port_info_dict['active_apsel_hostlane3'])
+                        if 'active_apsel_hostlane3' in port_info_dict else 'N/A'),
+                        ('active_apsel_hostlane4', str(port_info_dict['active_apsel_hostlane4'])
+                        if 'active_apsel_hostlane4' in port_info_dict else 'N/A'),
+                        ('active_apsel_hostlane5', str(port_info_dict['active_apsel_hostlane5'])
+                        if 'active_apsel_hostlane5' in port_info_dict else 'N/A'),
+                        ('active_apsel_hostlane6', str(port_info_dict['active_apsel_hostlane6'])
+                        if 'active_apsel_hostlane6' in port_info_dict else 'N/A'),
+                        ('active_apsel_hostlane7', str(port_info_dict['active_apsel_hostlane7'])
+                        if 'active_apsel_hostlane7' in port_info_dict else 'N/A'),
+                        ('active_apsel_hostlane8', str(port_info_dict['active_apsel_hostlane8'])
+                        if 'active_apsel_hostlane8' in port_info_dict else 'N/A'),
+                        ('media_interface_technology', port_info_dict['media_interface_technology']
+                        if 'media_interface_technology' in port_info_dict else 'N/A'),
+                        ('supported_max_tx_power', str(port_info_dict['supported_max_tx_power'])
+                        if 'supported_max_tx_power' in port_info_dict else 'N/A'),
+                        ('supported_min_tx_power', str(port_info_dict['supported_min_tx_power'])
+                        if 'supported_min_tx_power' in port_info_dict else 'N/A'),
+                        ('supported_max_laser_freq', str(port_info_dict['supported_max_laser_freq'])
+                        if 'supported_max_laser_freq' in port_info_dict else 'N/A'),
+                        ('supported_min_laser_freq', str(port_info_dict['supported_min_laser_freq'])
+                        if 'supported_min_laser_freq' in port_info_dict else 'N/A')
+                    ])
+                # else cmis is not supported by the module
+                else:
+                    fvs = swsscommon.FieldValuePairs([
+                        ('type', port_info_dict['type']),
+                        ('vendor_rev', port_info_dict['vendor_rev']),
+                        ('serial', port_info_dict['serial']),
+                        ('manufacturer', port_info_dict['manufacturer']),
+                        ('model', port_info_dict['model']),
+                        ('vendor_oui', port_info_dict['vendor_oui']),
+                        ('vendor_date', port_info_dict['vendor_date']),
+                        ('connector', port_info_dict['connector']),
+                        ('encoding', port_info_dict['encoding']),
+                        ('ext_identifier', port_info_dict['ext_identifier']),
+                        ('ext_rateselect_compliance', port_info_dict['ext_rateselect_compliance']),
+                        ('cable_type', port_info_dict['cable_type']),
+                        ('cable_length', str(port_info_dict['cable_length'])),
+                        ('specification_compliance', port_info_dict['specification_compliance']),
+                        ('nominal_bit_rate', str(port_info_dict['nominal_bit_rate'])),
+                        ('application_advertisement', port_info_dict['application_advertisement']
+                        if 'application_advertisement' in port_info_dict else 'N/A'),
+                        ('is_replaceable', str(is_replaceable)),
+                        ('dom_capability', port_info_dict['dom_capability']
+                        if 'dom_capability' in port_info_dict else 'N/A')
+                    ])
                 table.set(port_name, fvs)
             else:
                 return SFP_EEPROM_NOT_READY

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -324,6 +324,43 @@ def post_port_sfp_info_to_db(logical_port_name, port_mapping, table, transceiver
                      ('is_replaceable', str(is_replaceable)),
                      ('dom_capability', port_info_dict['dom_capability']
                       if 'dom_capability' in port_info_dict else 'N/A'),
+                     ('active_firmware', port_info_dict['active_firmware']
+                      if 'active_firmware' in port_info_dict else 'N/A'),
+                     ('inactive_firmware', port_info_dict['inactive_firmware']
+                      if 'inactive_firmware' in port_info_dict else 'N/A'),
+                     ('hardware_rev', port_info_dict['hardware_rev']
+                      if 'hardware_rev' in port_info_dict else 'N/A'),
+                     ('media_interface_code', port_info_dict['media_interface_code']
+                      if 'media_interface_code' in port_info_dict else 'N/A'),
+                     ('host_electrical_interface', port_info_dict['host_electrical_interface']
+                      if 'host_electrical_interface' in port_info_dict else 'N/A'),
+                     ('host_lane_count', str(port_info_dict['host_lane_count'])
+                      if 'host_lane_count' in port_info_dict else 'N/A'),
+                     ('media_lane_count', str(port_info_dict['media_lane_count'])
+                      if 'media_lane_count' in port_info_dict else 'N/A'),
+                     ('host_lane_assignment_option', str(port_info_dict['host_lane_assignment_option'])
+                      if 'host_lane_assignment_option' in port_info_dict else 'N/A'),
+                     ('media_lane_assignment_option', str(port_info_dict['media_lane_assignment_option'])
+                      if 'media_lane_assignment_option' in port_info_dict else 'N/A'),
+                     ('active_apsel_hostlane1', str(port_info_dict['active_apsel_hostlane1'])
+                      if 'active_apsel_hostlane1' in port_info_dict else 'N/A'),
+                     ('active_apsel_hostlane2', str(port_info_dict['active_apsel_hostlane2'])
+                      if 'active_apsel_hostlane2' in port_info_dict else 'N/A'),
+                     ('active_apsel_hostlane3', str(port_info_dict['active_apsel_hostlane3'])
+                      if 'active_apsel_hostlane3' in port_info_dict else 'N/A'),
+                     ('active_apsel_hostlane4', str(port_info_dict['active_apsel_hostlane4'])
+                      if 'active_apsel_hostlane4' in port_info_dict else 'N/A'),
+                     ('active_apsel_hostlane5', str(port_info_dict['active_apsel_hostlane5'])
+                      if 'active_apsel_hostlane5' in port_info_dict else 'N/A'),
+                     ('active_apsel_hostlane6', str(port_info_dict['active_apsel_hostlane6'])
+                      if 'active_apsel_hostlane6' in port_info_dict else 'N/A'),
+                     ('active_apsel_hostlane7', str(port_info_dict['active_apsel_hostlane7'])
+                      if 'active_apsel_hostlane7' in port_info_dict else 'N/A'),
+                     ('active_apsel_hostlane8', str(port_info_dict['active_apsel_hostlane8'])
+                      if 'active_apsel_hostlane8' in port_info_dict else 'N/A'),
+                     ('media_interface_technology', port_info_dict['media_interface_technology']
+                      if 'media_interface_technology' in port_info_dict else 'N/A'),
+                     ('cmis_rev', port_info_dict['cmis_rev'] if 'cmis_rev' in port_info_dict else 'N/A')
                      ])
                 table.set(port_name, fvs)
             else:


### PR DESCRIPTION
This PR intends to include the recent changes made in the following two PRs from sonic-platform-common into transceiver_info table in state_db in xcvrd.py file.

https://github.com/Azure/sonic-platform-common/pull/228
https://github.com/Azure/sonic-platform-common/pull/235

#### Description
The update transceiver info can be referenced to the HLD [here](https://github.com/Azure/SONiC/blob/9a350f6881b5c9609ba07425862e2c1b689c41e1/doc/platform_api/CMIS_and_C-CMIS_support_for_ZR.md#211-transceiver-info-table).

#### Motivation and Context
The old xcvrd was using sonic-platform-common that does not support CMIS and C-CMIS memory mapping. After we introduce the support for CMIS and C-CMIS memory map in xcvr_api in sonic-platform-common, we want to adopt the changes in xcvrd by starting with updating the transceiver_info table. After update, the new keys in this table include:

- active_firmware
- inactive_firmware
- hardware_rev
- media_interface_code
- host_electrical_interface
- host_lane_count
- media_lane_count
- host_lane_assignment_option
- media_lane_assignment_option
- active_apsel_hostlane1
- active_apsel_hostlane2
- active_apsel_hostlane3
- active_apsel_hostlane4
- active_apsel_hostlane5
- active_apsel_hostlane6
- active_apsel_hostlane7
- active_apsel_hostlane8
- media_interface_technology
- cmis_rev
- supported_max_tx_power
- supported_min_tx_power
- supported_max_laser_freq
- supported_min_laser_freq

#### How Has This Been Tested?
Example of tests in sonic-arista 7060 box. Note: to protect 400ZR vendor-specific information, I removed vendor-related information.
```
#### Ethernet0:  XXX 400G-ZR module
admin@sonic:~$ redis-cli -n 6 hgetall "TRANSCEIVER_INFO|Ethernet0"
 1) "media_interface_code"
 2) "400ZR, DWDM, amplified"
 3) "encoding"
 4) "N/A"
 5) "serial"
 6) 
 7) "host_lane_assignment_option"
 8) "1"
 9) "vendor_oui"
10) 
11) "host_lane_count"
12) "8"
13) "ext_identifier"
14) "Power Class 8 (20.0W Max)"
15) "nominal_bit_rate"
16) "0"
17) "active_apsel_hostlane1"
18) "1"
19) "model"
20) 
21) "supported_max_laser_freq"
22) "196100"
23) "vendor_rev"
24) 
25) "active_apsel_hostlane2"
26) "1"
27) "active_apsel_hostlane7"
28) "1"
29) "application_advertisement"
30) "{1: {'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)', 'module_media_interface_id': '400ZR, DWDM, amplified', 'media_lane_count': 1, 'host_lane_count': 8, 'host_lane_assignment_options': 1}, 2: {'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)', 'module_media_interface_id': '400ZR, Single Wavelength, Unamplified', 'media_lane_count': 1, 'host_lane_count': 8, 'host_lane_assignment_options': 1}, 3: {'host_electrical_interface_id': '100GAUI-2 C2M (Annex 135G)', 'module_media_interface_id': '400ZR, DWDM, amplified', 'media_lane_count': 1, 'host_lane_count': 2, 'host_lane_assignment_options': 85}}"
31) "supported_min_tx_power"
32) "-22.9"
33) "active_firmware"
34) 
35) "cable_length"
36) "0.0"
37) "inactive_firmware"
38) 
39) "ext_rateselect_compliance"
40) "N/A"
41) "hardware_rev"
42) 
43) "host_electrical_interface"
44) "400GAUI-8 C2M (Annex 120E)"
45) "supported_max_tx_power"
46) "4.0"
47) "supported_min_laser_freq"
48) "191300"
49) "specification_compliance"
50) "sm_media_interface"
51) "connector"
52) "LC"
53) "active_apsel_hostlane8"
54) "1"
55) "media_interface_technology"
56) "1550 nm DFB"
57) "active_apsel_hostlane5"
58) "1"
59) "media_lane_assignment_option"
60) "1"
61) "cable_type"
62) "Length Cable Assembly(m)"
63) "manufacturer"
64) 
65) "is_replaceable"
66) "True"
67) "type"
68) "QSFP-DD Double Density 8X Pluggable Transceiver"
69) "vendor_date"
70) "2020-21-02 17"
71) "active_apsel_hostlane4"
72) "1"
73) "dom_capability"
74) "N/A"
75) "cmis_rev"
76) "4.1"
77) "active_apsel_hostlane3"
78) "1"
79) "media_lane_count"
80) "1"
81) "active_apsel_hostlane6"
82) "1"

#### Ethernet16:  Molex 400G-DR4 module 
admin@sonic:~$ redis-cli -n 6 hgetall "TRANSCEIVER_INFO|Ethernet16"
 1) "media_interface_code"
 2) "400GBASE-DR4 (Cl 124)"
 3) "encoding"
 4) "N/A"
 5) "serial"
 6) "G21211B3113     "
 7) "host_lane_assignment_option"
 8) "1"
 9) "vendor_oui"
10) "00-09-3a"
11) "host_lane_count"
12) "8"
13) "ext_identifier"
14) "Power Class 6 (12.0W Max)"
15) "nominal_bit_rate"
16) "0"
17) "active_apsel_hostlane1"
18) "1"
19) "model"
20) "1064281000      "
21) "supported_max_laser_freq"
22) "N/A"
23) "vendor_rev"
24) "11"
25) "active_apsel_hostlane2"
26) "1"
27) "active_apsel_hostlane7"
28) "1"
29) "application_advertisement"
30) "{1: {'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)', 'module_media_interface_id': '400GBASE-DR4 (Cl 124)', 'media_lane_count': 4, 'host_lane_count': 8, 'host_lane_assignment_options': 1}, 2: {'host_electrical_interface_id': '100GAUI-2 C2M (Annex 135G)', 'module_media_interface_id': '100GBASE-DR (Cl 140)', 'media_lane_count': 1, 'host_lane_count': 2, 'host_lane_assignment_options': 85}}"
31) "supported_min_tx_power"
32) "N/A"
33) "active_firmware"
34) "3.1"
35) "cable_length"
36) "0.0"
37) "inactive_firmware"
38) "3.1"
39) "ext_rateselect_compliance"
40) "N/A"
41) "hardware_rev"
42) "1.1"
43) "host_electrical_interface"
44) "400GAUI-8 C2M (Annex 120E)"
45) "supported_max_tx_power"
46) "N/A"
47) "supported_min_laser_freq"
48) "N/A"
49) "specification_compliance"
50) "sm_media_interface"
51) "connector"
52) "MPO 1x12"
53) "active_apsel_hostlane8"
54) "1"
55) "media_interface_technology"
56) "1310 nm DFB"
57) "active_apsel_hostlane5"
58) "1"
59) "media_lane_assignment_option"
60) "1"
61) "cable_type"
62) "Length Cable Assembly(m)"
63) "manufacturer"
64) "MOLEX           "
65) "is_replaceable"
66) "True"
67) "type"
68) "QSFP-DD Double Density 8X Pluggable Transceiver"
69) "vendor_date"
70) "2021-05-24   "
71) "active_apsel_hostlane4"
72) "1"
73) "dom_capability"
74) "N/A"
75) "cmis_rev"
76) "4.0"
77) "active_apsel_hostlane3"
78) "1"
79) "media_lane_count"
80) "4"
81) "active_apsel_hostlane6"
82) "1"


#### Ethernet160:  YYY 400G-ZR module 
admin@sonic:~$ redis-cli -n 6 hgetall "TRANSCEIVER_INFO|Ethernet160"
 1) "media_interface_code"
 2) "400ZR, DWDM, amplified"
 3) "encoding"
 4) "N/A"
 5) "serial"
 6) 
 7) "host_lane_assignment_option"
 8) "1"
 9) "vendor_oui"
10) 
11) "host_lane_count"
12) "8"
13) "ext_identifier"
14) "Power Class 8 (18.0W Max)"
15) "nominal_bit_rate"
16) "0"
17) "active_apsel_hostlane1"
18) "1"
19) "model"
20) 
21) "supported_max_laser_freq"
22) "196100"
23) "vendor_rev"
24) "01"
25) "active_apsel_hostlane2"
26) "1"
27) "active_apsel_hostlane7"
28) "1"
29) "application_advertisement"
30) "{1: {'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)', 'module_media_interface_id': '400ZR, DWDM, amplified', 'media_lane_count': 1, 'host_lane_count': 8, 'host_lane_assignment_options': 1}, 2: {'host_electrical_interface_id': '100GAUI-2 C2M (Annex 135G)', 'module_media_interface_id': '400ZR, DWDM, amplified', 'media_lane_count': 1, 'host_lane_count': 2, 'host_lane_assignment_options': 85}}"
31) "supported_min_tx_power"
32) "-14.0"
33) "active_firmware"
34) 
35) "cable_length"
36) "0.0"
37) "inactive_firmware"
38) 
39) "ext_rateselect_compliance"
40) "N/A"
41) "hardware_rev"
42) 
43) "host_electrical_interface"
44) "400GAUI-8 C2M (Annex 120E)"
45) "supported_max_tx_power"
46) 
47) "supported_min_laser_freq"
48) "191300"
49) "specification_compliance"
50) "sm_media_interface"
51) "connector"
52) "LC"
53) "active_apsel_hostlane8"
54) "1"
55) "media_interface_technology"
56) "C-band tunable laser"
57) "active_apsel_hostlane5"
58) "1"
59) "media_lane_assignment_option"
60) "1"
61) "cable_type"
62) "Length Cable Assembly(m)"
63) "manufacturer"
64)    "
65) "is_replaceable"
66) "True"
67) "type"
68) "QSFP-DD Double Density 8X Pluggable Transceiver"
69) "vendor_date"
70) "2020-10-20 "
71) "active_apsel_hostlane4"
72) "1"
73) "dom_capability"
74) "N/A"
75) "cmis_rev"
76) "5.0"
77) "active_apsel_hostlane3"
78) "1"
79) "media_lane_count"
80) "1"
81) "active_apsel_hostlane6"
82) "1"


#### Ethernet192:  InPhi 100G-DWDM module 
admin@sonic:~$ redis-cli -n 6 hgetall "TRANSCEIVER_INFO|Ethernet192"
 1) "cable_type"
 2) "Length(km)"
 3) "vendor_rev"
 4) "10"
 5) "serial"
 6) "L164200324      "
 7) "encoding"
 8) "PAM4"
 9) "vendor_oui"
10) "00-21-b8"
11) "ext_identifier"
12) "Unknown, No CLEI code present in Page 02h, CDR present in TX, CDR present in RX"
13) "application_advertisement"
14) "N/A"
15) "nominal_bit_rate"
16) "255"
17) "manufacturer"
18) "INPHI CORP      "
19) "type"
20) "QSFP28 or later"
21) "vendor_date"
22) "2017-02-08   "
23) "connector"
24) "LC"
25) "model"
26) "IN-Q2AY2-45-M1  "
27) "specification_compliance"
28) "{'10/40G Ethernet Compliance Code': 'Extended', 'SONET Compliance Codes': 'Unknown', 'SAS/SATA Compliance Codes': 'Unknown', 'Gigabit Ethernet Compliant Codes': 'Unknown', 'Fibre Channel Link Length': 'Unknown', 'Fibre Channel Transmitter Technology': 'Unknown', 'Fibre Channel Transmission Media': 'Unknown', 'Fibre Channel Speed': 'Unknown', 'Extended Specification Compliance': '100GE-DWDM2'}"
29) "is_replaceable"
30) "True"
31) "cable_length"
32) "80.0"
33) "dom_capability"
34) "N/A"
35) "ext_rateselect_compliance"
36) "Unknown"

#### Ethernet224:  Molex 100G-DR module 
admin@sonic:~$ redis-cli -n 6 hgetall "TRANSCEIVER_INFO|Ethernet224"
 1) "cable_type"
 2) "Length(km)"
 3) "vendor_rev"
 4) "11"
 5) "serial"
 6) "G21081R1177     "
 7) "encoding"
 8) "64B/66B"
 9) "vendor_oui"
10) "00-09-3a"
11) "ext_identifier"
12) "Power Class 6 Module (4.5W max.), No CLEI code present in Page 02h, CDR present in TX, CDR present in RX"
13) "application_advertisement"
14) "N/A"
15) "nominal_bit_rate"
16) "255"
17) "manufacturer"
18) "MOLEX           "
19) "type"
20) "QSFP28 or later"
21) "vendor_date"
22) "2021-02-22   "
23) "connector"
24) "LC"
25) "model"
26) "1064273500      "
27) "specification_compliance"
28) "{'10/40G Ethernet Compliance Code': 'Extended', 'SONET Compliance Codes': 'Unknown', 'SAS/SATA Compliance Codes': 'Unknown', 'Gigabit Ethernet Compliant Codes': 'Unknown', 'Fibre Channel Link Length': 'Unknown', 'Fibre Channel Transmitter Technology': 'Unknown', 'Fibre Channel Transmission Media': 'Unknown', 'Fibre Channel Speed': 'Unknown', 'Extended Specification Compliance': '100GBASE-DR'}"
29) "is_replaceable"
30) "True"
31) "cable_length"
32) "1.0"
33) "dom_capability"
34) "N/A"
35) "ext_rateselect_compliance"
36) "Unknown"
```

#### Additional Information (Optional)
