### PR TITLE
[CMIS]Improved 400G link bring up sequence

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -341,7 +341,7 @@ class TestXcvrdScript(object):
         mock_select.return_value = (swsscommon.Select.OBJECT, mock_selectable)
         mock_sub_table.return_value = mock_selectable
 
-        sel, asic_context = subscribe_port_config_change()
+        sel, asic_context = subscribe_port_config_change(DEFAULT_NAMESPACE)
         port_mapping = PortMapping()
         stop_event = threading.Event()
         stop_event.is_set = MagicMock(return_value=False)
@@ -369,7 +369,7 @@ class TestXcvrdScript(object):
         mock_table.getKeys = MagicMock(return_value=['Ethernet0', 'Ethernet4', 'Ethernet-IB0'])
         mock_table.get = MagicMock(side_effect=[(True, (('index', 1), )), (True, (('index', 2), )), (True, (('index', 3), ))])
         mock_swsscommon_table.return_value = mock_table
-        port_mapping = get_port_mapping()
+        port_mapping = get_port_mapping(DEFAULT_NAMESPACE)
         assert port_mapping.logical_port_list.count('Ethernet0')
         assert port_mapping.get_asic_id_for_logical_port('Ethernet0') == 0
         assert port_mapping.get_physical_to_logical(1) == ['Ethernet0']

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1,3 +1,4 @@
+#from unittest.mock import DEFAULT
 from xcvrd.xcvrd_utilities.port_mapping import *
 from xcvrd.xcvrd_utilities.sfp_status_helper import *
 from xcvrd.xcvrd import *
@@ -28,6 +29,7 @@ test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "xcvrd")
 sys.path.insert(0, modules_path)
+DEFAULT_NAMESPACE = ['']
 
 os.environ["XCVRD_UNIT_TESTING"] = "1"
 
@@ -242,7 +244,7 @@ class TestXcvrdScript(object):
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
         port_mapping.handle_port_change_event(port_change_event)
         stop_event = threading.Event()
-        xcvr_table_helper = XcvrTableHelper()
+        xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         post_port_sfp_dom_info_to_db(True, port_mapping, xcvr_table_helper, stop_event)
 
     @patch('xcvrd.xcvrd_utilities.port_mapping.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -255,7 +257,7 @@ class TestXcvrdScript(object):
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
         port_mapping.handle_port_change_event(port_change_event)
         stop_event = threading.Event()
-        xcvr_table_helper = XcvrTableHelper()
+        xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         init_port_sfp_status_tbl(port_mapping, xcvr_table_helper, stop_event)
 
     def test_get_media_settings_key(self):
@@ -418,7 +420,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd._wrapper_get_sfp_type', MagicMock(return_value='QSFP_DD'))
     def test_CmisManagerTask_handle_port_change_event(self):
         port_mapping = PortMapping()
-        task = CmisManagerTask(port_mapping)
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping)
 
         assert not task.isPortConfigDone
         port_change_event = PortChangeEvent('PortConfigDone', -1, 0, PortChangeEvent.PORT_SET)
@@ -450,7 +452,7 @@ class TestXcvrdScript(object):
         mock_chassis.get_all_sfps = MagicMock(return_value=[mock_object, mock_object])
 
         port_mapping = PortMapping()
-        task = CmisManagerTask(port_mapping)
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping)
         task.task_run()
         task.task_stop()
         assert task.task_process is None
@@ -536,7 +538,7 @@ class TestXcvrdScript(object):
         mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
 
         port_mapping = PortMapping()
-        task = CmisManagerTask(port_mapping)
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping)
 
         port_change_event = PortChangeEvent('PortConfigDone', -1, 0, PortChangeEvent.PORT_SET)
         task.on_port_update_event(port_change_event)
@@ -547,7 +549,7 @@ class TestXcvrdScript(object):
         task.on_port_update_event(port_change_event)
         assert len(task.port_dict) == 1
 
-        task.get_host_tx_status = MagicMock(return_value='True')
+        task.get_host_tx_status = MagicMock(return_value='true')
         task.get_port_admin_status = MagicMock(return_value='up')
 
         # Case 1: Module Inserted --> DP_DEINIT
@@ -583,8 +585,8 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
     def test_DomInfoUpdateTask_handle_port_change_event(self):
         port_mapping = PortMapping()
-        task = DomInfoUpdateTask(port_mapping)
-        task.xcvr_table_helper = XcvrTableHelper()
+        task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping)
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
         task.on_port_config_change(port_change_event)
         assert task.port_mapping.logical_port_list.count('Ethernet0')
@@ -603,7 +605,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd_utilities.port_mapping.handle_port_config_change', MagicMock())
     def test_DomInfoUpdateTask_task_run_stop(self):
         port_mapping = PortMapping()
-        task = DomInfoUpdateTask(port_mapping)
+        task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping)
         task.task_run()
         task.task_stop()
         assert not task.task_thread.is_alive()
@@ -623,8 +625,8 @@ class TestXcvrdScript(object):
         mock_sub_table.return_value = mock_selectable
 
         port_mapping = PortMapping()
-        task = DomInfoUpdateTask(port_mapping)
-        task.xcvr_table_helper = XcvrTableHelper()
+        task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping)
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.task_stopping_event.wait = MagicMock(side_effect=[False, True])
         mock_detect_error.return_value = True
         task.task_worker()
@@ -651,8 +653,8 @@ class TestXcvrdScript(object):
         stopping_event = multiprocessing.Event()
         port_mapping = PortMapping()
         retry_eeprom_set = set()
-        task = SfpStateUpdateTask(port_mapping, retry_eeprom_set)
-        task.xcvr_table_helper = XcvrTableHelper()
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, retry_eeprom_set)
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
         wait_time = 5
         while wait_time > 0:
@@ -682,7 +684,7 @@ class TestXcvrdScript(object):
     def test_SfpStateUpdateTask_task_run_stop(self):
         port_mapping = PortMapping()
         retry_eeprom_set = set()
-        task = SfpStateUpdateTask(port_mapping, retry_eeprom_set)
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, retry_eeprom_set)
         sfp_error_event = multiprocessing.Event()
         task.task_run(sfp_error_event)
         assert wait_until(5, 1, task.task_process.is_alive)
@@ -697,8 +699,8 @@ class TestXcvrdScript(object):
 
         port_mapping = PortMapping()
         retry_eeprom_set = set()
-        task = SfpStateUpdateTask(port_mapping, retry_eeprom_set)
-        task.xcvr_table_helper = XcvrTableHelper()
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, retry_eeprom_set)
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_intf_tbl = MagicMock(return_value=mock_table)
         task.xcvr_table_helper.get_dom_tbl = MagicMock(return_value=mock_table)
         task.xcvr_table_helper.get_app_port_tbl = MagicMock(return_value=mock_table)
@@ -723,7 +725,7 @@ class TestXcvrdScript(object):
     def test_SfpStateUpdateTask_mapping_event_from_change_event(self):
         port_mapping = PortMapping()
         retry_eeprom_set = set()
-        task = SfpStateUpdateTask(port_mapping, retry_eeprom_set)
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, retry_eeprom_set)
         port_dict = {}
         assert task._mapping_event_from_change_event(False, port_dict) == SYSTEM_FAIL
         assert port_dict[EVENT_ON_ALL_SFP] == SYSTEM_FAIL
@@ -755,8 +757,8 @@ class TestXcvrdScript(object):
     def test_SfpStateUpdateTask_task_worker(self, mock_updata_status, mock_post_sfp_info, mock_post_dom_info, mock_post_dom_th, mock_update_media_setting, mock_del_dom, mock_change_event, mock_mapping_event, mock_os_kill):
         port_mapping = PortMapping()
         retry_eeprom_set = set()
-        task = SfpStateUpdateTask(port_mapping, retry_eeprom_set)
-        task.xcvr_table_helper = XcvrTableHelper()
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, retry_eeprom_set)
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         stop_event = multiprocessing.Event()
         sfp_error_event = multiprocessing.Event()
         mock_change_event.return_value = (True, {0: 0}, {})
@@ -865,8 +867,8 @@ class TestXcvrdScript(object):
 
         port_mapping = PortMapping()
         retry_eeprom_set = set()
-        task = SfpStateUpdateTask(port_mapping, retry_eeprom_set)
-        task.xcvr_table_helper = XcvrTableHelper()
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, retry_eeprom_set)
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_status_tbl = mock_table_helper.get_status_tbl
         task.xcvr_table_helper.get_intf_tbl = mock_table_helper.get_intf_tbl
         task.xcvr_table_helper.get_dom_tbl = mock_table_helper.get_dom_tbl

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -994,10 +994,10 @@ class CmisManagerTask:
                 self.port_dict[lport]['lanes'] = port_change_event.port_dict['lanes']
             if 'host_tx_ready' in port_change_event.port_dict:
                 self.port_dict[lport]['host_tx_ready'] = port_change_event.port_dict['host_tx_ready']
-            if 'admin_status' in port_change_event.port_dict and 'oper_status' in port_change_event.dict:
+            if 'admin_status' in port_change_event.port_dict and 'oper_status' in port_change_event.port_dict:
                 # At times 'admin_status' is NOT the same in the PORT_TABLE of APPL_DB and STATE_DB
                 # We dont have better way to check if 'admin_status' is from APPL_DB or STATE_DB so this
-                # check is put temporarily to list only to APPL_DB's admin_status and ignore that of STATE_DB
+                # check is put temporarily to listen only to APPL_DB's admin_status and ignore that of STATE_DB
                 self.port_dict[lport]['admin_status'] = port_change_event.port_dict['admin_status']
             self.force_cmis_reinit(lport, 0)
         else:

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1331,6 +1331,8 @@ class CmisManagerTask:
                            self.log_notice("{} Forcing Tx laser OFF".format(lport))
                            # Force DataPath re-init
                            api.tx_disable_channel(host_lanes, True)
+                           self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_READY
+                           continue
 
                         appl = self.get_cmis_application_desired(api, host_lanes, host_speed)
                         if appl < 1:

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -994,7 +994,10 @@ class CmisManagerTask:
                 self.port_dict[lport]['lanes'] = port_change_event.port_dict['lanes']
             if 'host_tx_ready' in port_change_event.port_dict:
                 self.port_dict[lport]['host_tx_ready'] = port_change_event.port_dict['host_tx_ready']
-            if 'admin_status' in port_change_event.port_dict:
+            if 'admin_status' in port_change_event.port_dict and 'oper_status' in port_change_event.dict:
+                # At times 'admin_status' is NOT the same in the PORT_TABLE of APPL_DB and STATE_DB
+                # We dont have better way to check if 'admin_status' is from APPL_DB or STATE_DB so this
+                # check is put temporarily to list only to APPL_DB's admin_status and ignore that of STATE_DB
                 self.port_dict[lport]['admin_status'] = port_change_event.port_dict['admin_status']
             self.force_cmis_reinit(lport, 0)
         else:

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/port_mapping.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/port_mapping.py
@@ -106,23 +106,21 @@ def subscribe_port_config_change():
         sel.addSelectable(port_tbl)
     return sel, asic_context
 
-def subscribe_port_update_event(db_list=['APPL_DB', 'STATE_DB']):
-    port_tbl_map = {
-        'APPL_DB': swsscommon.APP_PORT_TABLE_NAME,
-        'CONFIG_DB': swsscommon.CFG_PORT_TABLE_NAME,
-        'STATE_DB': 'TRANSCEIVER_INFO'
-    }
+def subscribe_port_update_event():
+    port_tbl_map = [
+        {'APPL_DB': swsscommon.APP_PORT_TABLE_NAME},
+        {'STATE_DB': 'TRANSCEIVER_INFO'},
+        {'STATE_DB': 'PORT_TABLE'},
+    ]
 
     sel = swsscommon.Select()
     asic_context = {}
     namespaces = multi_asic.get_front_end_namespaces()
-    for db_name in db_list:
-        if db_name not in port_tbl_map:
-            continue
+    for d in port_tbl_map:
         for namespace in namespaces:
-            db = daemon_base.db_connect(db_name, namespace=namespace)
+            db = daemon_base.db_connect(list(d.keys())[0], namespace=namespace)
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-            port_tbl = swsscommon.SubscriberStateTable(db, port_tbl_map[db_name])
+            port_tbl = swsscommon.SubscriberStateTable(db, list(d.values())[0])
             asic_context[port_tbl] = asic_id
             sel.addSelectable(port_tbl)
     return sel, asic_context
@@ -186,7 +184,7 @@ def read_port_config_change(asic_context, port_mapping, logger, port_change_even
             if not key:
                 break
             if not validate_port(key):
-                continue 
+                continue
             if op == swsscommon.SET_COMMAND:
                 fvp = dict(fvp)
                 if 'index' not in fvp:

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/port_mapping.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/port_mapping.py
@@ -94,10 +94,9 @@ def validate_port(port):
         return False
     return True
 
-def subscribe_port_config_change():
+def subscribe_port_config_change(namespaces):
     sel = swsscommon.Select()
     asic_context = {}
-    namespaces = multi_asic.get_front_end_namespaces()
     for namespace in namespaces:
         config_db = daemon_base.db_connect("CONFIG_DB", namespace=namespace)
         asic_id = multi_asic.get_asic_index_from_namespace(namespace)
@@ -106,7 +105,7 @@ def subscribe_port_config_change():
         sel.addSelectable(port_tbl)
     return sel, asic_context
 
-def subscribe_port_update_event():
+def subscribe_port_update_event(namespaces):
     port_tbl_map = [
         {'APPL_DB': swsscommon.APP_PORT_TABLE_NAME},
         {'STATE_DB': 'TRANSCEIVER_INFO'},
@@ -115,7 +114,6 @@ def subscribe_port_update_event():
 
     sel = swsscommon.Select()
     asic_context = {}
-    namespaces = multi_asic.get_front_end_namespaces()
     for d in port_tbl_map:
         for namespace in namespaces:
             db = daemon_base.db_connect(list(d.keys())[0], namespace=namespace)
@@ -216,11 +214,10 @@ def read_port_config_change(asic_context, port_mapping, logger, port_change_even
             else:
                 logger.log_warning('Invalid DB operation: {}'.format(op))
 
-def get_port_mapping():
+def get_port_mapping(namespaces):
     """Get port mapping from CONFIG_DB
     """
     port_mapping = PortMapping()
-    namespaces = multi_asic.get_front_end_namespaces()
     for namespace in namespaces:
         asic_id = multi_asic.get_asic_index_from_namespace(namespace)
         config_db = daemon_base.db_connect("CONFIG_DB", namespace=namespace)


### PR DESCRIPTION
#### Description
Improved 400G link bring up sequence [HLD](https://github.com/sonic-net/SONiC/blob/master/doc/sfp-cmis/Interface-Link-bring-up-sequence.md)

1. Ensure CMIS compliant transceiver Datapath are initialized and activated IFF the host Tx signal is good and admin_status is UP
2. get_all_namespace() API is not reentrant resulting in crash, so we cache the namespace at the xcvrd start
3. Datapath is deactivated if either 'admin_status' becomes down or 'host_tx_ready' signal becomes OFF.
4. An option "--skip_xcvrd_cmis_mgr" is added to skip launch of CMIS task manager for platforms that are in transition to using SFP-refactor code 
5. Datapath is NOT impacted if Xcvrd crash/restarts

#### Motivation and Context
Deterministically improve the link bring up of 400G link that are using CMIS compliant transceivers.

#### How Has This Been Tested?
Tested on 
1. Cisco 8800 chassis: Being validated by Cisco
2. Dell Z9332F

#### Additional Information (Optional)
