### PR TITLE
[ycabled] fix the posting for mux_cable_static_info per downlink when ycabled is spawned; synchronizing executing Telemetry API

### DIFF
--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -4674,3 +4674,15 @@ class TestYCableScript(object):
             rc = handle_show_hwmode_state_cmd_arg_tbl_notification(
                 fvp, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
             assert(rc == None)
+
+    def test_get_mux_cable_static_info_without_presence(self):
+
+        rc = get_muxcable_info_without_presence()
+
+        assert(rc['read_side'] == '-1')
+        assert(rc['nic_lane1_precursor1'] == 'unknown')
+        assert(rc['nic_lane1_precursor1'] == 'N/A')
+        assert(rc['nic_lane1_postcursor1'] == 'N/A')
+        assert(rc['nic_lane1_postcursor2'] == 'N/A')
+
+

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -379,9 +379,19 @@ class TestYCableScript(object):
     def test_y_cable_toggle_mux_torB_update_status_exception(self):
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as port_instance:
 
-            port_instance.get.return_value = "simulated_port"
-            port_instance.toggle_mux_to_tor_a.return_value = Exception(
-                NotImplementedError)
+            class PortInstanceHelper():
+                def __init__(self):
+                    self.EEPROM_ERROR = -1
+                    self.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED = 0
+
+                # Defining function without self argument creates an exception,
+                # which is what we want for this test.
+                def get_mux_direction():
+                    pass
+                def toggle_mux_to_tor_a():
+                    raise NotImplementedError
+
+            port_instance.get.return_value = PortInstanceHelper()
 
             rc = y_cable_toggle_mux_torB(1)
 

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -4740,7 +4740,7 @@ class TestYCableScript(object):
         rc = get_muxcable_static_info_without_presence()
 
         assert(rc['read_side'] == '-1')
-        assert(rc['nic_lane1_precursor1'] == 'unknown')
+        assert(rc['nic_lane1_precursor1'] == 'N/A')
         assert(rc['nic_lane1_precursor1'] == 'N/A')
         assert(rc['nic_lane1_postcursor1'] == 'N/A')
         assert(rc['nic_lane1_postcursor2'] == 'N/A')

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -347,9 +347,20 @@ class TestYCableScript(object):
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as port_instance:
 
-            port_instance.get.return_value = "simulated_port"
-            port_instance.toggle_mux_to_tor_a.return_value = Exception(
-                NotImplementedError)
+            class PortInstanceHelper():
+                def __init__(self):
+                    self.EEPROM_ERROR = -1
+                    self.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED = 0
+
+                # Defining function without self argument creates an exception,
+                # which is what we want for this test.
+                def get_mux_direction():
+                    pass
+                def toggle_mux_to_tor_a():
+                    raise NotImplementedError
+
+            port_instance.get.return_value = PortInstanceHelper()
+
 
             rc = y_cable_toggle_mux_torA(1)
 
@@ -1867,6 +1878,10 @@ class TestYCableScript(object):
                     self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
                     self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
                     self.download_firmware_status = 0
+                    self.MUX_TOGGLE_STATUS_INPROGRESS = 1
+                    self.MUX_TOGGLE_STATUS_FAILED = 2
+                    self.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED = 2
+                    self.mux_toggle_status = 0
                     self.SWITCH_COUNT_MANUAL = "manual"
                     self.SWITCH_COUNT_AUTO = "auto"
 
@@ -1929,6 +1944,10 @@ class TestYCableScript(object):
                     self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
                     self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
                     self.download_firmware_status = 0
+                    self.MUX_TOGGLE_STATUS_INPROGRESS = 1
+                    self.MUX_TOGGLE_STATUS_FAILED = 2
+                    self.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED = 2
+                    self.mux_toggle_status = 0
                     self.SWITCH_COUNT_MANUAL = "manual"
                     self.SWITCH_COUNT_AUTO = "auto"
 
@@ -1989,6 +2008,10 @@ class TestYCableScript(object):
                     self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
                     self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
                     self.download_firmware_status = 0
+                    self.MUX_TOGGLE_STATUS_INPROGRESS = 1
+                    self.MUX_TOGGLE_STATUS_FAILED = 2
+                    self.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED = 2
+                    self.mux_toggle_status = 0
                     self.SWITCH_COUNT_MANUAL = "manual"
                     self.SWITCH_COUNT_AUTO = "auto"
 
@@ -2051,6 +2074,10 @@ class TestYCableScript(object):
                     self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
                     self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
                     self.download_firmware_status = 0
+                    self.MUX_TOGGLE_STATUS_INPROGRESS = 1
+                    self.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED = 2
+                    self.MUX_TOGGLE_STATUS_FAILED = 2
+                    self.mux_toggle_status = 0
                     self.SWITCH_COUNT_MANUAL = "manual"
                     self.SWITCH_COUNT_AUTO = "auto"
 
@@ -2111,6 +2138,10 @@ class TestYCableScript(object):
                     self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
                     self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
                     self.download_firmware_status = 0
+                    self.MUX_TOGGLE_STATUS_INPROGRESS = 1
+                    self.MUX_TOGGLE_STATUS_FAILED = 2
+                    self.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED = 2
+                    self.mux_toggle_status = 0
                     self.SWITCH_COUNT_MANUAL = "manual"
                     self.SWITCH_COUNT_AUTO = "auto"
 
@@ -2173,6 +2204,9 @@ class TestYCableScript(object):
                     self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
                     self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
                     self.download_firmware_status = 0
+                    self.MUX_TOGGLE_STATUS_INPROGRESS = 1
+                    self.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED = 2
+                    self.mux_toggle_status = 0
                     self.SWITCH_COUNT_MANUAL = "manual"
                     self.SWITCH_COUNT_AUTO = "auto"
 
@@ -2233,6 +2267,10 @@ class TestYCableScript(object):
                     self.TARGET_TOR_B = 2
                     self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
                     self.download_firmware_status = 1
+                    self.MUX_TOGGLE_STATUS_INPROGRESS = 1
+                    self.MUX_TOGGLE_STATUS_FAILED = 2
+                    self.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED = 2
+                    self.mux_toggle_status = 0
                     self.SWITCH_COUNT_MANUAL = "manual"
                     self.SWITCH_COUNT_AUTO = "auto"
 
@@ -2308,6 +2346,10 @@ class TestYCableScript(object):
                     self.TARGET_TOR_B = 2
                     self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
                     self.download_firmware_status = 1
+                    self.MUX_TOGGLE_STATUS_INPROGRESS = 1
+                    self.MUX_TOGGLE_STATUS_FAILED = 2
+                    self.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED = 2
+                    self.mux_toggle_status = 0
                     self.SWITCH_COUNT_MANUAL = "manual"
                     self.SWITCH_COUNT_AUTO = "auto"
 
@@ -2383,6 +2425,10 @@ class TestYCableScript(object):
                     self.TARGET_TOR_B = 2
                     self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
                     self.download_firmware_status = 1
+                    self.MUX_TOGGLE_STATUS_INPROGRESS = 1
+                    self.MUX_TOGGLE_STATUS_FAILED = 2
+                    self.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED = 2
+                    self.mux_toggle_status = 0
                     self.SWITCH_COUNT_MANUAL = "manual"
                     self.SWITCH_COUNT_AUTO = "auto"
 

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -3943,6 +3943,10 @@ class TestYCableScript(object):
                     self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
                     self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
                     self.download_firmware_status = 0
+                    self.MUX_TOGGLE_STATUS_INPROGRESS = 1
+                    self.MUX_TOGGLE_STATUS_FAILED = 2
+                    self.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED = 2
+                    self.mux_toggle_status = 0
                     self.SWITCH_COUNT_MANUAL = "manual"
                     self.SWITCH_COUNT_AUTO = "auto"
 
@@ -4733,7 +4737,7 @@ class TestYCableScript(object):
 
     def test_get_mux_cable_static_info_without_presence(self):
 
-        rc = get_muxcable_info_without_presence()
+        rc = get_muxcable_static_info_without_presence()
 
         assert(rc['read_side'] == '-1')
         assert(rc['nic_lane1_precursor1'] == 'unknown')

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -1076,6 +1076,41 @@ def get_firmware_dict(physical_port, port_instance, target, side, mux_info_dict,
         mux_info_dict[("version_{}_inactive".format(side))] = "N/A"
         mux_info_dict[("version_{}_next".format(side))] = "N/A"
 
+def get_muxcable_static_info_without_presence():
+    mux_info_static_dict = {}
+    mux_info_static_dict['read_side']= '-1'
+    mux_info_static_dict['nic_lane1_precursor1'] = 'N/A'
+    mux_info_static_dict['nic_lane1_precursor2'] = 'N/A'
+    mux_info_static_dict['nic_lane1_maincursor'] = 'N/A'
+    mux_info_static_dict['nic_lane1_postcursor1'] = 'N/A'
+    mux_info_static_dict['nic_lane1_postcursor2'] = 'N/A'
+    mux_info_static_dict['nic_lane2_precursor1'] = 'N/A'
+    mux_info_static_dict['nic_lane2_precursor2'] = 'N/A'
+    mux_info_static_dict['nic_lane2_maincursor'] = 'N/A'
+    mux_info_static_dict['nic_lane2_postcursor1'] = 'N/A'
+    mux_info_static_dict['nic_lane2_postcursor2'] = 'N/A'
+    mux_info_static_dict['tor_self_lane1_precursor1'] = 'N/A'
+    mux_info_static_dict['tor_self_lane1_precursor2'] = 'N/A'
+    mux_info_static_dict['tor_self_lane1_maincursor'] = 'N/A'
+    mux_info_static_dict['tor_self_lane1_postcursor1'] = 'N/A'
+    mux_info_static_dict['tor_self_lane1_postcursor2'] = 'N/A'
+    mux_info_static_dict['tor_self_lane2_precursor1'] = 'N/A'
+    mux_info_static_dict['tor_self_lane2_precursor2'] = 'N/A'
+    mux_info_static_dict['tor_self_lane2_maincursor'] = 'N/A'
+    mux_info_static_dict['tor_self_lane2_postcursor1'] = 'N/A'
+    mux_info_static_dict['tor_self_lane2_postcursor2'] = 'N/A'
+    mux_info_static_dict['tor_peer_lane1_precursor1'] = 'N/A'
+    mux_info_static_dict['tor_peer_lane1_precursor2'] = 'N/A'
+    mux_info_static_dict['tor_peer_lane1_maincursor'] = 'N/A'
+    mux_info_static_dict['tor_peer_lane1_postcursor1'] = 'N/A'
+    mux_info_static_dict['tor_peer_lane1_postcursor2'] = 'N/A'
+    mux_info_static_dict['tor_peer_lane2_precursor1'] = 'N/A'
+    mux_info_static_dict['tor_peer_lane2_precursor2'] = 'N/A' 
+    mux_info_static_dict['tor_peer_lane2_maincursor'] = 'N/A'
+    mux_info_static_dict['tor_peer_lane2_postcursor1'] = 'N/A'
+    mux_info_static_dict['tor_peer_lane2_postcursor2'] = 'N/A'
+
+    return mux_info_static_dict
 
 def get_muxcable_info_without_presence():
     mux_info_dict = {}
@@ -1540,9 +1575,11 @@ def post_port_mux_static_info_to_db(logical_port_name, static_table):
     for physical_port in physical_port_list:
 
         if not y_cable_wrapper_get_presence(physical_port):
-            continue
+            helper_logger.log_warning("Error: trying to post mux static info without presence of port {}".format(logical_port_name))
+            mux_static_info_dict = get_muxcable_static_info_without_presence()
+        else:
+            mux_static_info_dict = get_muxcable_static_info(physical_port, logical_port_name)
 
-        mux_static_info_dict = get_muxcable_static_info(physical_port, logical_port_name)
 
         if mux_static_info_dict is not None and mux_static_info_dict is not -1:
             #transceiver_dict[physical_port] = port_info_dict

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -645,6 +645,8 @@ def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_c
                                 # fill in the newly found entry
                                 read_y_cable_and_update_statedb_port_tbl(
                                     logical_port_name, y_cable_tbl[asic_index])
+                                post_port_mux_static_info_to_db(
+                                    logical_port_name, static_tbl[asic_index])
 
                             else:
                                 # first create the state db y cable table and then fill in the entry

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -2578,10 +2578,11 @@ class YCableTableUpdateTask(object):
                             mux_port_dict = dict(fv)
                             read_side = mux_port_dict.get("read_side")
                             update_appdb_port_mux_cable_response_table(port_m, asic_index, appl_db, int(read_side))
+
             while True:
                 (port, op_m, fvp_m) = status_app_tbl[asic_index].pop()
 
-                if not port_m:
+                if not port:
                     break
                 helper_logger.log_debug("Y_CABLE_DEBUG: received a mux_cable_table app update for port status {} {}".format(port, threading.currentThread().getName()))
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -268,10 +268,11 @@ def y_cable_toggle_mux_torA(physical_port):
 
     try:
         update_status = port_instance.toggle_mux_to_tor_a()
-        port_instance.mux_toggle_status = port_instance.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED
     except Exception as e:
         update_status = -1
         helper_logger.log_warning("Failed to execute the toggle mux ToR A API for port {} due to {} {}".format(physical_port, repr(e) , threading.currentThread().getName()))
+
+    port_instance.mux_toggle_status = port_instance.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED
 
     helper_logger.log_debug("Y_CABLE_DEBUG: Status of toggling mux to ToR A for port {} status {} {}".format(physical_port, update_status, threading.currentThread().getName()))
     if update_status is True:
@@ -291,10 +292,11 @@ def y_cable_toggle_mux_torB(physical_port):
 
     try:
         update_status = port_instance.toggle_mux_to_tor_b()
-        port_instance.mux_toggle_status = port_instance.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED
     except Exception as e:
         update_status = -1
         helper_logger.log_warning("Failed to execute the toggle mux ToR B API for port {} due to {} {}".format(physical_port,repr(e), threading.currentThread().getName()))
+
+    port_instance.mux_toggle_status = port_instance.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED
 
     helper_logger.log_debug("Y_CABLE_DEBUG: Status of toggling mux to ToR B for port {} {} {}".format(physical_port, update_status, threading.currentThread().getName()))
     if update_status is True:
@@ -331,12 +333,14 @@ def toggle_mux_tor_direction_and_update_read_side(state, logical_port_name, phys
     if read_side is None or read_side is port_instance.EEPROM_ERROR or read_side < 0:
         helper_logger.log_error(
             "Error: Could not get read side for toggle command from orchagent Y cable port {}".format(logical_port_name))
+        port_instance.mux_toggle_status = port_instance.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED
         return (-1, -1)
     if int(read_side) == 1 or int(read_side) == 2:
         (active_side, read_side) = toggle_mux_direction(physical_port, read_side, state)
         return (active_side, read_side)
     else:
         #should not happen
+        port_instance.mux_toggle_status = port_instance.MUX_TOGGLE_STATUS_NOT_INITIATED_OR_FINISHED
         return (-1,-1)
 
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -602,6 +602,8 @@ def create_tables_and_insert_mux_unknown_entries(state_db, y_cable_tbl, static_t
     # fill the newly found entry
     read_y_cable_and_update_statedb_port_tbl(
         logical_port_name, y_cable_tbl[asic_index])
+    post_port_mux_static_info_to_db(
+        logical_port_name, static_tbl[asic_index])
 
 def check_identifier_presence_and_update_mux_table_entry(state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name, y_cable_presence):
 


### PR DESCRIPTION
This PR is meant to do two fixes.
1) For the Y-cable if presence is missing, currently there is no provision for posting the MUX_CABLE_STATIC_INFO, this PR puts in that fix.
2) ycabled now utilizes the MUX_CABLE_TABLE:<port> to be notified/prepared to toggle the mux and blocks all ongoing i2c telemetry transactions which could be concurrently running. This PR utilizes a support  for adding a mux_toggle_status variable inside the base class for mux_cable.
Using this variable the Derived classes for mux_cable can check this and return in case of a mux_toggle_status is in progress.
From the higher layer this allows ycabled to synchronize the calls and not let mux_cable toggle to go in conjunction with some of the Telemetry calls.

3) also added a commented sub-routine to poll the mux direction after toggle
dependent on https://github.com/Azure/sonic-platform-common/pull/280
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>


<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Unit-tests as well as ran changes on Arista7050cx3 testbed
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
