### PR TITLE
Mem leak caused by Xcvrd in Send-Q of REDIS-DB socket connection

### DIFF
--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -389,6 +389,33 @@ def waiting_time_compensation_with_sleep(time_start, time_to_wait):
     if time_diff < time_to_wait:
         time.sleep(time_to_wait - time_diff)
 
+def wait_for_all_ports_configured():
+    # Connect to APPL_DB and subscribe to PORT table notifications
+    appl_db = swsscommon.DBConnector(swsscommon.APPL_DB,
+                                     REDIS_HOSTNAME,
+                                     REDIS_PORT,
+                                     REDIS_TIMEOUT_MSECS)
+    sel = swsscommon.Select()
+    sst = swsscommon.SubscriberStateTable(appl_db, swsscommon.APP_PORT_TABLE_NAME)
+    sel.addSelectable(sst)
+
+    # Make sure this daemon started after all port configured.
+    while XCVRD_MAIN_TASK_RUNNING_FLAG:
+        (state, c) = sel.select(SELECT_TIMEOUT_MSECS)
+        if state == swsscommon.Select.TIMEOUT:
+            continue
+        if state != swsscommon.Select.OBJECT:
+            log_warning("sel.select() did not return swsscommon.Select.OBJECT")
+            continue
+
+        (key, op, fvp) = sst.pop()
+        if key in ["PortConfigDone", "PortInitDone"]:
+            break
+    # Close the unused socket to prevent mem-leak. Since Xcvrd opens socket to subscribe to
+    # APP_DB's PORT_TABLE events, if Xcvrd doesnot listen on the opened socket, then over a
+    # period of time, redis-DB Send-Q will accumulate events(Eg due to continous port flap)
+    # that can grow up slowly over a period of time resulting in memory leak.
+    sel.removeSelectable(sst)
 
 # Timer thread wrapper class to update dom info to DB periodically
 class dom_info_update_task:
@@ -446,34 +473,8 @@ def main():
     int_tbl = swsscommon.Table(state_db, "TRANSCEIVER_INFO")
     dom_tbl = swsscommon.Table(state_db, "TRANSCEIVER_DOM_SENSOR")
 
-    # Connect to APPL_DB abd subscribe to PORT table notifications
-    appl_db = swsscommon.DBConnector(swsscommon.APPL_DB,
-                                     REDIS_HOSTNAME,
-                                     REDIS_PORT,
-                                     REDIS_TIMEOUT_MSECS)
 
-    sel = swsscommon.Select()
-    sst = swsscommon.SubscriberStateTable(appl_db, swsscommon.APP_PORT_TABLE_NAME)
-    sel.addSelectable(sst)
-
-    # Make sure this daemon started after all port configured.
-    while XCVRD_MAIN_TASK_RUNNING_FLAG:
-        (state, c) = sel.select(SELECT_TIMEOUT_MSECS)
-        if state == swsscommon.Select.TIMEOUT:
-            continue
-        if state != swsscommon.Select.OBJECT:
-            log_warning("sel.select() did not return swsscommon.Select.OBJECT")
-            continue
-
-        (key, op, fvp) = sst.pop()
-        if key in ["PortConfigDone", "PortInitDone"]:
-            break
-
-    # Close the unused socket to prevent mem-leak. Since Xcvrd opens socket to subscribe to
-    # APP_DB's PORT_TABLE events, if Xcvrd doesnot listen on the opened socket, then over a
-    # period of time, redis-DB Send-Q will accumulate events(Eg due to continous port flap) 
-    # that can grow up slowly over a period of time resulting in memory leak. 
-    sel.removeSelectable(sst)
+    wait_for_all_ports_configured()
 
     # Post all the current interface SFP info to STATE_DB
     logical_port_list = platform_sfputil.logical
@@ -501,16 +502,16 @@ def main():
     # - Initial state: INIT, before received system ready or a normal event
     # - Final state: EXIT
     # - other state: NORMAL, after has received system-ready or a normal event
-    
+
     # events definition
     # - SYSTEM_NOT_READY
     # - SYSTEM_BECOME_READY
-    #   - 
+    #   -
     # - NORMAL_EVENT
     #   - sfp insertion/removal
     #   - timeout returned by sfputil.get_change_event with status = true
     # - SYSTEM_FAIL
-    
+
     # State transition:
     # 1. SYSTEM_NOT_READY
     #     - INIT
@@ -562,7 +563,7 @@ def main():
         time_start = time.time()
         status, port_dict = platform_sfputil.get_transceiver_change_event(timeout)
         event = mapping_event_from_change_event(status, port_dict)
-        
+
         if event == SYSTEM_NOT_READY:
             if state == STATE_INIT:
                 # system not ready, wait and retry
@@ -572,10 +573,10 @@ def main():
                 else:
                     retry = retry + 1
 
-                    # get_transceiver_change_event may return immediately, 
-                    # we want the retry expired in expected time period, 
-                    # So need to calc the time diff, 
-                    # if time diff less that the pre-defined waiting time, 
+                    # get_transceiver_change_event may return immediately,
+                    # we want the retry expired in expected time period,
+                    # So need to calc the time diff,
+                    # if time diff less that the pre-defined waiting time,
                     # use sleep() to complete the time.
                     waiting_time_compensation_with_sleep(time_start, RETRY_PERIOD_FOR_SYSTEM_READY_MSECS/1000)
             elif state == STATE_NORMAL:
@@ -593,8 +594,8 @@ def main():
                 next_state = STATE_NORMAL
             else:
                 next_state = STATE_EXIT
-        
-        
+
+
         elif event == NORMAL_EVENT:
             if state == STATE_NORMAL or state == STATE_INIT:
                 if state == STATE_INIT:
@@ -639,14 +640,14 @@ def main():
         elif event == SYSTEM_FAIL:
             if state == STATE_INIT:
                 # To overcome a case that system is only temporarily not available,
-                # when get system fail event will wait and retry for a certain period,  
+                # when get system fail event will wait and retry for a certain period,
                 # if system recovered in this period xcvrd will transit to INIT state
                 # and continue run, if can not recover then exit.
                 if retry >= RETRY_TIMES_FOR_SYSTEM_FAIL:
                     log_error("System failed to recover in {} secs. Exiting...".format((RETRY_PERIOD_FOR_SYSTEM_FAIL_MSECS/1000)*RETRY_TIMES_FOR_SYSTEM_FAIL))
                     next_state = STATE_EXIT
                 else:
-                    retry = retry + 1                   
+                    retry = retry + 1
                     waiting_time_compensation_with_sleep(time_start, RETRY_PERIOD_FOR_SYSTEM_FAIL_MSECS/1000)
             elif state == STATE_NORMAL:
                 log_error("Got system_fail in normal state, treat as error, transition to INIT...")
@@ -657,7 +658,7 @@ def main():
                 next_state = STATE_EXIT
         else:
             log_warning("Got unknown event {} on state {}.".format(event, state))
-        
+
         if next_state != state:
             log_info("State transition from {} to {}".format(state, next_state))
             state = next_state

--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -469,6 +469,12 @@ def main():
         if key in ["PortConfigDone", "PortInitDone"]:
             break
 
+    # Close the unused socket to prevent mem-leak. Since Xcvrd opens socket to subscribe to
+    # APP_DB's PORT_TABLE events, if Xcvrd doesnot listen on the opened socket, then over a
+    # period of time, redis-DB Send-Q will accumulate events(Eg due to continous port flap) 
+    # that can grow up slowly over a period of time resulting in memory leak. 
+    sel.removeSelectable(sst)
+
     # Post all the current interface SFP info to STATE_DB
     logical_port_list = platform_sfputil.logical
     for logical_port_name in logical_port_list:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Ensure Xcvrd close the unused socket to prevent memory leak. Unix socket cannot drain the data if the listener is NOT consuming the data so we ensure to close the unused socket by Xcvrd. Xcvrd opens the connection to listen to PORT_TABLE of APPL_DB and later on leaves the socket open.

#### Motivation and Context
Monit service complains of crossing the expected threshold for memory usage by database container as below:
```
Oct 17 01:05:10.970410 SONIC-T0 ERR monit[538]: 'container_memory_database' status failed (3) -- [database] Memory Usage (1.57391e+08 Bytes) is larger than the threshold (157286400 Bytes)!
 ```

The following shows which redis-db client is using the memory:-
 
```
GECHIANG@SONIC-T0:/var/log$ redis-cli client list | grep -v omem=0
id=613 addr=127.0.0.1:42212 fd=288 name= age=30229173 idle=27168066 flags=N db=0 sub=0 psub=1 multi=-1 qbuf=0 qbuf-free=0 obl=16384 oll=4185 omem=120041048 events=rw cmd=psubscribe
GECHIANG@SONIC-T0:/var/log$
 ```
```
GECHIANG@SONIC-T0:/var/log$ sudo netstat -antp | grep 42212
tcp        0 2547136 127.0.0.1:6379          127.0.0.1:42212         ESTABLISHED 903/redis-server 12 
tcp   1822707      0 127.0.0.1:42212         127.0.0.1:6379          ESTABLISHED 8308/python         
GECHIANG@SONIC-T0:/var/log$ sudo ps aux | grep 8308
root      8308  6.7  0.1 207788 15316 pts/0    Sl    2021 34146:26 /usr/bin/python /usr/bin/xcvrd
GECHIANG  9794  0.0  0.0  13376   976 pts/0    S+   01:38   0:00 grep 8308
GECHIANG@SONIC-T0:/var/log$
```

From above its clear Xcvrd is consuming the memory 

#### How Has This Been Tested?
Create continuous port flap events for 48 hours+ that gets queued over a period of time such that the APPL_DB's PORT_TABLE receives large number of events. Ensure REDIS DB's memory usage over a period of time is NOT increasing.

#### Additional Information (Optional)
