### PR TITLE
[sonic-ycabled] fix grpc logic for timeout,cli HWSTATUS value retrival logic for active-active cable

### DIFF
--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -4699,7 +4699,7 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.check_mux_cable_port_type', MagicMock(return_value=(True,"active-standby")))
     @patch('os.path.isfile', MagicMock(return_value=True))
     @patch('time.sleep', MagicMock(return_value=True))
-    def test_handle_show_mux_state_cmd_arg_tbl_notification_with_instance_auto(self, mock_swsscommon_table, platform_sfputil):
+    def test_handle_show_mux_state_cmd_arg_tbl_notification_with_instance_auto_active_standby(self, mock_swsscommon_table, platform_sfputil):
 
         mock_table = MagicMock()
         mock_table.get = MagicMock(
@@ -4717,6 +4717,61 @@ class TestYCableScript(object):
         port = "Ethernet0"
         platform_sfputil.get_asic_id_for_logical_port = 0
         fvp = {"state": "active"}
+
+        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
+            class PortInstanceHelper():
+                def __init__(self):
+                    self.EEPROM_ERROR = -1
+                    self.TARGET_NIC = 1
+                    self.TARGET_TOR_A = 1
+                    self.TARGET_TOR_B = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
+                    self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
+                    self.download_firmware_status = 0
+                    self.SWITCH_COUNT_MANUAL = "manual"
+                    self.SWITCH_COUNT_AUTO = "auto"
+                    self.SWITCHING_MODE_MANUAL = 0
+                    self.SWITCHING_MODE_AUTO = 1
+
+                def get_read_side(self):
+                    return 1
+
+                def get_switching_mode(self):
+                    return 1
+
+                def get_mux_direction(self):
+                    return 2
+
+            patched_util.get.return_value = PortInstanceHelper()
+            rc = handle_show_hwmode_state_cmd_arg_tbl_notification(
+                fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+            assert(rc == None)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
+    @patch('ycable.ycable_utilities.y_cable_helper.check_mux_cable_port_type', MagicMock(return_value=(True,"active-active")))
+    def test_handle_show_mux_state_cmd_arg_tbl_notification_with_instance_auto_active_active(self, mock_swsscommon_table, platform_sfputil):
+
+        mock_table = MagicMock()
+        mock_table.get = MagicMock(
+            side_effect=[(True, (('state', "auto"), ("soc_ipv4", "192.168.0.1/32"))), (True, (('index', 2), ))])
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_config_hwmode_state_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_state_rsp_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_dir_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_dir_rsp_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_dir_res_tbl = mock_swsscommon_table
+        port_tbl = mock_swsscommon_table
+        asic_index = 0
+        port = "Ethernet0"
+        platform_sfputil.get_asic_id_for_logical_port = 0
+        fvp = {"state": "active"}
+        swsscommon.Table.return_value.get.return_value = (
+                False, {"read_side": "2", "state": "active"})
 
         with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
             class PortInstanceHelper():

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -4753,6 +4753,36 @@ class TestYCableScript(object):
     @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
     @patch('ycable.ycable_utilities.y_cable_helper.check_mux_cable_port_type', MagicMock(return_value=(True,"active-active")))
+    def test_handle_show_mux_state_cmd_arg_tbl_notification_with_instance_auto_active_active_none(self, mock_swsscommon_table, platform_sfputil):
+
+        mock_table = MagicMock()
+        mock_table.get = MagicMock(
+            side_effect=[(True, (('state', "auto"), ("soc_ipv4", "192.168.0.1/32"))), (True, (('index', 2), ))])
+        mock_swsscommon_table.return_value = mock_table
+
+        xcvrd_config_hwmode_state_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_config_hwmode_state_rsp_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_dir_cmd_sts_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_dir_rsp_tbl = mock_swsscommon_table
+        xcvrd_show_hwmode_dir_res_tbl = mock_swsscommon_table
+        port_tbl = mock_swsscommon_table
+        asic_index = 0
+        port = "Ethernet0"
+        platform_sfputil.get_asic_id_for_logical_port = 0
+        fvp = {"state": "active"}
+        swsscommon.Table.return_value.get.return_value = (
+                True, {"read_side": "2", "state": "active"})
+
+        rc = handle_show_hwmode_state_cmd_arg_tbl_notification(
+            fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+        assert(rc == None)
+
+    @patch('swsscommon.swsscommon.Table')
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_platform_sfputil')
+    @patch('ycable.ycable_utilities.y_cable_helper.get_ycable_physical_port_from_logical_port', MagicMock(return_value=(0)))
+    @patch('ycable.ycable_utilities.y_cable_helper.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('ycable.ycable_utilities.y_cable_helper.y_cable_wrapper_get_presence', MagicMock(return_value=True))
+    @patch('ycable.ycable_utilities.y_cable_helper.check_mux_cable_port_type', MagicMock(return_value=(True,"active-active")))
     def test_handle_show_mux_state_cmd_arg_tbl_notification_with_instance_auto_active_active(self, mock_swsscommon_table, platform_sfputil):
 
         mock_table = MagicMock()
@@ -4773,34 +4803,9 @@ class TestYCableScript(object):
         swsscommon.Table.return_value.get.return_value = (
                 False, {"read_side": "2", "state": "active"})
 
-        with patch('ycable.ycable_utilities.y_cable_helper.y_cable_port_instances') as patched_util:
-            class PortInstanceHelper():
-                def __init__(self):
-                    self.EEPROM_ERROR = -1
-                    self.TARGET_NIC = 1
-                    self.TARGET_TOR_A = 1
-                    self.TARGET_TOR_B = 1
-                    self.FIRMWARE_DOWNLOAD_STATUS_INPROGRESS = 1
-                    self.FIRMWARE_DOWNLOAD_STATUS_FAILED = 2
-                    self.download_firmware_status = 0
-                    self.SWITCH_COUNT_MANUAL = "manual"
-                    self.SWITCH_COUNT_AUTO = "auto"
-                    self.SWITCHING_MODE_MANUAL = 0
-                    self.SWITCHING_MODE_AUTO = 1
-
-                def get_read_side(self):
-                    return 1
-
-                def get_switching_mode(self):
-                    return 1
-
-                def get_mux_direction(self):
-                    return 2
-
-            patched_util.get.return_value = PortInstanceHelper()
-            rc = handle_show_hwmode_state_cmd_arg_tbl_notification(
-                fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
-            assert(rc == None)
+        rc = handle_show_hwmode_state_cmd_arg_tbl_notification(
+            fvp, port_tbl, xcvrd_show_hwmode_dir_cmd_sts_tbl, xcvrd_show_hwmode_dir_rsp_tbl, xcvrd_show_hwmode_dir_res_tbl, asic_index, port)
+        assert(rc == -1)
 
     def test_retry_setup_grpc_channel_for_port_incorrect(self):
 

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -1183,7 +1183,7 @@ def init_ports_status_for_y_cable(platform_sfp, platform_chassis, y_cable_presen
     y_cable_platform_chassis = platform_chassis
     y_cable_is_platform_vs = is_vs
 
-    fvs_updated = swsscommon.FieldValuePairs([('log_verbosity', 'debug')])
+    fvs_updated = swsscommon.FieldValuePairs([('log_verbosity', 'notice')])
     # Get the namespaces in the platform
     namespaces = multi_asic.get_front_end_namespaces()
     for namespace in namespaces:

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -2932,6 +2932,7 @@ def handle_show_hwmode_state_cmd_arg_tbl_notification(fvp, port_tbl, xcvrd_show_
                 helper_logger.log_warning("Could not retreive fieldvalue pairs for {}, inside state_db table while responding to cli cmd show mux status {}".format(
                     port, hw_mux_cable_tbl[asic_index].getTableName()))
                 set_result_and_delete_port('state', 'unknown', xcvrd_show_hwmode_dir_cmd_sts_tbl[asic_index], xcvrd_show_hwmode_dir_rsp_tbl[asic_index], port)
+                return -1
 
             mux_port_dict = dict(fv)
             read_side = mux_port_dict.get("read_side", None)


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
This PR adds some improvement logic to ycabled daemon

1. correct the loopback IP's for active-active cable type for libra gRPC read_side establishment
2. improves the code for timeout value injection for different RPC's for gRPC
3. for cli HW_STATUS the daemon tries to use cached old value, if not present try to do RPC for getting ForwardingState with timeout of 0.1 ms

<!-- Provide a general summary of your changes in the Title above -->

#### Description

<!--
     Describe your changes in detail
-->

#### Motivation and Context
Required for gRPC logic improvement in few active-active scenario's
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
UT and deploying the changes in actual testbed
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
