### PR TITLE
[ycabled] Fix the init values for active-active ports

### DIFF
--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -5271,6 +5271,31 @@ class TestYCableScript(object):
         
         rc = handle_fwd_state_command_grpc_notification(fvs_m, hw_mux_cable_tbl, fwd_state_response_tbl, asic_index, port, "TestDB")
         assert(rc == True)
+
+    @patch('ycable.ycable_utilities.y_cable_helper.grpc_port_stubs', MagicMock(return_value={}))
+    @patch('ycable.ycable_utilities.y_cable_helper.grpc_port_channels', MagicMock(return_value={}))
+    def test_parse_grpc_response_forwarding_state_standby_standby_with_true_read_side(self):
+
+        status = True
+        asic_index = 0
+        test_db = "TEST_DB"
+        port = "Ethernet0"
+        fvs_m = [('command', "probe"), ('read_side', 1), ('cable_type','active-standby'), ('soc_ipv4','192.168.0.1')]
+        hw_mux_cable_tbl = {}
+        hw_mux_cable_tbl_peer = {}
+        fwd_state_response_tbl = {}
+        hw_mux_cable_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        hw_mux_cable_tbl_peer[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        fwd_state_response_tbl[asic_index] = swsscommon.Table(
+            test_db[asic_index], "PORT_INFO_TABLE")
+        hw_mux_cable_tbl[asic_index].get.return_value = (status, fvs_m)
+        
+        rc = put_init_values_for_grpc_states(port, '0', hw_mux_cable_tbl, hw_mux_cable_tbl_peer, 0)
+        assert(rc == None)
+        
+        
     def test_get_mux_cable_static_info_without_presence(self):
 
         rc = get_muxcable_static_info_without_presence()

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -401,8 +401,6 @@ def setup_grpc_channel_for_port(port, soc_ip):
 def put_init_values_for_grpc_states(port, read_side, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index):
 
 
-    self_state = "unknown"
-    peer_state = "unknown"
     stub = grpc_port_stubs.get(port, None)
     request = linkmgr_grpc_driver_pb2.AdminRequest(portid=[int(read_side), 1 - int(read_side)], state=[0, 0])
     if stub is None:

--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -398,6 +398,43 @@ def setup_grpc_channel_for_port(port, soc_ip):
 
     return channel, stub
 
+def put_init_values_for_grpc_states(port, read_side, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index):
+
+
+    self_state = "unknown"
+    peer_state = "unknown"
+    stub = grpc_port_stubs.get(port, None)
+    request = linkmgr_grpc_driver_pb2.AdminRequest(portid=[int(read_side), 1 - int(read_side)], state=[0, 0])
+    if stub is None:
+        helper_logger.log_notice("stub is None for getting admin port forwarding state RPC port {}".format(port))
+        fvs_updated = swsscommon.FieldValuePairs([('state', 'unknown'),
+                                                  ('read_side', str(read_side)),
+                                                  ('active_side', 'unknown')])
+        hw_mux_cable_tbl[asic_index].set(port, fvs_updated)
+        hw_mux_cable_tbl_peer[asic_index].set(port, fvs_updated)
+        return
+
+    ret, response = try_grpc(stub.QueryAdminForwardingPortState, QUERY_ADMIN_FORWARDING_TIMEOUT, request)
+    (self_state, peer_state) = parse_grpc_response_forwarding_state(ret, response, read_side)
+    if response is not None:
+        # Debug only, remove this section once Server side is Finalized
+        fwd_response_port_ids = response.portid
+        fwd_response_port_ids_state = response.state
+        helper_logger.log_notice(
+            "forwarding state RPC received response port ids = {} port {}".format(fwd_response_port_ids, port))
+        helper_logger.log_notice(
+            "forwarding state RPC received response state values = {} port {}".format(fwd_response_port_ids_state, port))
+    else:
+        helper_logger.log_warning("response was none while doing init config state for gRPC HW_MUX_CABLE_TABLE {} ".format(port))
+
+    fvs_updated = swsscommon.FieldValuePairs([('state', self_state),
+                                              ('read_side', str(read_side)),
+                                              ('active_side', self_state)])
+    hw_mux_cable_tbl[asic_index].set(port, fvs_updated)
+    fvs_updated = swsscommon.FieldValuePairs([('state', peer_state),
+                                              ('read_side', str(read_side)),
+                                              ('active_side', peer_state)])
+    hw_mux_cable_tbl_peer[asic_index].set(port, fvs_updated)
 
 def process_loopback_interface_and_get_read_side(loopback_keys):
 
@@ -473,12 +510,11 @@ def check_identifier_presence_and_setup_channel(logical_port_name, port_tbl, hw_
                             helper_logger.log_notice(
                                 "stub is not None, Cable-Insert or daemon init, daemon able to set up channel for gRPC SOC IP {}, port {}".format(soc_ipv4, logical_port_name))
 
-                        fvs_updated = swsscommon.FieldValuePairs([('read_side', str(read_side))])
-                        hw_mux_cable_tbl[asic_index].set(logical_port_name, fvs_updated)
-                        hw_mux_cable_tbl_peer[asic_index].set(logical_port_name, fvs_updated)
                     else:
                         helper_logger.log_warning(
                             "DAC cable not present while Channel setup Port {} for gRPC channel initiation".format(logical_port_name))
+
+                    put_init_values_for_grpc_states(logical_port_name, read_side, hw_mux_cable_tbl, hw_mux_cable_tbl_peer, asic_index)
 
                 else:
                     helper_logger.log_warning(
@@ -3049,8 +3085,8 @@ def handle_fwd_state_command_grpc_notification(fvp_m, hw_mux_cable_tbl, fwd_stat
             helper_logger.log_debug("Y_CABLE_DEBUG:before invoking RPC fwd_state read_side = {}".format(read_side))
             # TODO state only for dummy value in this request MSG remove this
             request = linkmgr_grpc_driver_pb2.AdminRequest(portid=[int(read_side), 1 - int(read_side)], state=[0, 0])
-            helper_logger.log_warning(
-                "calling RPC for getting forwarding state read_side portid = {} Ethernet port {}".format(read_side, port))
+            helper_logger.log_notice(
+                "calling RPC for getting forwarding state port = {} portid {} peer portid {} read_side {}".format(port, read_side, 1 - int(read_side), read_side))
 
             self_state = "unknown"
             peer_state = "unknown"
@@ -3075,9 +3111,9 @@ def handle_fwd_state_command_grpc_notification(fvp_m, hw_mux_cable_tbl, fwd_stat
                 fwd_response_port_ids = response.portid
                 fwd_response_port_ids_state = response.state
                 helper_logger.log_notice(
-                    "forwarding state RPC received response port ids = {} port {}".format(fwd_response_port_ids, port))
+                    "forwarding state RPC received response port = {} portids {} read_side {}".format(port, fwd_response_port_ids,read_side))
                 helper_logger.log_notice(
-                    "forwarding state RPC received response state values = {} port {}".format(fwd_response_port_ids_state, port))
+                    "forwarding state RPC received response port = {} state values = {} read_side {}".format(port, fwd_response_port_ids_state, read_side))
             else:
                 helper_logger.log_notice("response was none handle_fwd_state_command_grpc_notification {} ".format(port))
 
@@ -3132,7 +3168,7 @@ def handle_hw_mux_cable_table_grpc_notification(fvp, hw_mux_cable_tbl, asic_inde
                 state_req = 0
 
             helper_logger.log_notice(
-                "calling RPC for hw mux_cable set state state peer = {} portid Ethernet port {}".format(peer, port))
+                "calling RPC for hw mux_cable set state ispeer = {} port {} portid {} read_side {} state requested {}".format(peer, port, curr_read_side, read_side, new_state))
 
             request = linkmgr_grpc_driver_pb2.AdminRequest(portid=[curr_read_side], state=[state_req])
 
@@ -3152,9 +3188,9 @@ def handle_hw_mux_cable_table_grpc_notification(fvp, hw_mux_cable_tbl, asic_inde
                 hw_response_port_ids = response.portid
                 hw_response_port_ids_state = response.state
                 helper_logger.log_notice(
-                    "Set admin state RPC received response port ids = {}".format(hw_response_port_ids))
+                    "Set admin state RPC received response port {} port ids = {} curr_read_side {} read_side {}".format(port, hw_response_port_ids, curr_read_side, read_side))
                 helper_logger.log_notice(
-                    "Set admin state RPC received response state values = {}".format(hw_response_port_ids_state))
+                    "Set admin state RPC received response port {} state values = {} curr_read_side {} read_side {}".format(port, hw_response_port_ids_state, curr_read_side, read_side))
             else:
                 helper_logger.log_notice("response was none hw_mux_cable_table_grpc_notification {} ".format(port))
 
@@ -3166,8 +3202,8 @@ def handle_hw_mux_cable_table_grpc_notification(fvp, hw_mux_cable_tbl, asic_inde
                 new_state = 'unknown'
 
             time_end = datetime.datetime.utcnow().strftime("%Y-%b-%d %H:%M:%S.%f")
-            fvs_metrics = swsscommon.FieldValuePairs([('grpc_switch_{}_{}_start'.format(toggle_side, new_state), str(time_start)),
-                                                      ('grpc_switch_{}_{}_end'.format(toggle_side, new_state), str(time_end))])
+            fvs_metrics = swsscommon.FieldValuePairs([('xcvrd_switch_{}_{}_start'.format(toggle_side, new_state), str(time_start)),
+                                                      ('xcvrd_switch_{}_{}_end'.format(toggle_side, new_state), str(time_end))])
             grpc_metrics_tbl[asic_index].set(port, fvs_metrics)
 
             fvs_updated = swsscommon.FieldValuePairs([('state', new_state),


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

Since linkmgr/orchagent relies on ycabled to populate the mux_cable entries in the `HW_MUX_CABLE_TABLE`, for the cable `active-active` type this is accomplished by putting an unknown value if gRPC is unavailable, otherwise a normal RPC is used to query this and the response `active` or `standby` is written is `HW_MUX_CABLE_TABLE` table with a timeout.
This Fix accomplishes putting an `unknown/active/standby` to `state` key when ycabled starts

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Unit-Tests and deploying the changes on testbed
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
