### PR TITLE
[fastboot] fastboot enhancement: Use "ADVANCED REBOOT" infra for fast reboot

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -357,7 +357,7 @@ class TestXcvrdScript(object):
         assert port_mapping.get_asic_id_for_logical_port('Ethernet-IB0') == None
         assert port_mapping.get_physical_to_logical(3) == None
         assert port_mapping.get_logical_to_physical('Ethernet-IB0') == None
-                                        
+
     @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
     @patch('swsscommon.swsscommon.SubscriberStateTable')
     @patch('swsscommon.swsscommon.Select.select')
@@ -1061,7 +1061,7 @@ class TestXcvrdScript(object):
 
     @patch('xcvrd.xcvrd.DaemonXcvrd.load_platform_util', MagicMock())
     @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/tmp', None)))
-    @patch('swsscommon.swsscommon.WarmStart', MagicMock())
+    @patch('swsscommon.swsscommon.AdvancedStart', MagicMock())
     @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
     def test_DaemonXcvrd_init_deinit(self):
         xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -565,7 +565,7 @@ def post_port_dom_info_to_db(logical_port_name, port_mapping, table, stop_event=
 # Update port dom/sfp info in db
 
 
-def post_port_sfp_dom_info_to_db(is_advanced_start, port_mapping, stop_event=threading.Event()):
+def post_port_sfp_dom_info_to_db(is_advanced_start, port_mapping, xcvr_table_helper, stop_event=threading.Event()):
     # Connect to STATE_DB and create transceiver dom/sfp info tables
     transceiver_dict = {}
     retry_eeprom_set = set()
@@ -2038,7 +2038,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         # Post all the current interface dom/sfp info to STATE_DB
         self.log_info("Post all port DOM/SFP info to DB")
 
-        retry_eeprom_set = post_port_sfp_dom_info_to_db(is_advanced_start, port_mapping_data, self.stop_event)
+        retry_eeprom_set = post_port_sfp_dom_info_to_db(is_advanced_start, port_mapping_data, self.xcvr_table_helper, self.stop_event)
 
         # Init port sfp status table
         self.log_info("Init port sfp status table")

--- a/sonic-ycabled/tests/test_y_cable_helper.py
+++ b/sonic-ycabled/tests/test_y_cable_helper.py
@@ -2432,7 +2432,7 @@ class TestYCableScript(object):
         assert(rc == 0)
 
     @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/tmp', None)))
-    @patch('swsscommon.swsscommon.WarmStart', MagicMock())
+    @patch('swsscommon.swsscommon.AdvancedStart', MagicMock())
     @patch('ycable.ycable.platform_sfputil', MagicMock())
     @patch('ycable.ycable.DaemonYcable.load_platform_util', MagicMock())
     def test_DaemonYcable_init_deinit(self):

--- a/sonic-ycabled/tests/test_ycable.py
+++ b/sonic-ycabled/tests/test_ycable.py
@@ -262,7 +262,7 @@ class TestYcableScript(object):
         assert(rc == 0)
 
     @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/tmp', None)))
-    @patch('swsscommon.swsscommon.WarmStart', MagicMock())
+    @patch('swsscommon.swsscommon.AdvancedStart', MagicMock())
     @patch('ycable.ycable.platform_sfputil', MagicMock())
     @patch('ycable.ycable.DaemonYcable.load_platform_util', MagicMock())
     def test_DaemonYcable_init_deinit(self):
@@ -276,7 +276,7 @@ class TestYcableScript(object):
         # ycable.init/deinit will not raise unexpected exception. In future, probably more check will be added
 
     @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/tmp', None)))
-    @patch('swsscommon.swsscommon.WarmStart', MagicMock())
+    @patch('swsscommon.swsscommon.AdvancedStart', MagicMock())
     @patch('ycable.ycable.platform_sfputil', MagicMock())
     @patch('ycable.ycable.DaemonYcable.load_platform_util', MagicMock())
     @patch('ycable.ycable.YcableInfoUpdateTask', MagicMock())

--- a/sonic-ycabled/ycable/ycable.py
+++ b/sonic-ycabled/ycable/ycable.py
@@ -10,7 +10,7 @@ try:
     import sys
     import time
     import threading
-    
+
     from enum import Enum
     from sonic_py_common import daemon_base, device_info, logger
     from sonic_py_common import multi_asic
@@ -325,10 +325,10 @@ class DaemonYcable(daemon_base.DaemonBase):
 
         """
         # TODO need to decide if we need warm start capability in this ycabled daemon
-        warmstart = swsscommon.WarmStart()
-        warmstart.initialize("ycabled", "pmon")
-        warmstart.checkWarmStart("ycabled", "pmon", False)
-        is_warm_start = warmstart.isWarmStart()
+        advancedstart = swsscommon.AdvancedStart()
+        advancedstart.initialize("ycabled", "pmon")
+        advancedstart.checkAdvancedStart("ycabled", "pmon", False)
+        is_advanced_start = advancedstart.isAdvancedStart()
         """
 
         # Make sure this daemon started after all port configured


### PR DESCRIPTION
Signed-off-by: Aryeh Feigin [afeigin@nvidia.com](mailto:afeigin@nvidia.com)

Description
Align sonic-platform-daemons to new advanced reboot infrastructure replacing warm reboot infrastructure.

Motivation and Context
This is part of fast boot improvements, i.e. fast boot over warm boot. Since both are using the same infrastructure it was renamed to advanced instead of warm as both are kinds of advanced boot.

How Has This Been Tested?
Manual and automated tests as part of testing the whole set of changes to enable the fast boot over warm boot.

Additional Information (Optional)
https://github.com/sonic-net/SONiC/blob/master/doc/fast-reboot/Fast-reboot_Flow_Improvements_HLD.md

This PR is dependent on https://github.com/Azure/sonic-swss-common/pull/644