### PR TITLE
[ycabled] remove some redundant logging for active-active cable type

### DIFF
--- a/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
+++ b/sonic-ycabled/ycable/ycable_utilities/y_cable_helper.py
@@ -1424,12 +1424,13 @@ def check_identifier_presence_and_update_mux_info_entry(state_db, mux_tbl, asic_
         port_tbl[asic_id] = swsscommon.Table(config_db[asic_id], "MUX_CABLE")
 
     (status, fvs) = port_tbl[asic_index].get(logical_port_name)
+    (cable_status, cable_type) = check_mux_cable_port_type(port, port_tbl, asic_index)
 
     if status is False:
         helper_logger.log_warning("Could not retreive fieldvalue pairs for {}, inside config_db table {}".format(logical_port_name, port_tbl[asic_index].getTableName()))
         return
 
-    else:
+    elif cable_status and cable_type == "active-standby":
         # Convert list of tuples to a dictionary
         mux_table_dict = dict(fvs)
         if "state" in mux_table_dict:


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
This change is required for stop posting `MUX_CABLE_INFO` entries into state DB for `active-active` cable_type since for these cables there is no i2c/eeprom or muxcable. 
This loop is independent of main loop, hence it needs to be changed 
<!--
     Describe your changes in detail
-->

#### Motivation and Context
remove some unnecessary logs
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Unit-tests 
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
