### PR TITLE
Refactor ledd daemon & fix high CPU usage due to unexpected socket close

### DIFF
--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -179,7 +179,7 @@ class DaemonLedd(daemon_base.DaemonBase):
 
         # Load platform-specific LedControl module
         try:
-            led_control = self.load_platform_util(LED_MODULE_NAME, LED_CLASS_NAME)
+            self.led_control = self.load_platform_util(LED_MODULE_NAME, LED_CLASS_NAME)
         except Exception as e:
             self.log_error("Failed to load ledutil: %s" % (str(e)), True)
             sys.exit(LEDUTIL_LOAD_ERROR)
@@ -194,7 +194,7 @@ class DaemonLedd(daemon_base.DaemonBase):
 
         # Discover the front panel ports
         fp_plist, fp_ups, lmap = self.findFrontPanelPorts(namespaces)
-        self.fp_ports = FrontPanelPorts(fp_plist, fp_ups, lmap, led_control)
+        self.fp_ports = FrontPanelPorts(fp_plist, fp_ups, lmap, self.led_control)
 
         # Initialize the port LEDs color
         self.fp_ports.initPortLeds()

--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -55,6 +55,7 @@ class Port():
 
     def isFrontPanelPort(self):
         return multi_asic.is_front_panel_port(self._name, self._role)
+
 class FrontPanelPorts:
     def __init__(self, fp_list, up_subports, logical_pmap, led_ctrl):
         # {port-index, total subports oper UP}
@@ -137,7 +138,7 @@ class PortStateObserver:
         db = daemon_base.db_connect(dbname, namespace=namespace)
         return db
     
-    def getDatabseTable(self, dbname, tblname, namespace):
+    def getDatabaseTable(self, dbname, tblname, namespace):
         db = self.connectDB(dbname, namespace)
         table = swsscommon.Table(db, tblname)
         return table
@@ -206,8 +207,8 @@ class DaemonLedd(daemon_base.DaemonBase):
         logical_port_mapping = {}
         
         for namespace in namespaces:
-            port_cfg_table = self.portObserver.getDatabseTable("CONFIG_DB", swsscommon.CFG_PORT_TABLE_NAME, namespace)
-            port_st_table = self.portObserver.getDatabseTable("STATE_DB", swsscommon.STATE_PORT_TABLE_NAME, namespace)
+            port_cfg_table = self.portObserver.getDatabaseTable("CONFIG_DB", swsscommon.CFG_PORT_TABLE_NAME, namespace)
+            port_st_table = self.portObserver.getDatabaseTable("STATE_DB", swsscommon.STATE_PORT_TABLE_NAME, namespace)
             for key in port_cfg_table.getKeys():
                 _, pcfg = port_cfg_table.get(key)
                 _, pstate = port_st_table.get(key)
@@ -220,8 +221,6 @@ class DaemonLedd(daemon_base.DaemonBase):
                             pcfg_dict.get('role', None))
                 if p.isFrontPanelPort():
                     logical_port_mapping[key] = p
-                    self.log_notice("$$$ Port = {}".format(p))
-                    #print("port list = {}".format(self.fp_port_list))
                     fp_port_list[p._index].add(key)
                     if p._state == Port.PORT_UP:
                         fp_port_up_subports[p._index] += 1

--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -35,12 +35,11 @@ SELECT_TIMEOUT = 1000
 LEDUTIL_LOAD_ERROR = 1
 LEDUTIL_RUNTIME_ERROR = 2
 
-MAX_FRONT_PANEL_PORTS = 64
+MAX_FRONT_PANEL_PORTS = 64+1
 
 class Port():
     PORT_UP = "up" # All subports are up
     PORT_DOWN = "down" # All subports are down
-    PORT_MIXED = "mixed" # Some subports are up and some are down
 
     def __init__(self, name, index, state, subport, role):
         self._name = name
@@ -50,56 +49,72 @@ class Port():
         self._role = role
         self.is_front_panel_port = multi_asic.is_front_panel_port(name, role)
 
-    def isFrontPanelPort(self, port_name):
+    def isFrontPanelPort(self):
         return self.is_front_panel_port
 class FrontPanelPorts:
     def __init__(self, namespaces):
         # {port-index, list of logical ports}
-        self.fp_port_list = [set() * MAX_FRONT_PANEL_PORTS]
-        self.fp_port_state_bitmap = [0] * MAX_FRONT_PANEL_PORTS
+        self.fp_port_list = [set() for _ in range(MAX_FRONT_PANEL_PORTS)]
+        # {port-index, total subports oper UP}
+        self.fp_port_up_subports = [0] * MAX_FRONT_PANEL_PORTS
         self.logical_port_mapping = {}
+        self.port_obs = PortStateObserver()
 
         for namespace in namespaces:
-            config_db = daemon_base.db_connect("CONFIG_DB", namespace=namespace)
-            port_table = swsscommon.Table(config_db, swsscommon.CFG_PORT_TABLE_NAME)
-            for key in port_table.getKeys():
-                _, pcfg_table = port_table.get(key)
-                pcfg_dict = dict(pcfg_table)
+            port_cfg_table = self.port_obs.getDatabseTable("CONFIG_DB", swsscommon.CFG_PORT_TABLE_NAME, namespace)
+            port_st_table = self.port_obs.getDatabseTable("STATE_DB", swsscommon.STATE_PORT_TABLE_NAME, namespace)
+            for key in port_cfg_table.getKeys():
+                _, pcfg = port_cfg_table.get(key)
+                _, pstate = port_st_table.get(key)
+                pcfg_dict = dict(pcfg)
+                pstate_dict = dict(pstate)
                 p = Port(key,
-                            pcfg_table['index'], 
-                            Port.DOWN,
+                            int(pcfg_dict['index']),
+                            pstate_dict.get('oper_status', Port.PORT_DOWN),
                             pcfg_dict.get('subport', 0),
                             pcfg_dict.get('role', None))
                 self.logical_port_mapping[key] = p
+                print("name={} index={} state={} subport={} role={}".format(p._name, p._index, p._state, p._subport, p._role))
+                #print("port list = {}".format(self.fp_port_list))
                 self.fp_port_list[p._index].add(key)
+                if p._state == Port.PORT_UP:
+                    self.fp_port_up_subports[p._index] += 1
 
     def getPort(self, name):
         if name in self.logical_port_mapping:
-            return self.logical_port_mapping[name]
+            port = self.logical_port_mapping[name]
+            return port if port.isFrontPanelPort() else None
         return None
-    
-    def areAllSubportsUp(self, index):
-        if self.getTotalSubports(index) == 1:
-            return self.fp_port_state_bitmap[index] == 1
-        
-        return self.fp_port_state_bitmap[index] == (1 << self.getTotalSubports(index)) - 1
-    
-    def areAllSubportsDown(self, index):
-        return self.fp_port_state_bitmap[index] == 0
-    
+
+    def areAllSubportsUp(self, name):
+        port = self.getPort(name)
+        if port:
+            return self.fp_port_up_subports[port._index] == self.getTotalSubports(port._index)
+
+        return False
+
+    def areAllSubportsDown(self, name):
+        port = self.getPort(name)
+        if port:
+            return self.fp_port_up_subports[port._index] == 0
+
+        return True
+
     def getTotalSubports(self, index):
         if index < MAX_FRONT_PANEL_PORTS:
             return len(self.fp_port_list[index])
         return 0
 
     def updatePortState(self, port_name, port_state):
-        if port_name in self.logical_port_mapping:
-            port = self.logical_port_mapping[port_name]
-            port._state = port_state
-            if port._state == Port.PORT_UP:
-                self.fp_port_state_bitmap[port._index] |= 1 << port._subport
-            else:
-                self.fp_port_state_bitmap[port._index] &= ~(1 << port._subport)
+            assert port_state in [Port.PORT_UP, Port.PORT_DOWN]
+            port = self.getPort(port_name)
+            if port:
+                if port_state == Port.PORT_UP:
+                    self.fp_port_up_subports[port._index] = max(1 + self.fp_port_up_subports[port._index],
+                                                                self.getTotalSubports(port._index))
+                else:
+                    self.fp_port_up_subports[port._index] = min(0, self.fp_port_up_subports[port._index] - 1)
+                port._state = port_state
 
 class PortStateObserver:
     def __init__(self):
@@ -114,7 +129,12 @@ class PortStateObserver:
     def connectDB(self, dbname, namespace):
         db = daemon_base.db_connect(dbname, namespace=namespace)
         return db
-  
+    
+    def getDatabseTable(self, dbname, tblname, namespace):
+        db = self.connectDB(dbname, namespace)
+        table = swsscommon.Table(db, tblname)
+        return table
+
     def subscribeDbTable(self, dbname, tblname, namespace):
         db = self.connectDB(dbname, namespace)
         self.tables[namespace] = swsscommon.SubscriberStateTable(db, tblname)
@@ -122,7 +142,7 @@ class PortStateObserver:
 
     def getSelectEvent(self, timeout=SELECT_TIMEOUT):
         return self.sel.select(timeout)
-    
+
     def getPortTableEvent(self, selectableObj):
         redisSelectObj = swsscommon.CastSelectableToRedisSelectObj(selectableObj)
         namespace = redisSelectObj.getDbConnector().getNamespace()
@@ -130,16 +150,16 @@ class PortStateObserver:
         (key, op, fvp) = self.tables[namespace].pop()
         if not key:
             return None
-        
+
         if fvp:
             if key in ["PortConfigDone", "PortInitDone"]:
                 return None
             if op == "SET" and "oper_status" in fvp_dict:
                 fvp_dict = dict(fvp)
                 return (key, fvp_dict["oper_status"])
-            
+
         return None
-        
+
 
 class DaemonLedd(daemon_base.DaemonBase):
     def __init__(self):
@@ -162,16 +182,20 @@ class DaemonLedd(daemon_base.DaemonBase):
         # subscribe to all the front panel ports namespaces
         namespaces = multi_asic.get_front_end_namespaces()
         self.portObserver.subscribePortTable(namespaces)
+        self.fp_ports = FrontPanelPorts(namespaces)
 
-    
     def updatePortLed(self, port_name, port_state):
-        if self.isFrontPanelPort(port_name):
-            self.led_control(port_name, port_state)
-    
-    def processFinalPortState(self):
-        for port_name in self.portObserver.fp_port_list:
-            port_state = self.portObserver.fp_port_state_bitmap[port_name]
-            self.updatePortLed(port_name, port_state)
+        self.log_notice("Updating LED for port %s to state %s" % (port_name, port_state))
+        self.led_control(port_name, port_state)
+
+    def processPortStateChange(self, port_name, port_state):
+        if self.fp_ports.getPort(port_name):
+            # Update the port state for front panel ports
+            self.fp_ports.updatePortState(port_name, port_state)
+            if self.fp_ports.areAllSubportsUp(port_name):
+                self.updatePortLed(port_name, Port.PORT_UP)
+            else:
+                self.updatePortLed(port_name, Port.PORT_DOWN)
 
     # Run daemon
     def run(self):

--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -37,7 +37,6 @@ LEDUTIL_RUNTIME_ERROR = 2
 
 
 class DaemonLedd(daemon_base.DaemonBase):
-
     def __init__(self):
         daemon_base.DaemonBase.__init__(self, SYSLOG_IDENTIFIER)
 
@@ -82,9 +81,11 @@ class DaemonLedd(daemon_base.DaemonBase):
         # Get the corresponding namespace from redisselect db connector object
         return selectObj.getDbConnector().getNamespace()
     
+    def getSelectObj(self, timeout=SELECT_TIMEOUT):
+        return self.sel.select(timeout)
+    
     def processPortTableEvent(self, selectableObj):
         ''' Process (if any) event from the PORT table in the Application DB '''
-
         # Get the redisselect object from selectable object
         redisSelectObj = swsscommon.CastSelectableToRedisSelectObj(selectableObj)
         namespace = self.getEventNamespace(redisSelectObj)
@@ -101,13 +102,11 @@ class DaemonLedd(daemon_base.DaemonBase):
             if op == "SET" and "oper_status" in fvp_dict and self.isFrontPanelPort(key):
                 self.updatePortLedColor(key, fvp_dict["oper_status"])
 
-
-
     # Run daemon
     def run(self):
         # Use timeout to prevent ignoring the signals we want to handle
         # in signal_handler() (e.g. SIGTERM for graceful shutdown)
-        (state, selectableObj) = self.sel.select(SELECT_TIMEOUT)
+        (state, selectableObj) = self.getSelectObj()
 
         if state == swsscommon.Select.TIMEOUT:
             # NOOP - Nothing to process here

--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
     ledd
@@ -15,7 +15,7 @@ from swsscommon import swsscommon
 
 #============================= Constants =============================
 
-VERSION = '1.0'
+VERSION = '2.0'
 
 SYSLOG_IDENTIFIER = "ledd"
 
@@ -33,6 +33,7 @@ LED_CLASS_NAME = "LedControl"
 SELECT_TIMEOUT = 1000
 
 LEDUTIL_LOAD_ERROR = 1
+LEDUTIL_RUNTIME_ERROR = 2
 
 
 class DaemonLedd(daemon_base.DaemonBase):
@@ -56,15 +57,51 @@ class DaemonLedd(daemon_base.DaemonBase):
         namespaces = multi_asic.get_front_end_namespaces()
 
         # Subscribe to PORT table notifications in the Application DB
-        appl_db = {}
-        self.sst = {}
+        self.tables = {}
         self.sel = swsscommon.Select()
 
         for namespace in namespaces:
-            # Open a handle to the Application database, in all namespaces
-            appl_db[namespace] = daemon_base.db_connect("APPL_DB", namespace=namespace)
-            self.sst[namespace] = swsscommon.SubscriberStateTable(appl_db[namespace], swsscommon.APP_PORT_TABLE_NAME)
-            self.sel.addSelectable(self.sst[namespace])
+            self.subscribeDbTable("APPL_DB", swsscommon.APP_PORT_TABLE_NAME, namespace)
+    
+    def connectDB(self, dbname, namespace):
+        db = daemon_base.db_connect(dbname, namespace=namespace)
+        return db
+    
+    def subscribeDbTable(self, dbname, tblname, namespace):
+        db = self.connectDB(dbname, namespace)
+        self.tables[namespace] = swsscommon.SubscriberStateTable(db, tblname)
+        self.sel.addSelectable(self.tables[namespace])
+
+    def isFrontPanelPort(self, port_name):
+        return not port_name.startswith((backplane_prefix(), inband_prefix(), recirc_prefix()))
+
+    def updatePortLedColor(self, port_name, port_status):
+        self.led_control.port_link_state_change(port_name, port_status)
+
+    def getEventNamespace(self, selectObj):
+        # Get the corresponding namespace from redisselect db connector object
+        return selectObj.getDbConnector().getNamespace()
+    
+    def processPortTableEvent(self, selectableObj):
+        ''' Process (if any) event from the PORT table in the Application DB '''
+
+        # Get the redisselect object from selectable object
+        redisSelectObj = swsscommon.CastSelectableToRedisSelectObj(selectableObj)
+        namespace = self.getEventNamespace(redisSelectObj)
+
+        (key, op, fvp) = self.tables[namespace].pop()
+        if fvp:
+            # TODO: Once these flag entries have been removed from the DB,
+            # we can remove this check
+            if key in ["PortConfigDone", "PortInitDone"]:
+                return
+
+            fvp_dict = dict(fvp)
+
+            if op == "SET" and "oper_status" in fvp_dict and self.isFrontPanelPort(key):
+                self.updatePortLedColor(key, fvp_dict["oper_status"])
+
+
 
     # Run daemon
     def run(self):
@@ -73,33 +110,14 @@ class DaemonLedd(daemon_base.DaemonBase):
         (state, selectableObj) = self.sel.select(SELECT_TIMEOUT)
 
         if state == swsscommon.Select.TIMEOUT:
-            # Do not flood log when select times out
-            return 1
+            # NOOP - Nothing to process here
+            return 0
 
         if state != swsscommon.Select.OBJECT:
-            self.log_warning("sel.select() did not return swsscommon.Select.OBJECT")
-            return 2
+            self.log_warning("sel.select() did not return swsscommon.Select.OBJECT - May be socket closed???")
+            return -1 ## Fail here so that the daemon can be restarted
 
-        # Get the redisselect object from selectable object
-        redisSelectObj = swsscommon.CastSelectableToRedisSelectObj(selectableObj)
-
-        # Get the corresponding namespace from redisselect db connector object
-        namespace = redisSelectObj.getDbConnector().getNamespace()
-
-        (key, op, fvp) = self.sst[namespace].pop()
-        if fvp:
-            # TODO: Once these flag entries have been removed from the DB,
-            # we can remove this check
-            if key in ["PortConfigDone", "PortInitDone"]:
-                return 3
-
-            fvp_dict = dict(fvp)
-
-            if op == "SET" and "oper_status" in fvp_dict:
-                if not key.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
-                    self.led_control.port_link_state_change(key, fvp_dict["oper_status"])
-        else:
-            return 4
+        self.processPortTableEvent(selectableObj)
 
         return 0
 
@@ -126,8 +144,9 @@ def main():
 
     # Listen indefinitely for changes to the PORT table in the Application DB's
     while True:
-        ledd.run()
-
+        if 0 != ledd.run():
+            print("ledd.run() failed... Exiting")
+            sys.exit(LEDUTIL_RUNTIME_ERROR)
 
 if __name__ == '__main__':
     main()

--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -10,7 +10,6 @@ import sys
 
 from sonic_py_common import daemon_base
 from sonic_py_common import multi_asic
-#from sonic_py_common.interface import backplane_prefix, inband_prefix, recirc_prefix
 from swsscommon import swsscommon
 
 #============================= Constants =============================
@@ -34,12 +33,14 @@ SELECT_TIMEOUT = 1000
 
 LEDUTIL_LOAD_ERROR = 1
 LEDUTIL_RUNTIME_ERROR = 2
+LEDD_SELECT_ERROR = 3
 
-MAX_FRONT_PANEL_PORTS = 64+1
+MAX_FRONT_PANEL_PORTS = 256
 
 class Port():
     PORT_UP = "up" # All subports are up
     PORT_DOWN = "down" # All subports are down
+    PORT_OP_FIELD = "netdev_oper_status"
 
     def __init__(self, name, index, state, subport, role):
         self._name = name
@@ -47,43 +48,44 @@ class Port():
         self._state = state
         self._subport = subport
         self._role = role
-        self.is_front_panel_port = multi_asic.is_front_panel_port(name, role)
+
+    def __str__(self):
+        return "Port(name={}, index={}, state={}, subport={}, role={})".format(
+                    self._name, self._index, self._state, self._subport, self._role)
 
     def isFrontPanelPort(self):
-        return self.is_front_panel_port
+        return multi_asic.is_front_panel_port(self._name, self._role)
 class FrontPanelPorts:
-    def __init__(self, namespaces):
-        # {port-index, list of logical ports}
-        self.fp_port_list = [set() for _ in range(MAX_FRONT_PANEL_PORTS)]
+    def __init__(self, fp_list, up_subports, logical_pmap, led_ctrl):
         # {port-index, total subports oper UP}
-        self.fp_port_up_subports = [0] * MAX_FRONT_PANEL_PORTS
-        self.logical_port_mapping = {}
-        self.port_obs = PortStateObserver()
+        self.fp_port_up_subports = up_subports
+        # {port-index, list of logical ports}
+        self.fp_port_list = fp_list
+        self.logical_port_mapping = logical_pmap
+        self.led_control = led_ctrl
 
-        for namespace in namespaces:
-            port_cfg_table = self.port_obs.getDatabseTable("CONFIG_DB", swsscommon.CFG_PORT_TABLE_NAME, namespace)
-            port_st_table = self.port_obs.getDatabseTable("STATE_DB", swsscommon.STATE_PORT_TABLE_NAME, namespace)
-            for key in port_cfg_table.getKeys():
-                _, pcfg = port_cfg_table.get(key)
-                _, pstate = port_st_table.get(key)
-                pcfg_dict = dict(pcfg)
-                pstate_dict = dict(pstate)
-                p = Port(key,
-                            int(pcfg_dict['index']),
-                            pstate_dict.get('oper_status', Port.PORT_DOWN),
-                            pcfg_dict.get('subport', 0),
-                            pcfg_dict.get('role', None))
-                self.logical_port_mapping[key] = p
-                print("name={} index={} state={} subport={} role={}".format(p._name, p._index, p._state, p._subport, p._role))
-                #print("port list = {}".format(self.fp_port_list))
-                self.fp_port_list[p._index].add(key)
-                if p._state == Port.PORT_UP:
-                    self.fp_port_up_subports[p._index] += 1
+    def initPortLeds(self):
+        """
+        Initialize the port LEDs based on the current state of the front panel ports
+        """
+        for index in range(MAX_FRONT_PANEL_PORTS):
+            if len(self.fp_port_list[index]) > 0:
+               name = next(iter(self.fp_port_list[index]))
+               if self.areAllSubportsUp(name):
+                  self.updatePortLed(name, Port.PORT_UP)
+               else:
+                  self.updatePortLed(name, Port.PORT_DOWN)
+
+    def updatePortLed(self, port_name, port_state):
+        try:
+            self.led_control.port_link_state_change(port_name, port_state)
+        except Exception as e:
+            sys.exit(LEDUTIL_RUNTIME_ERROR)
 
     def getPort(self, name):
         if name in self.logical_port_mapping:
             port = self.logical_port_mapping[name]
-            return port if port.isFrontPanelPort() else None
+            return port
         return None
 
     def areAllSubportsUp(self, name):
@@ -106,15 +108,20 @@ class FrontPanelPorts:
         return 0
 
     def updatePortState(self, port_name, port_state):
-            assert port_state in [Port.PORT_UP, Port.PORT_DOWN]
-            port = self.getPort(port_name)
-            if port:
-                if port_state == Port.PORT_UP:
-                    self.fp_port_up_subports[port._index] = max(1 + self.fp_port_up_subports[port._index],
-                                                                self.getTotalSubports(port._index))
-                else:
-                    self.fp_port_up_subports[port._index] = min(0, self.fp_port_up_subports[port._index] - 1)
-                port._state = port_state
+        """
+        Return True if the port state has changed, False otherwise
+        """
+        assert port_state in [Port.PORT_UP, Port.PORT_DOWN]
+        port = self.getPort(port_name)
+        if port and port_state != port._state:
+            if port_state == Port.PORT_UP:
+                self.fp_port_up_subports[port._index] = min(1 + self.fp_port_up_subports[port._index],
+                                                            self.getTotalSubports(port._index))
+            else:
+                self.fp_port_up_subports[port._index] = max(0, self.fp_port_up_subports[port._index] - 1)
+            port._state = port_state
+            return True
+        return False
 
 class PortStateObserver:
     def __init__(self):
@@ -154,27 +161,28 @@ class PortStateObserver:
         if fvp:
             if key in ["PortConfigDone", "PortInitDone"]:
                 return None
-            if op == "SET" and "oper_status" in fvp_dict:
-                fvp_dict = dict(fvp)
-                return (key, fvp_dict["oper_status"])
+
+            fvp_dict = dict(fvp)
+            if op == "SET" and Port.PORT_OP_FIELD in fvp_dict:
+                return (key, fvp_dict[Port.PORT_OP_FIELD])
 
         return None
-
 
 class DaemonLedd(daemon_base.DaemonBase):
     def __init__(self):
         daemon_base.DaemonBase.__init__(self, SYSLOG_IDENTIFIER)
 
+        if multi_asic.is_multi_asic():
+            # Load the namespace details first from the database_global.json file.
+            swsscommon.SonicDBConfig.initializeGlobalConfig()
+
         # Load platform-specific LedControl module
         try:
-            self.led_control = self.load_platform_util(LED_MODULE_NAME, LED_CLASS_NAME)
+            led_control = self.load_platform_util(LED_MODULE_NAME, LED_CLASS_NAME)
         except Exception as e:
             self.log_error("Failed to load ledutil: %s" % (str(e)), True)
             sys.exit(LEDUTIL_LOAD_ERROR)
 
-        if multi_asic.is_multi_asic():
-            # Load the namespace details first from the database_global.json file.
-            swsscommon.SonicDBConfig.initializeGlobalConfig()
 
         # Initialize the PortStateObserver
         self.portObserver = PortStateObserver()
@@ -182,21 +190,53 @@ class DaemonLedd(daemon_base.DaemonBase):
         # subscribe to all the front panel ports namespaces
         namespaces = multi_asic.get_front_end_namespaces()
         self.portObserver.subscribePortTable(namespaces)
-        self.fp_ports = FrontPanelPorts(namespaces)
 
-    def updatePortLed(self, port_name, port_state):
-        self.log_notice("Updating LED for port %s to state %s" % (port_name, port_state))
-        self.led_control(port_name, port_state)
+        # Discover the front panel ports
+        fp_plist, fp_ups, lmap = self.findFrontPanelPorts(namespaces)
+        self.fp_ports = FrontPanelPorts(fp_plist, fp_ups, lmap, led_control)
+
+        # Initialize the port LEDs color
+        self.fp_ports.initPortLeds()
+
+    def findFrontPanelPorts(self, namespaces):
+        # {port-index, list of logical ports}
+        fp_port_list = [set() for _ in range(MAX_FRONT_PANEL_PORTS)]
+        # {port-index, total subports oper UP}
+        fp_port_up_subports = [0] * MAX_FRONT_PANEL_PORTS
+        logical_port_mapping = {}
+        
+        for namespace in namespaces:
+            port_cfg_table = self.portObserver.getDatabseTable("CONFIG_DB", swsscommon.CFG_PORT_TABLE_NAME, namespace)
+            port_st_table = self.portObserver.getDatabseTable("STATE_DB", swsscommon.STATE_PORT_TABLE_NAME, namespace)
+            for key in port_cfg_table.getKeys():
+                _, pcfg = port_cfg_table.get(key)
+                _, pstate = port_st_table.get(key)
+                pcfg_dict = dict(pcfg)
+                pstate_dict = dict(pstate)
+                p = Port(key,
+                            int(pcfg_dict['index']),
+                            pstate_dict.get(Port.PORT_OP_FIELD, Port.PORT_DOWN), # Current oper state
+                            pcfg_dict.get('subport', 0),
+                            pcfg_dict.get('role', None))
+                if p.isFrontPanelPort():
+                    logical_port_mapping[key] = p
+                    self.log_notice("$$$ Port = {}".format(p))
+                    #print("port list = {}".format(self.fp_port_list))
+                    fp_port_list[p._index].add(key)
+                    if p._state == Port.PORT_UP:
+                        fp_port_up_subports[p._index] += 1
+        return fp_port_list, fp_port_up_subports, logical_port_mapping
 
     def processPortStateChange(self, port_name, port_state):
         if self.fp_ports.getPort(port_name):
             # Update the port state for front panel ports
-            self.fp_ports.updatePortState(port_name, port_state)
-            if self.fp_ports.areAllSubportsUp(port_name):
-                self.updatePortLed(port_name, Port.PORT_UP)
-            else:
-                self.updatePortLed(port_name, Port.PORT_DOWN)
-
+            if self.fp_ports.updatePortState(port_name, port_state):
+                if self.fp_ports.areAllSubportsUp(port_name):
+                    state = Port.PORT_UP
+                else:
+                    state = Port.PORT_DOWN
+                self.log_notice("Setting Port %s LED state change for %s" % (port_name, state))
+                self.fp_ports.updatePortLed(port_name, state)
     # Run daemon
     def run(self):
         state, event = self.portObserver.getSelectEvent()
@@ -212,9 +252,9 @@ class DaemonLedd(daemon_base.DaemonBase):
         portEvent = self.portObserver.getPortTableEvent(event)
         if portEvent:
             self.log_notice("Received PORT table event: key=%s, state=%s" % (portEvent[0], portEvent[1]))
+            self.processPortStateChange(portEvent[0], portEvent[1])
 
         return 0
-
 
 def main():
     # Parse options if provided
@@ -236,11 +276,11 @@ def main():
 
     ledd = DaemonLedd()
 
-    # Listen indefinitely for changes to the PORT table in the Application DB's
+    # Listen indefinitely for port oper status changes
     while True:
         if 0 != ledd.run():
             print("ledd.run() failed... Exiting")
-            sys.exit(LEDUTIL_RUNTIME_ERROR)
+            sys.exit(LEDD_SELECT_ERROR)
 
 if __name__ == '__main__':
     main()

--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -10,7 +10,7 @@ import sys
 
 from sonic_py_common import daemon_base
 from sonic_py_common import multi_asic
-from sonic_py_common.interface import backplane_prefix, inband_prefix, recirc_prefix
+#from sonic_py_common.interface import backplane_prefix, inband_prefix, recirc_prefix
 from swsscommon import swsscommon
 
 #============================= Constants =============================
@@ -35,6 +35,111 @@ SELECT_TIMEOUT = 1000
 LEDUTIL_LOAD_ERROR = 1
 LEDUTIL_RUNTIME_ERROR = 2
 
+MAX_FRONT_PANEL_PORTS = 64
+
+class Port():
+    PORT_UP = "up" # All subports are up
+    PORT_DOWN = "down" # All subports are down
+    PORT_MIXED = "mixed" # Some subports are up and some are down
+
+    def __init__(self, name, index, state, subport, role):
+        self._name = name
+        self._index = index
+        self._state = state
+        self._subport = subport
+        self._role = role
+        self.is_front_panel_port = multi_asic.is_front_panel_port(name, role)
+
+    def isFrontPanelPort(self, port_name):
+        return self.is_front_panel_port
+class FrontPanelPorts:
+    def __init__(self, namespaces):
+        # {port-index, list of logical ports}
+        self.fp_port_list = [set() * MAX_FRONT_PANEL_PORTS]
+        self.fp_port_state_bitmap = [0] * MAX_FRONT_PANEL_PORTS
+        self.logical_port_mapping = {}
+
+        for namespace in namespaces:
+            config_db = daemon_base.db_connect("CONFIG_DB", namespace=namespace)
+            port_table = swsscommon.Table(config_db, swsscommon.CFG_PORT_TABLE_NAME)
+            for key in port_table.getKeys():
+                _, pcfg_table = port_table.get(key)
+                pcfg_dict = dict(pcfg_table)
+                p = Port(key,
+                            pcfg_table['index'], 
+                            Port.DOWN,
+                            pcfg_dict.get('subport', 0),
+                            pcfg_dict.get('role', None))
+                self.logical_port_mapping[key] = p
+                self.fp_port_list[p._index].add(key)
+
+    def getPort(self, name):
+        if name in self.logical_port_mapping:
+            return self.logical_port_mapping[name]
+        return None
+    
+    def areAllSubportsUp(self, index):
+        if self.getTotalSubports(index) == 1:
+            return self.fp_port_state_bitmap[index] == 1
+        
+        return self.fp_port_state_bitmap[index] == (1 << self.getTotalSubports(index)) - 1
+    
+    def areAllSubportsDown(self, index):
+        return self.fp_port_state_bitmap[index] == 0
+    
+    def getTotalSubports(self, index):
+        if index < MAX_FRONT_PANEL_PORTS:
+            return len(self.fp_port_list[index])
+        return 0
+
+    def updatePortState(self, port_name, port_state):
+        if port_name in self.logical_port_mapping:
+            port = self.logical_port_mapping[port_name]
+            port._state = port_state
+            if port._state == Port.PORT_UP:
+                self.fp_port_state_bitmap[port._index] |= 1 << port._subport
+            else:
+                self.fp_port_state_bitmap[port._index] &= ~(1 << port._subport)
+
+class PortStateObserver:
+    def __init__(self):
+       # Subscribe to PORT table notifications in the STATE DB
+        self.tables = {}
+        self.sel = swsscommon.Select()
+
+    def subscribePortTable(self, namespaces):
+        for namespace in namespaces:
+            self.subscribeDbTable("STATE_DB", swsscommon.STATE_PORT_TABLE_NAME, namespace)
+ 
+    def connectDB(self, dbname, namespace):
+        db = daemon_base.db_connect(dbname, namespace=namespace)
+        return db
+  
+    def subscribeDbTable(self, dbname, tblname, namespace):
+        db = self.connectDB(dbname, namespace)
+        self.tables[namespace] = swsscommon.SubscriberStateTable(db, tblname)
+        self.sel.addSelectable(self.tables[namespace])
+
+    def getSelectEvent(self, timeout=SELECT_TIMEOUT):
+        return self.sel.select(timeout)
+    
+    def getPortTableEvent(self, selectableObj):
+        redisSelectObj = swsscommon.CastSelectableToRedisSelectObj(selectableObj)
+        namespace = redisSelectObj.getDbConnector().getNamespace()
+
+        (key, op, fvp) = self.tables[namespace].pop()
+        if not key:
+            return None
+        
+        if fvp:
+            if key in ["PortConfigDone", "PortInitDone"]:
+                return None
+            if op == "SET" and "oper_status" in fvp_dict:
+                fvp_dict = dict(fvp)
+                return (key, fvp_dict["oper_status"])
+            
+        return None
+        
 
 class DaemonLedd(daemon_base.DaemonBase):
     def __init__(self):
@@ -51,72 +156,38 @@ class DaemonLedd(daemon_base.DaemonBase):
             # Load the namespace details first from the database_global.json file.
             swsscommon.SonicDBConfig.initializeGlobalConfig()
 
-        # Get the namespaces in the platform. For multi-asic devices we get the namespaces
-        # of front-end ascis which have front-panel interfaces.
+        # Initialize the PortStateObserver
+        self.portObserver = PortStateObserver()
+
+        # subscribe to all the front panel ports namespaces
         namespaces = multi_asic.get_front_end_namespaces()
+        self.portObserver.subscribePortTable(namespaces)
 
-        # Subscribe to PORT table notifications in the Application DB
-        self.tables = {}
-        self.sel = swsscommon.Select()
-
-        for namespace in namespaces:
-            self.subscribeDbTable("APPL_DB", swsscommon.APP_PORT_TABLE_NAME, namespace)
     
-    def connectDB(self, dbname, namespace):
-        db = daemon_base.db_connect(dbname, namespace=namespace)
-        return db
+    def updatePortLed(self, port_name, port_state):
+        if self.isFrontPanelPort(port_name):
+            self.led_control(port_name, port_state)
     
-    def subscribeDbTable(self, dbname, tblname, namespace):
-        db = self.connectDB(dbname, namespace)
-        self.tables[namespace] = swsscommon.SubscriberStateTable(db, tblname)
-        self.sel.addSelectable(self.tables[namespace])
-
-    def isFrontPanelPort(self, port_name):
-        return not port_name.startswith((backplane_prefix(), inband_prefix(), recirc_prefix()))
-
-    def updatePortLedColor(self, port_name, port_status):
-        self.led_control.port_link_state_change(port_name, port_status)
-
-    def getEventNamespace(self, selectObj):
-        # Get the corresponding namespace from redisselect db connector object
-        return selectObj.getDbConnector().getNamespace()
-    
-    def getSelectObj(self, timeout=SELECT_TIMEOUT):
-        return self.sel.select(timeout)
-    
-    def processPortTableEvent(self, selectableObj):
-        ''' Process (if any) event from the PORT table in the Application DB '''
-        # Get the redisselect object from selectable object
-        redisSelectObj = swsscommon.CastSelectableToRedisSelectObj(selectableObj)
-        namespace = self.getEventNamespace(redisSelectObj)
-
-        (key, op, fvp) = self.tables[namespace].pop()
-        if fvp:
-            # TODO: Once these flag entries have been removed from the DB,
-            # we can remove this check
-            if key in ["PortConfigDone", "PortInitDone"]:
-                return
-
-            fvp_dict = dict(fvp)
-
-            if op == "SET" and "oper_status" in fvp_dict and self.isFrontPanelPort(key):
-                self.updatePortLedColor(key, fvp_dict["oper_status"])
+    def processFinalPortState(self):
+        for port_name in self.portObserver.fp_port_list:
+            port_state = self.portObserver.fp_port_state_bitmap[port_name]
+            self.updatePortLed(port_name, port_state)
 
     # Run daemon
     def run(self):
-        # Use timeout to prevent ignoring the signals we want to handle
-        # in signal_handler() (e.g. SIGTERM for graceful shutdown)
-        (state, selectableObj) = self.getSelectObj()
+        state, event = self.portObserver.getSelectEvent()
 
         if state == swsscommon.Select.TIMEOUT:
-            # NOOP - Nothing to process here
+            # Process final state
             return 0
 
         if state != swsscommon.Select.OBJECT:
             self.log_warning("sel.select() did not return swsscommon.Select.OBJECT - May be socket closed???")
             return -1 ## Fail here so that the daemon can be restarted
 
-        self.processPortTableEvent(selectableObj)
+        portEvent = self.portObserver.getPortTableEvent(event)
+        if portEvent:
+            self.log_notice("Received PORT table event: key=%s, state=%s" % (portEvent[0], portEvent[1]))
 
         return 0
 

--- a/sonic-ledd/setup.py
+++ b/sonic-ledd/setup.py
@@ -8,8 +8,8 @@ setup(
     author='SONiC Team',
     author_email='linuxnetdev@microsoft.com',
     url='https://github.com/Azure/sonic-platform-daemons',
-    maintainer='Joe LeVeque',
-    maintainer_email='jolevequ@microsoft.com',
+    maintainer='Prince George',
+    maintainer_email='prgeor@microsoft.com',
     scripts=[
         'scripts/ledd',
     ],

--- a/sonic-ledd/tests/test_ledd.py
+++ b/sonic-ledd/tests/test_ledd.py
@@ -162,7 +162,7 @@ def test_daemon_ledd_run_timeout(mock_fp_ports, mock_find_front_panel_ports, moc
 
 @mock.patch('swsscommon.swsscommon.Select.addSelectable', mock.MagicMock())
 @mock.patch("ledd.DaemonLedd.load_platform_util")
-@mock.patch("ledd.PortStateObserver.getDatabseTable")
+@mock.patch("ledd.PortStateObserver.getDatabaseTable")
 def test_find_front_panel_ports(mock_get_database_table, mock_load_platform_util):
     """
     Test DaemonLedd.findFrontPanelPorts to ensure it correctly processes namespaces and returns

--- a/sonic-ledd/tests/test_ledd.py
+++ b/sonic-ledd/tests/test_ledd.py
@@ -109,7 +109,7 @@ def test_port_state_observer_initialization(mock_select):
 @mock.patch("ledd.daemon_base.db_connect")
 def test_port_state_observer_get_database_table(mock_db_connect, mock_table):
     observer = ledd.PortStateObserver()
-    table = observer.getDatabseTable("STATE_DB", "PORT_TABLE", "namespace")
+    table = observer.getDatabaseTable("STATE_DB", "PORT_TABLE", "namespace")
     mock_db_connect.assert_called_once_with("STATE_DB", namespace="namespace")
     mock_table.assert_called_once_with(mock_db_connect.return_value, "PORT_TABLE")
     assert table == mock_table.return_value

--- a/sonic-ledd/tests/test_ledd.py
+++ b/sonic-ledd/tests/test_ledd.py
@@ -3,14 +3,9 @@ import sys
 from imp import load_source
 
 import pytest
-# TODO: Clean this up once we no longer need to support Python 2
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
+from unittest import mock
 from sonic_py_common import daemon_base
-
-daemon_base.db_connect = mock.MagicMock()
+from swsscommon import swsscommon
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
@@ -18,8 +13,14 @@ scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, modules_path)
 
 load_source('ledd', scripts_path + '/ledd')
+
 import ledd
 
+daemon_base.db_connect = mock.MagicMock()
+swsscommon.Table = mock.MagicMock()
+swsscommon.ProducerStateTable = mock.MagicMock()
+swsscommon.SubscriberStateTable = mock.MagicMock()
+swsscommon.SonicDBConfig = mock.MagicMock()
 
 def test_help_args(capsys):
     for flag in ['-h', '--help']:
@@ -52,100 +53,224 @@ def test_bad_args(capsys):
             assert pytest_wrapped_e.value.code == 1
             out, err = capsys.readouterr()
             assert out.rstrip().endswith(ledd.USAGE_HELP.rstrip())
+# Test Port class
+def test_port_initialization():
+    port = ledd.Port("Ethernet0", 1, ledd.Port.PORT_DOWN, 0, "front-panel")
+    assert port._name == "Ethernet0"
+    assert port._index == 1
+    assert port._state == ledd.Port.PORT_DOWN
+    assert port._subport == 0
+    assert port._role == "front-panel"
+    assert port.isFrontPanelPort() is True
 
 
-class TestDaemonLedd(object):
+# Test FrontPanelPorts class
+def test_front_panel_ports_initialization():
+    fp_list = [set() for _ in range(ledd.MAX_FRONT_PANEL_PORTS)]
+    up_subports = [0] * ledd.MAX_FRONT_PANEL_PORTS
+    logical_pmap = {}
+    led_control = mock.Mock()
+
+    fp_ports = ledd.FrontPanelPorts(fp_list, up_subports, logical_pmap, led_control)
+    assert fp_ports.fp_port_up_subports == up_subports
+    assert fp_ports.fp_port_list == fp_list
+    assert fp_ports.logical_port_mapping == logical_pmap
+    assert fp_ports.led_control == led_control
+
+def test_front_panel_ports_update_port_led():
+    led_control = mock.Mock()
+    fp_ports = ledd.FrontPanelPorts([], [], {}, led_control)
+
+    fp_ports.updatePortLed("Ethernet0", ledd.Port.PORT_UP)
+    led_control.port_link_state_change.assert_called_once_with("Ethernet0", ledd.Port.PORT_UP)
+
+
+def test_front_panel_ports_update_port_state():
+    port = ledd.Port("Ethernet0", 1, ledd.Port.PORT_DOWN, 0, "front-panel")
+    fp_list = [set() for _ in range(ledd.MAX_FRONT_PANEL_PORTS)]
+    up_subports = [0] * ledd.MAX_FRONT_PANEL_PORTS
+    logical_pmap = {"Ethernet0": port}
+    led_control = mock.Mock()
+
+    fp_ports = ledd.FrontPanelPorts(fp_list, up_subports, logical_pmap, led_control)
+    assert fp_ports.updatePortState("Ethernet0", ledd.Port.PORT_UP) is True
+    assert port._state == ledd.Port.PORT_UP
+
+
+# Test PortStateObserver class
+@mock.patch("ledd.swsscommon.Select")
+def test_port_state_observer_initialization(mock_select):
+    observer = ledd.PortStateObserver()
+    assert observer.sel == mock_select.return_value
+    assert observer.tables == {}
+
+
+@mock.patch("ledd.swsscommon.Table")
+@mock.patch("ledd.daemon_base.db_connect")
+def test_port_state_observer_get_database_table(mock_db_connect, mock_table):
+    observer = ledd.PortStateObserver()
+    table = observer.getDatabseTable("STATE_DB", "PORT_TABLE", "namespace")
+    mock_db_connect.assert_called_once_with("STATE_DB", namespace="namespace")
+    mock_table.assert_called_once_with(mock_db_connect.return_value, "PORT_TABLE")
+    assert table == mock_table.return_value
+
+# Test DaemonLedd class
+@mock.patch("ledd.DaemonLedd.load_platform_util")
+@mock.patch("ledd.multi_asic.get_front_end_namespaces")
+@mock.patch("ledd.PortStateObserver")
+@mock.patch("ledd.FrontPanelPorts")
+def test_daemon_ledd_initialization(mock_fp_ports, mock_port_observer, mock_get_namespaces, mock_load_platform_util):
+    mock_get_namespaces.return_value = ["namespace1", "namespace2"]
+    daemon_ledd = ledd.DaemonLedd()
+
+    mock_load_platform_util.assert_called_once_with("led_control", "LedControl")
+    mock_port_observer.return_value.subscribePortTable.assert_called_once_with(["namespace1", "namespace2"])
+    mock_fp_ports.return_value.initPortLeds.assert_called_once()
+
+@mock.patch('swsscommon.swsscommon.Select.addSelectable', mock.MagicMock())
+@mock.patch("ledd.DaemonLedd.load_platform_util")
+@mock.patch("ledd.PortStateObserver.getSelectEvent")
+@mock.patch("ledd.DaemonLedd.findFrontPanelPorts")
+@mock.patch("ledd.FrontPanelPorts")
+def test_daemon_ledd_run_timeout(mock_fp_ports, mock_find_front_panel_ports, mock_get_select_event, mock_load_platform_util):
     """
-    Test cases to cover functionality in DaemonLedd class
+    Test that DaemonLedd.run() handles a timeout from the select method correctly.
     """
+    # Mock getSelectEvent to return a timeout
+    mock_get_select_event.return_value = (swsscommon.Select.TIMEOUT, None)
 
-    def test_run_fail_load_platform_util(self):
-        with pytest.raises(SystemExit) as pytest_wrapped_e:
-            ledd.DaemonLedd()
-        assert pytest_wrapped_e.type == SystemExit
-        assert pytest_wrapped_e.value.code == ledd.LEDUTIL_LOAD_ERROR
+    # Mock load_platform_util to prevent actual loading of the LedControl module
+    mock_load_platform_util.return_value = mock.Mock()
 
-    @mock.patch("ledd.DaemonLedd.load_platform_util")
-    @mock.patch("ledd.swsscommon.SubscriberStateTable")
-    @mock.patch("ledd.swsscommon.Select")
-    def test_run_select_timeout(self, mock_select, mock_sst, mock_load_plat_util):
-        select_instance = mock_select.return_value
-        select_instance.select.return_value = (ledd.swsscommon.Select.TIMEOUT, None)
+    # Mock findFrontPanelPorts to return dummy data
+    mock_find_front_panel_ports.return_value = ([], [], {})
 
-        daemon_ledd = ledd.DaemonLedd()
-        ret = daemon_ledd.run()
-        assert ret == 0
+    # Mock FrontPanelPorts to avoid side effects
+    mock_fp_ports.return_value.initPortLeds.return_value = None
 
-    @mock.patch("ledd.DaemonLedd.load_platform_util")
-    @mock.patch("ledd.swsscommon.SubscriberStateTable")
-    @mock.patch("ledd.swsscommon.Select")
-    def test_run_bad_select_return(self, mock_select, mock_sst, mock_load_plat_util):
-        select_instance = mock_select.return_value
-        select_instance.select.return_value = (ledd.swsscommon.Select.ERROR, mock.MagicMock())
+    # Create an instance of DaemonLedd
+    daemon_ledd = ledd.DaemonLedd()
 
-        daemon_ledd = ledd.DaemonLedd()
-        ret = daemon_ledd.run()
-        assert ret == -1
+    # Call the run method
+    ret = daemon_ledd.run()
 
-    @mock.patch("ledd.DaemonLedd.load_platform_util")
-    @mock.patch("ledd.swsscommon.CastSelectableToRedisSelectObj")
-    @mock.patch("ledd.swsscommon.SubscriberStateTable")
-    @mock.patch("ledd.swsscommon.Select")
-    def test_run_ignore_keys(self, mock_select, mock_sst, mock_cstrso, mock_load_plat_util):
-        select_instance = mock_select.return_value
-        select_instance.select.return_value = (ledd.swsscommon.Select.OBJECT, mock.MagicMock())
+    # Assert that the return value is 0 (indicating successful handling of timeout)
+    assert ret == 0
 
-        mock_cstrso.return_value.getDbConnector.return_value.getNamespace.return_value = ledd.multi_asic.DEFAULT_NAMESPACE
+    # Verify that initPortLeds was called during initialization
+    mock_fp_ports.return_value.initPortLeds.assert_called_once()
 
-        sst_instance = mock_sst.return_value
+@mock.patch('swsscommon.swsscommon.Select.addSelectable', mock.MagicMock())
+@mock.patch("ledd.DaemonLedd.load_platform_util")
+@mock.patch("ledd.PortStateObserver.getDatabseTable")
+def test_find_front_panel_ports(mock_get_database_table, mock_load_platform_util):
+    """
+    Test DaemonLedd.findFrontPanelPorts to ensure it correctly processes namespaces and returns
+    the expected front panel port data.
+    """
+    # Mock the database table behavior
+    mock_config_table = mock.Mock()
+    mock_state_table = mock.Mock()
 
-        for key in ['PortConfigDone', 'PortInitDone']:
-            sst_instance.pop.return_value = ('PortConfigDone', 'SET', {'not': 'applicable'})
+    # Mock load_platform_util to prevent actual loading of the LedControl module
+    mock_load_platform_util.return_value = mock.Mock()
 
-            daemon_ledd = ledd.DaemonLedd()
-            ret = daemon_ledd.run()
-            assert ret == 0
+    # Mock the return values for CONFIG_DB and STATE_DB tables
+    mock_get_database_table.side_effect = lambda dbname, tblname, namespace: (
+        mock_config_table if dbname == "CONFIG_DB" else mock_state_table
+    )
 
-    @mock.patch("ledd.DaemonLedd.load_platform_util")
-    @mock.patch("ledd.swsscommon.CastSelectableToRedisSelectObj")
-    @mock.patch("ledd.swsscommon.SubscriberStateTable")
-    @mock.patch("ledd.swsscommon.Select")
-    def test_run_bad_fvp(self, mock_select, mock_sst, mock_cstrso, mock_load_plat_util):
-        select_instance = mock_select.return_value
-        select_instance.select.return_value = (ledd.swsscommon.Select.OBJECT, mock.MagicMock())
+    # Mock the keys and values for the CONFIG_DB and STATE_DB tables
+    mock_config_table.getKeys.return_value = ["Ethernet0", "Ethernet1"]
+    mock_config_table.get.side_effect = lambda key: (
+        key,
+        [
+            ("index", "0" if key == "Ethernet0" else "1"),
+            ("subport", "0"),
+            ("role", "front-panel"),
+        ],
+    )
+    mock_state_table.get.side_effect = lambda key: (
+        key,
+        [("netdev_oper_status", "up" if key == "Ethernet0" else "down")],
+    )
 
-        mock_cstrso.return_value.getDbConnector.return_value.getNamespace.return_value = ledd.multi_asic.DEFAULT_NAMESPACE
+    # Create an instance of DaemonLedd
+    daemon_ledd = ledd.DaemonLedd()
 
-        sst_instance = mock_sst.return_value
+    # Call the method under test
+    namespaces = ["namespace1"]
+    fp_port_list, fp_port_up_subports, logical_port_mapping = daemon_ledd.findFrontPanelPorts(namespaces)
 
-        for fvp in [None, {}]:
-            sst_instance.pop.return_value = ('Ethernet0', 'SET', fvp)
+    # Assertions
+    assert len(fp_port_list) == ledd.MAX_FRONT_PANEL_PORTS
+    assert len(fp_port_list[0]) == 1  # Ethernet0 is in index 0
+    assert len(fp_port_list[1]) == 1  # Ethernet1 is in index 1
+    assert "Ethernet0" in logical_port_mapping
+    assert "Ethernet1" in logical_port_mapping
+    assert logical_port_mapping["Ethernet0"]._state == ledd.Port.PORT_UP
+    assert logical_port_mapping["Ethernet1"]._state == ledd.Port.PORT_DOWN
+    assert fp_port_up_subports[0] == 1  # Ethernet0 is up
+    assert fp_port_up_subports[1] == 0  # Ethernet1 is down
 
-            daemon_ledd = ledd.DaemonLedd()
-            ret = daemon_ledd.run()
-            assert ret == 0
+@mock.patch("ledd.swsscommon.SubscriberStateTable")
+@mock.patch("ledd.swsscommon.CastSelectableToRedisSelectObj")
+def test_get_port_table_event(mock_cast_selectable, mock_subscriber_table):
+    """
+    Test PortStateObserver.getPortTableEvent to ensure it correctly processes events from the PORT table.
+    """
+    # Mock the selectable object and namespace
+    mock_redis_select_obj = mock.Mock()
+    mock_cast_selectable.return_value = mock_redis_select_obj
+    mock_redis_select_obj.getDbConnector.return_value.getNamespace.return_value = "namespace1"
 
-    @mock.patch("ledd.DaemonLedd.load_platform_util")
-    @mock.patch("ledd.swsscommon.CastSelectableToRedisSelectObj")
-    @mock.patch("ledd.swsscommon.SubscriberStateTable")
-    @mock.patch("ledd.swsscommon.Select")
-    def test_run_good(self, mock_select, mock_sst, mock_cstrso, mock_led_control):
-        select_instance = mock_select.return_value
-        select_instance.select.return_value = (ledd.swsscommon.Select.OBJECT, mock.MagicMock())
+    # Mock the SubscriberStateTable behavior
+    mock_table = mock.Mock()
+    mock_subscriber_table.return_value = mock_table
+    mock_table.pop.return_value = ("Ethernet0", "SET", [("netdev_oper_status", ledd.Port.PORT_UP)])
 
-        mock_cstrso.return_value.getDbConnector.return_value.getNamespace.return_value = ledd.multi_asic.DEFAULT_NAMESPACE
+    # Create an instance of PortStateObserver
+    observer = ledd.PortStateObserver()
+    observer.tables["namespace1"] = mock_table
 
-        sst_instance = mock_sst.return_value
+    # Call the method under test
+    event = observer.getPortTableEvent(mock.Mock())
 
-        led_control_instance = mock_led_control.return_value
+    # Assertions
+    assert event is not None
+    assert event[0] == "Ethernet0"  # Port name
+    assert event[1] == ledd.Port.PORT_UP  # Port state
 
-        for port in ['Ethernet0', 'Ethernet4']:
-            for link_state in ['up', 'down']:
-                sst_instance.pop.return_value = (port, 'SET', {'oper_status': link_state})
+    # Verify that the mock methods were called
+    mock_cast_selectable.assert_called_once()
+    mock_table.pop.assert_called_once()
 
-                daemon_ledd = ledd.DaemonLedd()
-                ret = daemon_ledd.run()
-                assert ret == 0
-                assert led_control_instance.port_link_state_change.call_count == 1
-                led_control_instance.port_link_state_change.assert_called_with(port, link_state)
-                led_control_instance.port_link_state_change.reset_mock()
+@mock.patch("ledd.swsscommon.SubscriberStateTable")
+@mock.patch("ledd.swsscommon.CastSelectableToRedisSelectObj")
+def test_get_port_table_event_no_key(mock_cast_selectable, mock_subscriber_table):
+    """
+    Test PortStateObserver.getPortTableEvent to handle cases where no key is returned.
+    """
+    # Mock the selectable object and namespace
+    mock_redis_select_obj = mock.Mock()
+    mock_cast_selectable.return_value = mock_redis_select_obj
+    mock_redis_select_obj.getDbConnector.return_value.getNamespace.return_value = "namespace1"
+
+    # Mock the SubscriberStateTable behavior
+    mock_table = mock.Mock()
+    mock_subscriber_table.return_value = mock_table
+    mock_table.pop.return_value = (None, None, None)
+
+    # Create an instance of PortStateObserver
+    observer = ledd.PortStateObserver()
+    observer.tables["namespace1"] = mock_table
+
+    # Call the method under test
+    event = observer.getPortTableEvent(mock.Mock())
+
+    # Assertions
+    assert event is None
+
+    # Verify that the mock methods were called
+    mock_cast_selectable.assert_called_once()
+    mock_table.pop.assert_called_once()

--- a/sonic-ledd/tests/test_ledd.py
+++ b/sonic-ledd/tests/test_ledd.py
@@ -74,7 +74,7 @@ class TestDaemonLedd(object):
 
         daemon_ledd = ledd.DaemonLedd()
         ret = daemon_ledd.run()
-        assert ret == 1
+        assert ret == 0
 
     @mock.patch("ledd.DaemonLedd.load_platform_util")
     @mock.patch("ledd.swsscommon.SubscriberStateTable")
@@ -85,7 +85,7 @@ class TestDaemonLedd(object):
 
         daemon_ledd = ledd.DaemonLedd()
         ret = daemon_ledd.run()
-        assert ret == 2
+        assert ret == -1
 
     @mock.patch("ledd.DaemonLedd.load_platform_util")
     @mock.patch("ledd.swsscommon.CastSelectableToRedisSelectObj")
@@ -104,7 +104,7 @@ class TestDaemonLedd(object):
 
             daemon_ledd = ledd.DaemonLedd()
             ret = daemon_ledd.run()
-            assert ret == 3
+            assert ret == 0
 
     @mock.patch("ledd.DaemonLedd.load_platform_util")
     @mock.patch("ledd.swsscommon.CastSelectableToRedisSelectObj")
@@ -123,7 +123,7 @@ class TestDaemonLedd(object):
 
             daemon_ledd = ledd.DaemonLedd()
             ret = daemon_ledd.run()
-            assert ret == 4
+            assert ret == 0
 
     @mock.patch("ledd.DaemonLedd.load_platform_util")
     @mock.patch("ledd.swsscommon.CastSelectableToRedisSelectObj")


### PR DESCRIPTION
…close

<!-- Provide a general summary of your changes in the Title above -->

#### Description
[ledd] Refactor ledd daemon and fix high CPU usage due to unexpected redis DB socket close

As part of the refactor, the LED port color is changed to oper UP only if all subports of a front panel ports are UP.
If any subport is oper DOWN, the LED port color is changed to oper DOWN

#### Motivation and Context
For unkown reason if redis closes the socket, then ledd daemon is continuously  busy waiting for socket event and failing all the time. This is resulting in high CPI

The change in Port LED behavior is necessary to prevent situation in the old behavior where even if some subports are oper down, the front panel port LED should not glow green.

#### How Has This Been Tested?
Close the socket abruptly and see ledd daemon is respawned so that new socket connection is established to redis DB without causing high CPU.

Test this on Arista 7060X6 with 8x100G mode and 2x400G mode 

#### Additional Information (Optional)
