### PR TITLE
Delay DOM polling until all ports are initialized

### DIFF
--- a/sonic-xcvrd/xcvrd/dom/dom_mgr.py
+++ b/sonic-xcvrd/xcvrd/dom/dom_mgr.py
@@ -34,8 +34,8 @@ SYSLOG_IDENTIFIER_DOMINFOUPDATETASK = "DomInfoUpdateTask"
 
 class DomInfoUpdateTask(threading.Thread):
     DOM_INFO_UPDATE_PERIOD_SECS = 60
-    DOM_WAIT_PORT_INITIALIZATION_POLL_SECS = 60
-    DOM_WAIT_PORT_INIT_TIMEOUT_SECS = 300
+    DOM_WAIT_PORT_INITIALIZATION_POLL_SECS = 150
+    DOM_WAIT_PORT_INIT_TIMEOUT_SECS = 600
     DIAG_DB_UPDATE_TIME_AFTER_LINK_CHANGE = 1
     DOM_PORT_CHG_OBSERVER_TBL_MAP = [
         {'APPL_DB': 'PORT_TABLE', 'FILTER': ['flap_count']},
@@ -264,6 +264,8 @@ class DomInfoUpdateTask(threading.Thread):
             self.log_notice("All ports are in CMIS terminal state, start DOM monitoring")
 
         next_periodic_db_update_time = datetime.datetime.now()
+        dom_info_update_periodic_secs = self.DOM_INFO_UPDATE_PERIOD_SECS
+
         # Start loop to update dom info in DB periodically and handle port change events
         while not self.task_stopping_event.is_set():
             # Check if periodic db update is needed


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Delay DOM polling until all ports are initialized

#### Motivation and Context
Platforms with large radix like 512 ports may take more time to initialize and complete the CMIS datapath state machine. Since DOM polling is quite expensive on IO bound operation, it can result in contention with CMIS manager task which is initializing the port

#### How Has This Been Tested?
Tested this on a platform with 512 100G ports with 800G DR8 optics and see a reduction of overall link up time by around 4mins.

#### Additional Information (Optional)
