### PR TITLE
[Port-breakout] Fix Unable to find key NPU_SI_SETTINGS_SYNC_STATUS ERR

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -4114,6 +4114,7 @@ class TestXcvrdScript(object):
         mock_table_helper.get_int_tbl = MagicMock(return_value=mock_table)
         mock_table_helper.get_dom_tbl = MagicMock(return_value=mock_table)
         mock_table_helper.get_dom_threshold_tbl = MagicMock(return_value=mock_table)
+        mock_table_helper.get_state_port_tbl = MagicMock(return_value=mock_table)
         stop_event = threading.Event()
         sfp_error_event = threading.Event()
         port_mapping = PortMapping()
@@ -4123,6 +4124,7 @@ class TestXcvrdScript(object):
         task.xcvr_table_helper.get_status_tbl = mock_table_helper.get_status_tbl
         task.xcvr_table_helper.get_intf_tbl = mock_table_helper.get_intf_tbl
         task.xcvr_table_helper.get_dom_tbl = mock_table_helper.get_dom_tbl
+        task.xcvr_table_helper.get_state_port_tbl = mock_table_helper.get_state_port_tbl
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
         wait_time = 5
         while wait_time > 0:
@@ -4353,9 +4355,13 @@ class TestXcvrdScript(object):
         dom_threshold_tbl = MockTable()
         dom_threshold_tbl.get = MagicMock(return_value=(True, (('key4', 'value4'),)))
         dom_threshold_tbl.set = MagicMock()
+        state_port_tbl = MockTable()
+        state_port_tbl.get = MagicMock(return_value=(True, (('key5', 'value5'),)))
+        state_port_tbl.set = MagicMock()
         mock_table_helper.get_status_sw_tbl = MagicMock(return_value=status_sw_tbl)
         mock_table_helper.get_intf_tbl = MagicMock(return_value=int_tbl)
         mock_table_helper.get_dom_threshold_tbl = MagicMock(return_value=dom_threshold_tbl)
+        mock_table_helper.get_state_port_tbl = MagicMock(return_value=state_port_tbl)
 
         port_mapping = PortMapping()
         mock_sfp_obj_dict = MagicMock()
@@ -4366,6 +4372,7 @@ class TestXcvrdScript(object):
         task.xcvr_table_helper.get_status_sw_tbl = mock_table_helper.get_status_sw_tbl
         task.xcvr_table_helper.get_intf_tbl = mock_table_helper.get_intf_tbl
         task.xcvr_table_helper.get_dom_threshold_tbl = mock_table_helper.get_dom_threshold_tbl
+        task.xcvr_table_helper.get_state_port_tbl = mock_table_helper.get_state_port_tbl
         task.dom_db_utils.post_port_dom_thresholds_to_db = MagicMock()
         task.vdm_db_utils.post_port_vdm_thresholds_to_db = MagicMock()
         port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -772,6 +772,15 @@ class SfpStateUpdateTask(threading.Thread):
         #  3. SFP is not present. Only update TRANSCEIVER_STATUS_INFO table.
         status_sw_tbl = self.xcvr_table_helper.get_status_sw_tbl(port_change_event.asic_id)
         int_tbl = self.xcvr_table_helper.get_intf_tbl(port_change_event.asic_id)
+        # Initialize the NPU_SI_SETTINGS_SYNC_STATUS to default value
+        state_port_table = self.xcvr_table_helper.get_state_port_tbl(port_change_event.asic_id)
+        found, state_port_table_fvs = state_port_table.get(port_change_event.port_name)
+        if not found:
+            helper_logger.log_notice("Add logical port: Creating STATE_DB PORT_TABLE as unable to find for lport {}".format(port_change_event.port_name))
+            state_port_table_fvs = []
+        state_port_table.set(port_change_event.port_name, [(NPU_SI_SETTINGS_SYNC_STATUS_KEY,
+                                                      NPU_SI_SETTINGS_DEFAULT_VALUE)])
+        helper_logger.log_notice("Add logical port: Initialized NPU_SI_SETTINGS_SYNC_STATUS for lport {}".format(port_change_event.port_name))
 
         error_description = 'N/A'
         status = None


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
What is the Issue:

For newly created breakout ports, the NPU_SI_SETTINGS_SYNC_STATUS value is not getting set in the STATE_DB's PORT_TABLE. This is normally done during xcvrd init for all the port present in system using initialize_port_init_control_fields_in_port_table(). Due to this during SI setting programming for DPB ports, the code fails to locate the NPU_SI_SETTINGS_SYNC_STATUS key in the STATE_DB, resulting in an below syslog error.

```
sonic ERR pmon#chassis: Get value by key from STATE_DB: Unable to
 find key NPU_SI_SETTINGS_SYNC_STATUS state_port_table_fvs_dict
 {'host_tx_ready': 'false', 'state': 'ok', 'netdev_oper_status':
 'down', 'admin_status': 'down', 'mtu': '9100', 'supported_speeds':
 '50000,100000', 'supported_fecs': 'rs'} for lport Ethernet448
```

Fix:
Set the NPU_SI_SETTINGS_SYNC_STATUS to NPU_SI_SETTINGS_DEFAULT_VALUE value in State DB on the event of "port_event_helper.PortChangeEvent.PORT_ADD" in on_add_logical_port() which get trigged for newly added DPB ports.

This PR fixes below issue: 
https://github.com/sonic-net/sonic-platform-daemons/issues/621

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

To fix error seen in syslog during port breakout 

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Verified that syslog ERR is not seen with breakout CLI
sudo config interface breakout Ethernet448 "8x100G[50G,25G]" -y -f

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
#### Additional Information (Optional)
