### PR TITLE
Remove space from the vendor key used for obtaining media si settings

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -100,7 +100,7 @@ def get_media_settings_key(physical_port, transceiver_dict, port_speed, lane_cou
     extended_spec_compliance_str = 'Extended Specification Compliance'
     vendor_name_str = transceiver_dict[physical_port]['manufacturer']
     vendor_pn_str = transceiver_dict[physical_port]['model']
-    vendor_key = vendor_name_str.upper() + '-' + vendor_pn_str
+    vendor_key = vendor_name_str.strip().upper() + '-' + vendor_pn_str.strip().upper()
 
     media_len = ''
     if transceiver_dict[physical_port]['cable_type'] == sup_len_str:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Remove space from the vendor key used for obtaining media si settings

#### Motivation and Context
To remove the vendor name + vendor PN where each of these have space character its better to remove them before using as the key because the media_settings.json will need the to speciy the key like

...
`'Eoptolink      -EO199HGPKT11PLQ  '`

instead of 

`'Eoptolink-EO199HGPKT11PLQ'`


#### How Has This Been Tested?
Used custom SI settings with above module and ensured the Xcvrd is sending the correct SI settings to the orchagent.

#### Additional Information (Optional)
