### PR TITLE
Make polling intervals in the ThermalMonitor class configurable

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -6,7 +6,7 @@
 """
 
 from enum import Enum, auto
-import argparse
+import os
 import signal
 import sys
 import threading
@@ -31,6 +31,8 @@ PHYSICAL_ENTITY_INFO_TABLE = 'PHYSICAL_ENTITY_INFO'
 INVALID_SLOT_OR_DPU = -1
 
 ERR_UNKNOWN = 1
+
+PLATFORM_ENV_CONF_FILE = "/usr/share/sonic/platform/platform_env.conf"
 
 # Thermal control daemon is designed to never exit, it must always
 # return non-zero exit code when exiting and so that supervisord will
@@ -743,8 +745,13 @@ class TemperatureUpdater(logger.Logger):
 
 
 class ThermalMonitor(ProcessTaskBase):
-
-    def __init__(self, chassis, initial_interval, update_interval, update_elapsed_threshold):
+    def __init__(
+        self,
+        chassis,
+        initial_interval=5,
+        update_interval=60,
+        update_elapsed_threshold=30,
+    ):
         """
         Initializer for ThermalMonitor
         :param chassis: Object representing a platform chassis
@@ -755,7 +762,7 @@ class ThermalMonitor(ProcessTaskBase):
         self.initial_interval = initial_interval
         # Update interval value
         self.update_interval = update_interval
-        # Update elapse threshold. If update used time is larger than the value, generate a warning log
+        # Update elapse threshold. If update used time is larger than the value, generate a warning log.
         self.update_elapsed_threshold = update_elapsed_threshold
 
         self.wait_time = self.initial_interval
@@ -808,10 +815,11 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
 
     POLICY_FILE = '/usr/share/sonic/platform/thermal_policy.json'
 
-    def __init__(self, thermal_monitor_initial_interval, thermal_monitor_update_interval,
-                 thermal_monitor_update_elapsed_threshold):
+    def __init__(self, platform_env_conf_file=PLATFORM_ENV_CONF_FILE):
         """
         Initializer of ThermalControlDaemon
+        :param platform_env_conf_file: Filepath to platform env config.
+                                       Used for dependency injection in unit tests.
         """
         super(ThermalControlDaemon, self).__init__(SYSLOG_IDENTIFIER)
 
@@ -824,15 +832,24 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
 
         self.chassis = sonic_platform.platform.Platform().get_chassis()
 
-        self.thermal_monitor_initial_interval = thermal_monitor_initial_interval
-        self.thermal_monitor_update_interval = thermal_monitor_update_interval
-        self.thermal_monitor_update_elapsed_threshold = thermal_monitor_update_elapsed_threshold
-        self.thermal_monitor = ThermalMonitor(
-            self.chassis,
-            self.thermal_monitor_initial_interval,
-            self.thermal_monitor_update_interval,
-            self.thermal_monitor_update_elapsed_threshold
-        )
+        # Replace ThermalMonitor timing-related config with values
+        # from platform_env.conf if defined.
+        thermal_monitor_extra_args = {}
+        if os.path.isfile(platform_env_conf_file):
+            with open(platform_env_conf_file, 'r') as file:
+                for line in file:
+                    if not line or '=' not in line:
+                        continue
+                    k, v = line.split('=', 1)
+                    k = k.strip()
+                    v = v.strip()
+                    if k == 'THERMALCTLD_THERMAL_MONITOR_INITIAL_INTERVAL':
+                        thermal_monitor_extra_args['initial_interval'] = int(v)
+                    elif k == 'THERMALCTLD_THERMAL_MONITOR_UPDATE_INTERVAL':
+                        thermal_monitor_extra_args['update_interval'] = int(v)
+                    elif k == 'THERMALCTLD_THERMAL_MONITOR_UPDATE_ELAPSED_THRESHOLD':
+                        thermal_monitor_extra_args['update_elapsed_threshold'] = int(v)
+        self.thermal_monitor = ThermalMonitor(self.chassis, **thermal_monitor_extra_args)
         self.thermal_monitor.task_run()
 
         self.thermal_manager = None
@@ -921,17 +938,7 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
 # Main =========================================================================
 #
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--thermal-monitor-initial-interval', type=int, default=5)
-    parser.add_argument('--thermal-monitor-update-interval', type=int, default=60)
-    parser.add_argument('--thermal-monitor-update-elapsed-threshold', type=int, default=30)
-    args = parser.parse_args()
-
-    thermal_control = ThermalControlDaemon(
-        args.thermal_monitor_initial_interval,
-        args.thermal_monitor_update_interval,
-        args.thermal_monitor_update_elapsed_threshold
-    )
+    thermal_control = ThermalControlDaemon()
 
     thermal_control.log_info("Starting up...")
 

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -6,7 +6,7 @@
 """
 
 from enum import Enum, auto
-import os
+import argparse
 import signal
 import sys
 import threading
@@ -31,8 +31,6 @@ PHYSICAL_ENTITY_INFO_TABLE = 'PHYSICAL_ENTITY_INFO'
 INVALID_SLOT_OR_DPU = -1
 
 ERR_UNKNOWN = 1
-
-PLATFORM_ENV_CONF_FILE = "/usr/share/sonic/platform/platform_env.conf"
 
 # Thermal control daemon is designed to never exit, it must always
 # return non-zero exit code when exiting and so that supervisord will
@@ -745,12 +743,9 @@ class TemperatureUpdater(logger.Logger):
 
 
 class ThermalMonitor(ProcessTaskBase):
+
     def __init__(
-        self,
-        chassis,
-        initial_interval=5,
-        update_interval=60,
-        update_elapsed_threshold=30,
+        self, chassis, initial_interval, update_interval, update_elapsed_threshold
     ):
         """
         Initializer for ThermalMonitor
@@ -762,7 +757,7 @@ class ThermalMonitor(ProcessTaskBase):
         self.initial_interval = initial_interval
         # Update interval value
         self.update_interval = update_interval
-        # Update elapse threshold. If update used time is larger than the value, generate a warning log.
+        # Update elapse threshold. If update used time is larger than the value, generate a warning log
         self.update_elapsed_threshold = update_elapsed_threshold
 
         self.wait_time = self.initial_interval
@@ -815,11 +810,14 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
 
     POLICY_FILE = '/usr/share/sonic/platform/thermal_policy.json'
 
-    def __init__(self, platform_env_conf_file=PLATFORM_ENV_CONF_FILE):
+    def __init__(
+        self,
+        thermal_monitor_initial_interval,
+        thermal_monitor_update_interval,
+        thermal_monitor_update_elapsed_threshold,
+    ):
         """
         Initializer of ThermalControlDaemon
-        :param platform_env_conf_file: Filepath to platform env config.
-                                       Used for dependency injection in unit tests.
         """
         super(ThermalControlDaemon, self).__init__(SYSLOG_IDENTIFIER)
 
@@ -832,27 +830,12 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
 
         self.chassis = sonic_platform.platform.Platform().get_chassis()
 
-        # Replace ThermalMonitor timing-related config with values
-        # from platform_env.conf if defined.
-        thermal_monitor_extra_args = {}
-        if os.path.isfile(platform_env_conf_file):
-            with open(platform_env_conf_file, 'r') as file:
-                for line in file:
-                    if not line or '=' not in line:
-                        continue
-                    k, v = line.split('=', 1)
-                    k = k.strip()
-                    v = v.strip()
-                    try:
-                        if k == 'THERMALCTLD_THERMAL_MONITOR_INITIAL_INTERVAL':
-                            thermal_monitor_extra_args['initial_interval'] = int(v)
-                        elif k == 'THERMALCTLD_THERMAL_MONITOR_UPDATE_INTERVAL':
-                            thermal_monitor_extra_args['update_interval'] = int(v)
-                        elif k == 'THERMALCTLD_THERMAL_MONITOR_UPDATE_ELAPSED_THRESHOLD':
-                            thermal_monitor_extra_args['update_elapsed_threshold'] = int(v)
-                    except ValueError as e:
-                        self.log_error(f'Failed to load {k} from {platform_env_conf_file}, falling back to default, err: {e}')
-        self.thermal_monitor = ThermalMonitor(self.chassis, **thermal_monitor_extra_args)
+        self.thermal_monitor = ThermalMonitor(
+            self.chassis,
+            thermal_monitor_initial_interval,
+            thermal_monitor_update_interval,
+            thermal_monitor_update_elapsed_threshold
+        )
         self.thermal_monitor.task_run()
 
         self.thermal_manager = None
@@ -941,7 +924,17 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
 # Main =========================================================================
 #
 def main():
-    thermal_control = ThermalControlDaemon()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--thermal-monitor-initial-interval', type=int, default=5)
+    parser.add_argument('--thermal-monitor-update-interval', type=int, default=60)
+    parser.add_argument('--thermal-monitor-update-elapsed-threshold', type=int, default=30)
+    args = parser.parse_args()
+
+    thermal_control = ThermalControlDaemon(
+        args.thermal_monitor_initial_interval,
+        args.thermal_monitor_update_interval,
+        args.thermal_monitor_update_elapsed_threshold
+    )
 
     thermal_control.log_info("Starting up...")
 

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -843,12 +843,15 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
                     k, v = line.split('=', 1)
                     k = k.strip()
                     v = v.strip()
-                    if k == 'THERMALCTLD_THERMAL_MONITOR_INITIAL_INTERVAL':
-                        thermal_monitor_extra_args['initial_interval'] = int(v)
-                    elif k == 'THERMALCTLD_THERMAL_MONITOR_UPDATE_INTERVAL':
-                        thermal_monitor_extra_args['update_interval'] = int(v)
-                    elif k == 'THERMALCTLD_THERMAL_MONITOR_UPDATE_ELAPSED_THRESHOLD':
-                        thermal_monitor_extra_args['update_elapsed_threshold'] = int(v)
+                    try:
+                        if k == 'THERMALCTLD_THERMAL_MONITOR_INITIAL_INTERVAL':
+                            thermal_monitor_extra_args['initial_interval'] = int(v)
+                        elif k == 'THERMALCTLD_THERMAL_MONITOR_UPDATE_INTERVAL':
+                            thermal_monitor_extra_args['update_interval'] = int(v)
+                        elif k == 'THERMALCTLD_THERMAL_MONITOR_UPDATE_ELAPSED_THRESHOLD':
+                            thermal_monitor_extra_args['update_elapsed_threshold'] = int(v)
+                    except ValueError as e:
+                        self.log_error(f'Failed to load {k} from {platform_env_conf_file}, falling back to default, err: {e}')
         self.thermal_monitor = ThermalMonitor(self.chassis, **thermal_monitor_extra_args)
         self.thermal_monitor.task_run()
 

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -6,6 +6,7 @@
 """
 
 from enum import Enum, auto
+import argparse
 import signal
 import sys
 import threading
@@ -742,23 +743,22 @@ class TemperatureUpdater(logger.Logger):
 
 
 class ThermalMonitor(ProcessTaskBase):
-    # Initial update interval
-    INITIAL_INTERVAL = 5
 
-    # Update interval value
-    UPDATE_INTERVAL = 60
-
-    # Update elapse threshold. If update used time is larger than the value, generate a warning log.
-    UPDATE_ELAPSED_THRESHOLD = 30
-
-    def __init__(self, chassis):
+    def __init__(self, chassis, initial_interval, update_interval, update_elapsed_threshold):
         """
         Initializer for ThermalMonitor
         :param chassis: Object representing a platform chassis
         """
         super(ThermalMonitor, self).__init__()
 
-        self.wait_time = self.INITIAL_INTERVAL
+        # Initial update interval
+        self.initial_interval = initial_interval
+        # Update interval value
+        self.update_interval = update_interval
+        # Update elapse threshold. If update used time is larger than the value, generate a warning log
+        self.update_elapsed_threshold = update_elapsed_threshold
+
+        self.wait_time = self.initial_interval
 
         # TODO: Refactor to eliminate the need for this Logger instance
         self.logger = logger.Logger(SYSLOG_IDENTIFIER)
@@ -774,12 +774,12 @@ class ThermalMonitor(ProcessTaskBase):
         self.fan_updater.update()
         self.temperature_updater.update()
         elapsed = time.time() - begin
-        if elapsed < self.UPDATE_INTERVAL:
-            self.wait_time = self.UPDATE_INTERVAL - elapsed
+        if elapsed < self.update_interval:
+            self.wait_time = self.update_interval - elapsed
         else:
-            self.wait_time = self.INITIAL_INTERVAL
+            self.wait_time = self.initial_interval
 
-        if elapsed > self.UPDATE_ELAPSED_THRESHOLD:
+        if elapsed > self.update_elapsed_threshold:
             self.logger.log_warning('Update fan and temperature status took {} seconds, '
                                     'there might be performance risk'.format(elapsed))
 
@@ -808,7 +808,8 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
 
     POLICY_FILE = '/usr/share/sonic/platform/thermal_policy.json'
 
-    def __init__(self):
+    def __init__(self, thermal_monitor_initial_interval, thermal_monitor_update_interval,
+                 thermal_monitor_update_elapsed_threshold):
         """
         Initializer of ThermalControlDaemon
         """
@@ -823,7 +824,15 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
 
         self.chassis = sonic_platform.platform.Platform().get_chassis()
 
-        self.thermal_monitor = ThermalMonitor(self.chassis)
+        self.thermal_monitor_initial_interval = thermal_monitor_initial_interval
+        self.thermal_monitor_update_interval = thermal_monitor_update_interval
+        self.thermal_monitor_update_elapsed_threshold = thermal_monitor_update_elapsed_threshold
+        self.thermal_monitor = ThermalMonitor(
+            self.chassis,
+            self.thermal_monitor_initial_interval,
+            self.thermal_monitor_update_interval,
+            self.thermal_monitor_update_elapsed_threshold
+        )
         self.thermal_monitor.task_run()
 
         self.thermal_manager = None
@@ -912,7 +921,17 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
 # Main =========================================================================
 #
 def main():
-    thermal_control = ThermalControlDaemon()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--thermal-monitor-initial-interval', type=int, default=5)
+    parser.add_argument('--thermal-monitor-update-interval', type=int, default=60)
+    parser.add_argument('--thermal-monitor-update-elapsed-threshold', type=int, default=30)
+    args = parser.parse_args()
+
+    thermal_control = ThermalControlDaemon(
+        args.thermal_monitor_initial_interval,
+        args.thermal_monitor_update_interval,
+        args.thermal_monitor_update_elapsed_threshold
+    )
 
     thermal_control.log_info("Starting up...")
 

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -294,7 +294,7 @@ class TestThermalMonitor(object):
     """
     def test_main(self):
         mock_chassis = MockChassis()
-        thermal_monitor = thermalctld.ThermalMonitor(mock_chassis)
+        thermal_monitor = thermalctld.ThermalMonitor(mock_chassis, 5, 60, 30)
         thermal_monitor.fan_updater.update = mock.MagicMock()
         thermal_monitor.temperature_updater.update = mock.MagicMock()
 
@@ -680,7 +680,7 @@ def test_updater_thermal_check_min_max():
 
 def test_signal_handler():
     # Test SIGHUP
-    daemon_thermalctld = thermalctld.ThermalControlDaemon()
+    daemon_thermalctld = thermalctld.ThermalControlDaemon(5, 60, 30)
     daemon_thermalctld.stop_event.set = mock.MagicMock()
     daemon_thermalctld.log_info = mock.MagicMock()
     daemon_thermalctld.log_warning = mock.MagicMock()
@@ -695,7 +695,7 @@ def test_signal_handler():
     assert thermalctld.exit_code == thermalctld.ERR_UNKNOWN
 
     # Test SIGINT
-    daemon_thermalctld = thermalctld.ThermalControlDaemon()
+    daemon_thermalctld = thermalctld.ThermalControlDaemon(5, 60, 30)
     daemon_thermalctld.stop_event.set = mock.MagicMock()
     daemon_thermalctld.log_info = mock.MagicMock()
     daemon_thermalctld.log_warning = mock.MagicMock()
@@ -712,7 +712,7 @@ def test_signal_handler():
 
     # Test SIGTERM
     thermalctld.exit_code = thermalctld.ERR_UNKNOWN
-    daemon_thermalctld = thermalctld.ThermalControlDaemon()
+    daemon_thermalctld = thermalctld.ThermalControlDaemon(5, 60, 30)
     daemon_thermalctld.stop_event.set = mock.MagicMock()
     daemon_thermalctld.log_info = mock.MagicMock()
     daemon_thermalctld.log_warning = mock.MagicMock()
@@ -729,7 +729,7 @@ def test_signal_handler():
 
     # Test an unhandled signal
     thermalctld.exit_code = thermalctld.ERR_UNKNOWN
-    daemon_thermalctld = thermalctld.ThermalControlDaemon()
+    daemon_thermalctld = thermalctld.ThermalControlDaemon(5, 60, 30)
     daemon_thermalctld.stop_event.set = mock.MagicMock()
     daemon_thermalctld.log_info = mock.MagicMock()
     daemon_thermalctld.log_warning = mock.MagicMock()
@@ -745,14 +745,14 @@ def test_signal_handler():
 
 
 def test_daemon_run():
-    daemon_thermalctld = thermalctld.ThermalControlDaemon()
+    daemon_thermalctld = thermalctld.ThermalControlDaemon(5, 60, 30)
     daemon_thermalctld.stop_event.wait = mock.MagicMock(return_value=True)
     daemon_thermalctld.thermal_manager.get_interval = mock.MagicMock(return_value=60)
     ret = daemon_thermalctld.run()
     daemon_thermalctld.deinit() # Deinit becuase the test will hang if we assert
     assert ret is False
 
-    daemon_thermalctld = thermalctld.ThermalControlDaemon()
+    daemon_thermalctld = thermalctld.ThermalControlDaemon(5, 60, 30)
     daemon_thermalctld.stop_event.wait = mock.MagicMock(return_value=False)
     daemon_thermalctld.thermal_manager.get_interval = mock.MagicMock(return_value=60)
     ret = daemon_thermalctld.run()

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -10,7 +10,6 @@ else:
     import mock
 
 import pytest
-import tempfile
 tests_path = os.path.dirname(os.path.abspath(__file__))
 
 # Add mocked_libs path so that the file under test can load mocked modules from there
@@ -295,67 +294,13 @@ class TestThermalMonitor(object):
     """
     def test_main(self):
         mock_chassis = MockChassis()
-        thermal_monitor = thermalctld.ThermalMonitor(mock_chassis)
+        thermal_monitor = thermalctld.ThermalMonitor(mock_chassis, 5, 60, 30)
         thermal_monitor.fan_updater.update = mock.MagicMock()
         thermal_monitor.temperature_updater.update = mock.MagicMock()
 
         thermal_monitor.main()
         assert thermal_monitor.fan_updater.update.call_count == 1
         assert thermal_monitor.temperature_updater.update.call_count == 1
-
-    def test_init_with_default_timing_config(self):
-        mock_chassis = MockChassis()
-        thermal_monitor = thermalctld.ThermalMonitor(mock_chassis)
-        assert thermal_monitor.initial_interval == 5
-        assert thermal_monitor.update_interval == 60
-        assert thermal_monitor.update_elapsed_threshold == 30
-
-    def test_init_with_custom_config(self):
-        mock_chassis = MockChassis()
-        thermal_monitor = thermalctld.ThermalMonitor(
-            mock_chassis,
-            initial_interval=5,
-            update_interval=10,
-            update_elapsed_threshold=15,
-        )
-        assert thermal_monitor.initial_interval == 5
-        assert thermal_monitor.update_interval == 10
-        assert thermal_monitor.update_elapsed_threshold == 15
-
-    @mock.patch('thermalctld.time.time')
-    def test_main_with_custom_timing_config(self, mock_time):
-        # Given
-        mock_chassis = MockChassis()
-        thermal_monitor = thermalctld.ThermalMonitor(
-            mock_chassis,
-            initial_interval=5,
-            update_interval=10,
-            update_elapsed_threshold=15,
-        )
-        thermal_monitor.logger.log_warning = mock.MagicMock()
-        # First tick should match initial_interval
-        assert thermal_monitor.wait_time == 5
-
-        # When - mock elapsed time (begin=0, end=7)
-        mock_time.side_effect = [0, 7]
-        thermal_monitor.main()
-        # Then - next tick should be what is left from update_interval: 10 - 7 = 3
-        assert thermal_monitor.wait_time == 3
-
-        # When - mock elapsed time larger than update_interval
-        mock_time.side_effect = [10, 21]
-        thermal_monitor.main()
-        # Then - next tick should become initial_interval
-        assert thermal_monitor.wait_time == 5
-
-        # When - mock elapsed time larger than update_elapsed_threshold
-        mock_time.side_effect = [26, 42]
-        thermal_monitor.main()
-        # Then - a warning should be logged
-        assert thermal_monitor.logger.log_warning.call_count == 1
-        thermal_monitor.logger.log_warning.assert_called_with(
-            'Update fan and temperature status took 16 seconds, there might be performance risk'
-        )
 
 
 def test_insufficient_fan_number():
@@ -735,7 +680,7 @@ def test_updater_thermal_check_min_max():
 
 def test_signal_handler():
     # Test SIGHUP
-    daemon_thermalctld = thermalctld.ThermalControlDaemon()
+    daemon_thermalctld = thermalctld.ThermalControlDaemon(5, 60, 30)
     daemon_thermalctld.stop_event.set = mock.MagicMock()
     daemon_thermalctld.log_info = mock.MagicMock()
     daemon_thermalctld.log_warning = mock.MagicMock()
@@ -750,7 +695,7 @@ def test_signal_handler():
     assert thermalctld.exit_code == thermalctld.ERR_UNKNOWN
 
     # Test SIGINT
-    daemon_thermalctld = thermalctld.ThermalControlDaemon()
+    daemon_thermalctld = thermalctld.ThermalControlDaemon(5, 60, 30)
     daemon_thermalctld.stop_event.set = mock.MagicMock()
     daemon_thermalctld.log_info = mock.MagicMock()
     daemon_thermalctld.log_warning = mock.MagicMock()
@@ -767,7 +712,7 @@ def test_signal_handler():
 
     # Test SIGTERM
     thermalctld.exit_code = thermalctld.ERR_UNKNOWN
-    daemon_thermalctld = thermalctld.ThermalControlDaemon()
+    daemon_thermalctld = thermalctld.ThermalControlDaemon(5, 60, 30)
     daemon_thermalctld.stop_event.set = mock.MagicMock()
     daemon_thermalctld.log_info = mock.MagicMock()
     daemon_thermalctld.log_warning = mock.MagicMock()
@@ -784,7 +729,7 @@ def test_signal_handler():
 
     # Test an unhandled signal
     thermalctld.exit_code = thermalctld.ERR_UNKNOWN
-    daemon_thermalctld = thermalctld.ThermalControlDaemon()
+    daemon_thermalctld = thermalctld.ThermalControlDaemon(5, 60, 30)
     daemon_thermalctld.stop_event.set = mock.MagicMock()
     daemon_thermalctld.log_info = mock.MagicMock()
     daemon_thermalctld.log_warning = mock.MagicMock()
@@ -800,95 +745,19 @@ def test_signal_handler():
 
 
 def test_daemon_run():
-    daemon_thermalctld = thermalctld.ThermalControlDaemon()
+    daemon_thermalctld = thermalctld.ThermalControlDaemon(5, 60, 30)
     daemon_thermalctld.stop_event.wait = mock.MagicMock(return_value=True)
     daemon_thermalctld.thermal_manager.get_interval = mock.MagicMock(return_value=60)
     ret = daemon_thermalctld.run()
     daemon_thermalctld.deinit() # Deinit becuase the test will hang if we assert
     assert ret is False
 
-    daemon_thermalctld = thermalctld.ThermalControlDaemon()
+    daemon_thermalctld = thermalctld.ThermalControlDaemon(5, 60, 30)
     daemon_thermalctld.stop_event.wait = mock.MagicMock(return_value=False)
     daemon_thermalctld.thermal_manager.get_interval = mock.MagicMock(return_value=60)
     ret = daemon_thermalctld.run()
     daemon_thermalctld.deinit() # Deinit becuase the test will hang if we assert
     assert ret is True
-
-def _create_platform_env_conf_file(content):
-    """
-    Creates a platform_env.conf, under a temporary directory, with the given content
-    :param content: Content to write to the file
-    :return: Path to the created file
-    """
-    root = tempfile.mkdtemp()
-    filepath = os.path.join(root, 'platform_env.conf')
-    with open(filepath, 'w+') as f:
-        f.write(content)
-    return filepath
-
-
-def test_daemon_init_with_default_thermal_monitor_config():
-    filepath = _create_platform_env_conf_file("")
-    daemon_thermalctld = thermalctld.ThermalControlDaemon(
-        platform_env_conf_file=filepath
-    )
-    daemon_thermalctld.deinit()  # Deinit becuase the test will hang if we assert
-    assert daemon_thermalctld.thermal_monitor.initial_interval == 5
-    assert daemon_thermalctld.thermal_monitor.update_interval == 60
-    assert daemon_thermalctld.thermal_monitor.update_elapsed_threshold == 30
-
-
-def test_daemon_init_with_custom_thermal_monitor_config():
-    filepath = _create_platform_env_conf_file(
-        """\
-THERMALCTLD_THERMAL_MONITOR_INITIAL_INTERVAL=5
-THERMALCTLD_THERMAL_MONITOR_UPDATE_INTERVAL=10
-THERMALCTLD_THERMAL_MONITOR_UPDATE_ELAPSED_THRESHOLD=15
-"""
-    )
-    daemon_thermalctld = thermalctld.ThermalControlDaemon(
-        platform_env_conf_file=filepath
-    )
-    daemon_thermalctld.deinit()  # Deinit becuase the test will hang if we assert
-    assert daemon_thermalctld.thermal_monitor.initial_interval == 5
-    assert daemon_thermalctld.thermal_monitor.update_interval == 10
-    assert daemon_thermalctld.thermal_monitor.update_elapsed_threshold == 15
-
-
-def test_daemon_init_with_invalid_thermal_monitor_config():
-    thermalctld.ThermalControlDaemon.log_error = mock.MagicMock()
-
-    filepath = _create_platform_env_conf_file(
-        """\
-THERMALCTLD_THERMAL_MONITOR_INITIAL_INTERVAL=non-int-value
-THERMALCTLD_THERMAL_MONITOR_UPDATE_INTERVAL=non-int-value
-THERMALCTLD_THERMAL_MONITOR_UPDATE_ELAPSED_THRESHOLD=non-int-value
-"""
-    )
-    daemon_thermalctld = thermalctld.ThermalControlDaemon(
-        platform_env_conf_file=filepath
-    )
-    daemon_thermalctld.deinit()  # Deinit becuase the test will hang if we assert
-    assert any(
-        f"Failed to load THERMALCTLD_THERMAL_MONITOR_INITIAL_INTERVAL from {filepath}"
-        in call_args[0][0]
-        for call_args in thermalctld.ThermalControlDaemon.log_error.call_args_list
-    ), thermalctld.ThermalControlDaemon.log_error.call_args_list
-    assert any(
-        f"Failed to load THERMALCTLD_THERMAL_MONITOR_UPDATE_INTERVAL from {filepath}"
-        in call_args[0][0]
-        for call_args in thermalctld.ThermalControlDaemon.log_error.call_args_list
-    ), thermalctld.ThermalControlDaemon.log_error.call_args_list
-    assert any(
-        f"Failed to load THERMALCTLD_THERMAL_MONITOR_UPDATE_ELAPSED_THRESHOLD from {filepath}"
-        in call_args[0][0]
-        for call_args in thermalctld.ThermalControlDaemon.log_error.call_args_list
-    ), thermalctld.ThermalControlDaemon.log_error.call_args_list
-
-    # Verify default values are used
-    assert daemon_thermalctld.thermal_monitor.initial_interval == 5
-    assert daemon_thermalctld.thermal_monitor.update_interval == 60
-    assert daemon_thermalctld.thermal_monitor.update_elapsed_threshold == 30
 
 
 def test_try_get():


### PR DESCRIPTION

Default polling interval of 60s is quite high and can be unresponsive. Vendors should be able to override this polling interval

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
