### PR TITLE
MIGSMSFT-1047 : Add FPD FW current version to STATE_DB

### DIFF
--- a/sonic-chassisd/scripts/chassis_db_init
+++ b/sonic-chassisd/scripts/chassis_db_init
@@ -33,6 +33,10 @@ CHASSIS_INFO_SERIAL_FIELD = 'serial'
 CHASSIS_INFO_MODEL_FIELD = 'model'
 CHASSIS_INFO_REV_FIELD = 'revision'
 
+COMPONENT_INFO_TABLE = 'COMPONENT_INFO'
+COMPONENT_INFO_KEY_TEMPLATE = '{}'
+COMPONENT_INFO_VERSION_FIELD = 'firmware-version'
+
 CHASSIS_LOAD_ERROR = 1
 
 NOT_AVAILABLE = 'N/A'
@@ -78,6 +82,17 @@ def provision_db(platform_chassis, log):
                                         (CHASSIS_INFO_REV_FIELD, try_get(platform_chassis.get_revision))
                                     ])
     chassis_table.set(CHASSIS_INFO_KEY_TEMPLATE.format(1), fvs)
+
+    # Populate DB with chassis component current version
+    comps = platform_chassis.get_all_components()
+    component_table = swsscommon.Table(state_db, COMPONENT_INFO_TABLE)
+    for comp in comps:
+        comp_name = comp.get_name()
+        fvs = swsscommon.FieldValuePairs([
+            (COMPONENT_INFO_VERSION_FIELD, try_get(comp.get_firmware_version))
+        ])
+        component_table.set(COMPONENT_INFO_KEY_TEMPLATE.format(comp_name), fvs)
+
     log.log_info("STATE_DB provisioned with chassis info.")
 
     return chassis_table


### PR DESCRIPTION
Add component current firmware version to STATE_DB.

Description

For telemetry, add component (FPD) current firmware version to STATE_DB.

Motivation and Context

Customer request

```
root@sonic:/home/cisco# redis-dump -d 6 -y -k "COMPONENT_INFO*"
{
  "COMPONENT_INFO|Aikido": {
    "expireat": 1749034477.8798983,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "firmware-version": "1.7"
    }
  },
  "COMPONENT_INFO|BIOS": {
    "expireat": 1749034477.8799129,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "firmware-version": "0-4"
    }
  },
  "COMPONENT_INFO|IOFPGA": {
    "expireat": 1749034477.8799255,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "firmware-version": "1.8"
    }
  },
  "COMPONENT_INFO|SSD": {
    "expireat": 1749034477.87991,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "firmware-version": "0.2"
    }
  },
  "COMPONENT_INFO|TAM": {
    "expireat": 1749034477.879916,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "firmware-version": "2.7"
    }
  },
  "COMPONENT_INFO|iocpld0": {
    "expireat": 1749034477.8799045,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "firmware-version": "0.2"
    }
  },
  "COMPONENT_INFO|iocpld1": {
    "expireat": 1749034477.8799193,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "firmware-version": "0.2"
    }
  },
  "COMPONENT_INFO|pwrcpld": {
    "expireat": 1749034477.8799224,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "firmware-version": "0.11"
    }
  }
}

```