### PR TITLE
Add support for custom serdes attributes

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1991,13 +1991,17 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd_utilities.media_settings_parser.get_speed_lane_count_and_subport', MagicMock(return_value=(400000, 4, 0)))
     def test_notify_media_setting_with_gearbox(self):
         """
-        Verify notify_media_setting() preserves gearbox line-side lane widths.
+        Test notify_media_setting() with gearbox media settings.
 
-        Args:
-            None
+        This test verifies that the notify_media_setting() function correctly handles
+        gearbox-specific media settings from gearbox_media_settings.json. The test covers:
+        - COPPER50 settings with 8 line lanes and 4 system lanes
+        - OPTICAL50 settings with 8 line lanes and 4 system lanes
+        - COPPER25 settings with 4 line lanes and 4 system lanes
+        - OPTICAL25 settings with 4 line lanes and 4 system lanes
 
-        Returns:
-            None
+        The gearbox settings include both line-side (gb_line_*) and system-side (gb_system_*)
+        SerDes parameters that need to be correctly extracted and formatted.
         """
         # Test COPPER50 with gearbox (8 line lanes, 4 system lanes)
         with patch('xcvrd.xcvrd_utilities.media_settings_parser.get_media_settings_key',
@@ -2241,9 +2245,6 @@ class TestXcvrdScript(object):
             gearbox_line_lanes: Number of gearbox line lanes
             system_lanes: Number of system lanes
             xcvr_info_dict: Optional transceiver info dictionary
-
-        Returns:
-            None
         """
         xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         cfg_port_tbl = MagicMock()

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1780,9 +1780,9 @@ class TestXcvrdScript(object):
     # Test 20: Media key should be prioritized over medium lane speed key in PORT_MEDIA_SETTINGS
     (media_settings_media_priority_over_medium_lane_port, 7, {'vendor_key': 'VENDOR_NOMATCH', 'media_key': 'QSFP-DD-400GBASE-DR4', 'lane_speed_key': 'MISSING', 'medium_lane_speed_key': 'COPPER100'}, {'idriver': {'lane0': '0x00000066', 'lane1': '0x00000077', 'lane2': '0x00000088', 'lane3': '0x00000099'}, 'pre1': {'lane0': '0x00000066', 'lane1': '0x00000077', 'lane2': '0x00000088', 'lane3': '0x00000099'}, 'ob_m2lp': {'lane0': '0x00000066', 'lane1': '0x00000077', 'lane2': '0x00000088', 'lane3': '0x00000099'}})
     ])
-    def test_get_traditional_media_settings_value(self, media_settings_dict, port, key, expected):
+    def test_get_media_settings_value(self, media_settings_dict, port, key, expected):
         with patch('xcvrd.xcvrd_utilities.media_settings_parser.g_dict', media_settings_dict):
-            result = media_settings_parser.get_traditional_media_settings_value(port, key)
+            result = media_settings_parser.get_media_settings_value(port, key)
             assert result == expected
 
     @patch('xcvrd.xcvrd_utilities.common.platform_chassis')
@@ -1885,7 +1885,7 @@ class TestXcvrdScript(object):
             }
         }
         with patch.multiple('xcvrd.xcvrd_utilities.media_settings_parser',
-                            get_traditional_media_settings_value=MagicMock(return_value={}),
+                            get_media_settings_value=MagicMock(return_value={}),
                             get_custom_media_settings_value=MagicMock(return_value=custom_media_dict)):
             media_settings_parser.notify_media_setting('Ethernet0', transceiver_dict, xcvr_table_helper, port_mapping)
 
@@ -1893,7 +1893,50 @@ class TestXcvrdScript(object):
         set_key, fvs = app_port_tbl.set.call_args[0]
         assert set_key == 'Ethernet0'
         result_dict = dict(fvs)
-        assert result_dict == {CUSTOM_SERDES_ATTRS_KEY_IN_DB: expected}
+        assert result_dict == {
+            media_settings_parser.CustomMediaSettingsParser.CUSTOM_SERDES_ATTRS_KEY_IN_DB: expected
+        }
+
+    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.media_settings_parser.media_settings_present', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.media_settings_parser.get_media_settings_key',
+           MagicMock(return_value={'vendor_key': 'MOLEX-1064141421', 'media_key': 'QSFP-DD-active_cable_media_interface', 'lane_speed_key': 'speed:100GAUI-2', 'medium_lane_speed_key': 'UNKNOWN'}))
+    @patch('xcvrd.xcvrd_utilities.media_settings_parser.get_speed_lane_count_and_subport', MagicMock(return_value=(100000, 2, 1)))
+    def test_notify_media_setting_empty_serialized_payload(self):
+        custom_media_dict = {
+            'NOT_CUSTOM': {'lane0': 10, 'lane1': 11, 'lane2': 12, 'lane3': 13},
+        }
+
+        xcvr_table_helper = MagicMock()
+        xcvr_table_helper.is_npu_si_settings_update_required = MagicMock(return_value=True)
+        xcvr_table_helper.get_cfg_port_tbl = MagicMock(return_value=MagicMock())
+        xcvr_table_helper.get_gearbox_line_lanes_dict = MagicMock(return_value={})
+        app_port_tbl = MagicMock()
+        xcvr_table_helper.get_app_port_tbl = MagicMock(return_value=app_port_tbl)
+        state_port_tbl = MagicMock()
+        xcvr_table_helper.get_state_port_tbl = MagicMock(return_value=state_port_tbl)
+
+        port_mapping = MagicMock()
+        port_mapping.get_asic_id_for_logical_port = MagicMock(return_value=0)
+        port_mapping.logical_port_name_to_physical_port_list = MagicMock(return_value=[1])
+
+        transceiver_dict = {
+            1: {
+                'manufacturer': 'Molex',
+                'model': '1064141421',
+                'cable_type': 'Length Cable Assembly(m)',
+                'cable_length': '255',
+                'specification_compliance': "{'10/40G Ethernet Compliance Code': '10GBase-SR'}",
+                'type_abbrv_name': 'QSFP+'
+            }
+        }
+        with patch.multiple('xcvrd.xcvrd_utilities.media_settings_parser',
+                            get_media_settings_value=MagicMock(return_value={}),
+                            get_custom_media_settings_value=MagicMock(return_value=custom_media_dict)):
+            media_settings_parser.notify_media_setting('Ethernet0', transceiver_dict, xcvr_table_helper, port_mapping)
+
+        assert not app_port_tbl.set.called
+        assert not state_port_tbl.set.called
 
     @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd_utilities.media_settings_parser.media_settings_present', MagicMock(return_value=True))
@@ -1938,7 +1981,7 @@ class TestXcvrdScript(object):
             'main': '0x00000020,0x00000020',
             'post1': '0x00000006,0x00000006',
             'regn_bfm1n': '0x000000aa,0x000000aa',
-            CUSTOM_SERDES_ATTRS_KEY_IN_DB: expected_custom,
+            media_settings_parser.CustomMediaSettingsParser.CUSTOM_SERDES_ATTRS_KEY_IN_DB: expected_custom,
         }
 
     @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
@@ -2036,6 +2079,18 @@ class TestXcvrdScript(object):
         assert expected == media_settings_parser.CustomMediaSettingsParser.to_db_value(
             media_dict, lane_count, subport_num)
 
+    def test_custom_media_settings_get_lane_values(self):
+        lane_dict = {'lane0': 1, 'lane1': 2, 'lane2': 3, 'lane3': 4}
+        lane_values = media_settings_parser.CustomMediaSettingsParser._get_lane_values(
+            lane_dict, 2, 2
+        )
+        assert lane_values == [3, 4]
+
+        lane_values = media_settings_parser.CustomMediaSettingsParser._get_lane_values(
+            lane_dict, 2, 3
+        )
+        assert lane_values == [1, 2]
+
     def test_custom_media_settings_is_port_selected(self):
         assert media_settings_parser.CustomMediaSettingsParser.is_port_selected('1, 3-4, 8', 8)
         assert media_settings_parser.CustomMediaSettingsParser.is_port_selected('1,3-4,8', 4)
@@ -2101,7 +2156,7 @@ class TestXcvrdScript(object):
         }
         with patch('xcvrd.xcvrd_utilities.media_settings_parser.g_dict',
                    media_settings_custom_attrs_with_port_and_global):
-            result = media_settings_parser.get_traditional_media_settings_value(7, key)
+            result = media_settings_parser.get_media_settings_value(7, key)
             assert result == {
                 'pre1': {'lane0': '0x00000002', 'lane1': '0x00000002'},
                 'main': {'lane0': '0x00000020', 'lane1': '0x00000020'},
@@ -2143,17 +2198,17 @@ class TestXcvrdScript(object):
         (
             {'main': {'lane0': '0x11', 'lane1': '0x12', 'lane2': '0x13', 'lane3': '0x14'}},
             2, 2, None,
-            {'main': '0x13,0x14'},
+            [('main', '0x13,0x14')],
         ),
         (
             {'main': {'lane0': '0x11', 'lane1': '0x12'}, 'los_thresh': '7'},
             2, 0, None,
-            {'main': '0x11,0x12', 'los_thresh': '7'},
+            [('main', '0x11,0x12'), ('los_thresh', '7')],
         ),
         (
             {},
             2, 2, None,
-            {},
+            [],
         ),
         (
             {
@@ -2166,74 +2221,16 @@ class TestXcvrdScript(object):
                 },
             },
             4, 0, 8,
-            {
-                'gb_line_main': '0x10,0x11,0x12,0x13,0x14,0x15,0x16,0x17',
-                'gb_system_main': '0x20,0x21,0x22,0x23',
-            },
+            [
+                ('gb_line_main', '0x10,0x11,0x12,0x13,0x14,0x15,0x16,0x17'),
+                ('gb_system_main', '0x20,0x21,0x22,0x23'),
+            ],
         ),
     ])
     def test_media_settings_to_db_value(self, media_dict, lane_count, subport_num,
                                         gearbox_line_lane_count, expected):
         assert expected == media_settings_parser.MediaSettingsParserBase.to_db_value(
             media_dict, lane_count, subport_num, gearbox_line_lane_count)
-
-    @pytest.mark.parametrize("media_dict, custom_media_dict, lane_count, subport_num, gearbox_line_lane_count, expected", [
-        (
-            {'main': {'lane0': '0x11', 'lane1': '0x12', 'lane2': '0x13', 'lane3': '0x14'}},
-            {},
-            2, 2, None,
-            {'main': '0x13,0x14'},
-        ),
-        (
-            {},
-            {'CUSTOM:XYZ': {'lane0': 10, 'lane1': 11, 'lane2': 12, 'lane3': 13}},
-            2, 2, None,
-            {CUSTOM_SERDES_ATTRS_KEY_IN_DB: '{"attributes":[{"XYZ":{"value":[12,13]}}]}'},
-        ),
-        (
-            {'main': {'lane0': '0x11', 'lane1': '0x12', 'lane2': '0x13', 'lane3': '0x14'}},
-            {'CUSTOM:ABC': {'lane0': 1, 'lane1': 2, 'lane2': 3, 'lane3': 4}},
-            2, 2, None,
-            {
-                'main': '0x13,0x14',
-                CUSTOM_SERDES_ATTRS_KEY_IN_DB: '{"attributes":[{"ABC":{"value":[3,4]}}]}',
-            },
-        ),
-        (
-            {},
-            {},
-            2, 2, None,
-            {},
-        ),
-        (
-            {
-                'gb_line_main': {
-                    'lane0': '0x10', 'lane1': '0x11', 'lane2': '0x12', 'lane3': '0x13',
-                    'lane4': '0x14', 'lane5': '0x15', 'lane6': '0x16', 'lane7': '0x17',
-                },
-                'gb_system_main': {
-                    'lane0': '0x20', 'lane1': '0x21', 'lane2': '0x22', 'lane3': '0x23',
-                },
-            },
-            {},
-            4, 0, 8,
-            {
-                'gb_line_main': '0x10,0x11,0x12,0x13,0x14,0x15,0x16,0x17',
-                'gb_system_main': '0x20,0x21,0x22,0x23',
-            },
-        ),
-    ])
-    def test_resolve_media_settings_for_db(self, media_dict, custom_media_dict, lane_count,
-                                           subport_num, gearbox_line_lane_count, expected):
-        with patch.multiple(
-            'xcvrd.xcvrd_utilities.media_settings_parser',
-            get_traditional_media_settings_value=MagicMock(return_value=media_dict),
-            get_custom_media_settings_value=MagicMock(return_value=custom_media_dict),
-        ):
-            result = media_settings_parser.resolve_media_settings_for_db(
-                7, {}, lane_count, subport_num, gearbox_line_lane_count
-            )
-            assert result == expected
 
     def _check_notify_media_setting_with_gearbox(self, index, gearbox_line_lanes, system_lanes, xcvr_info_dict=None):
         """
@@ -5843,45 +5840,59 @@ class TestXcvrdScript(object):
         physical_port = 33
         assert not common.check_port_in_range(range_str, physical_port)
 
-    def test_get_serdes_si_setting_val_str(self):
+    def test_media_settings_parser_base_get_lane_values_str(self):
         lane_dict = {'lane0': '1', 'lane1': '2', 'lane2': '3', 'lane3': '4'}
         # non-breakout case
         lane_count = 4
         subport_num = 0
-        media_str = get_serdes_si_setting_val_str(lane_dict, lane_count, subport_num)
+        media_str = media_settings_parser.MediaSettingsParserBase._get_lane_values_str(
+            lane_dict, lane_count, subport_num
+        )
         assert media_str == '1,2,3,4'
         # breakout case
         lane_count = 2
         subport_num = 2
-        media_str = get_serdes_si_setting_val_str(lane_dict, lane_count, subport_num)
+        media_str = media_settings_parser.MediaSettingsParserBase._get_lane_values_str(
+            lane_dict, lane_count, subport_num
+        )
         assert media_str == '3,4'
         # breakout case without subport number specified in config
         lane_count = 2
         subport_num = 0
-        media_str = get_serdes_si_setting_val_str(lane_dict, lane_count, subport_num)
+        media_str = media_settings_parser.MediaSettingsParserBase._get_lane_values_str(
+            lane_dict, lane_count, subport_num
+        )
         assert media_str == '1,2'
         # breakout case with out-of-range subport number
         lane_count = 2
         subport_num = 3
-        media_str = get_serdes_si_setting_val_str(lane_dict, lane_count, subport_num)
+        media_str = media_settings_parser.MediaSettingsParserBase._get_lane_values_str(
+            lane_dict, lane_count, subport_num
+        )
         assert media_str == '1,2'
         # breakout case with smaler lane_dict
         lane_dict = {'lane0': '1', 'lane1': '2'}
         lane_count = 2
         subport_num = 2
-        media_str = get_serdes_si_setting_val_str(lane_dict, lane_count, subport_num)
+        media_str = media_settings_parser.MediaSettingsParserBase._get_lane_values_str(
+            lane_dict, lane_count, subport_num
+        )
         assert media_str == '1,2'
         # lane key-value pair inserted in non-asceding order
         lane_dict = {'lane0': 'a', 'lane2': 'c', 'lane1': 'b', 'lane3': 'd'}
         lane_count = 2
         subport_num = 2
-        media_str = get_serdes_si_setting_val_str(lane_dict, lane_count, subport_num)
+        media_str = media_settings_parser.MediaSettingsParserBase._get_lane_values_str(
+            lane_dict, lane_count, subport_num
+        )
         assert media_str == 'c,d'
         # non-string lane values are coerced defensively for string output
         lane_dict = {'lane0': 1, 'lane1': 2, 'lane2': 3, 'lane3': 4}
         lane_count = 2
         subport_num = 2
-        media_str = get_serdes_si_setting_val_str(lane_dict, lane_count, subport_num)
+        media_str = media_settings_parser.MediaSettingsParserBase._get_lane_values_str(
+            lane_dict, lane_count, subport_num
+        )
         assert media_str == '3,4'
 
     class MockPortMapping:

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -279,6 +279,98 @@ media_settings_optic_copper_si = {
 
 media_settings_empty = {}
 
+custom_serdes_attrs_xyz_10 = {'lane0': 10, 'lane1': 11, 'lane2': 12, 'lane3': 13}
+custom_serdes_attrs_xyz_20 = {'lane0': 20, 'lane1': 21, 'lane2': 22, 'lane3': 23}
+custom_serdes_attrs_abc_mode = {'lane0': 'mode_a', 'lane1': 'mode_b', 'lane2': 'mode_c', 'lane3': 'mode_d'}
+
+media_settings_custom_attrs = {
+    'CUSTOM_MEDIA_SETTINGS': {
+        '1, 3-4, 8': {
+            'QSFP-DD-active_cable_media_interface': {
+                'speed:100GAUI-2': {
+                    'CUSTOM:XYZ': custom_serdes_attrs_xyz_10,
+                    'CUSTOM:ABC': custom_serdes_attrs_abc_mode,
+                },
+            },
+            'Default': {
+                'speed:100GAUI-2': {
+                    'CUSTOM:XYZ': custom_serdes_attrs_xyz_20,
+                },
+            },
+        },
+        '7-9': {
+            'Default': {
+                'speed:100GAUI-2': {
+                    'CUSTOM:XYZ': custom_serdes_attrs_xyz_20,
+                },
+            },
+        },
+    }
+}
+
+media_settings_custom_attrs_no_space = {
+    'CUSTOM_MEDIA_SETTINGS': {
+        '1,3-4,8': {
+            'QSFP-DD-active_cable_media_interface': {
+                'speed:100GAUI-2': {
+                    'CUSTOM:XYZ': custom_serdes_attrs_xyz_10,
+                },
+            },
+        },
+    }
+}
+
+media_settings_custom_attrs_non_string_selector = {
+    'CUSTOM_MEDIA_SETTINGS': {
+        9: {
+            'Default': {
+                'speed:100GAUI-2': {
+                    'CUSTOM:XYZ': custom_serdes_attrs_xyz_20,
+                },
+            },
+        },
+    }
+}
+
+media_settings_custom_attrs_with_port_and_global = copy.deepcopy(media_settings_port_media_key_lane_speed_si)
+media_settings_custom_attrs_with_port_and_global['CUSTOM_MEDIA_SETTINGS'] = media_settings_custom_attrs['CUSTOM_MEDIA_SETTINGS']
+media_settings_custom_attrs_with_port_and_global['GLOBAL_MEDIA_SETTINGS'] = {
+    '0-31': {
+        'NO_MATCH': {
+            'speed:100GAUI-2': {
+                'pre1': {'lane0': '0x000000ff'},
+            },
+        },
+    },
+}
+
+media_settings_custom_attrs_medium_lane = {
+    'CUSTOM_MEDIA_SETTINGS': {
+        '7-9': {
+            'COPPER50': {
+                'CUSTOM:XYZ': custom_serdes_attrs_xyz_20,
+            },
+        },
+    }
+}
+
+media_settings_custom_attrs_empty_explicit_then_default = {
+    'CUSTOM_MEDIA_SETTINGS': {
+        '7-9': {
+            'QSFP-DD-active_cable_media_interface': {
+                'speed:200GAUI-4': {
+                    'CUSTOM:XYZ': custom_serdes_attrs_xyz_10,
+                },
+            },
+            'Default': {
+                'speed:100GAUI-2': {
+                    'CUSTOM:XYZ': custom_serdes_attrs_xyz_20,
+                },
+            },
+        },
+    }
+}
+
 def gen_cmis_lanes_dict(key_format_str, value, one_based=True):
     start_idx = 1 if one_based else 0
     lanes_dict = {}
@@ -1688,9 +1780,9 @@ class TestXcvrdScript(object):
     # Test 20: Media key should be prioritized over medium lane speed key in PORT_MEDIA_SETTINGS
     (media_settings_media_priority_over_medium_lane_port, 7, {'vendor_key': 'VENDOR_NOMATCH', 'media_key': 'QSFP-DD-400GBASE-DR4', 'lane_speed_key': 'MISSING', 'medium_lane_speed_key': 'COPPER100'}, {'idriver': {'lane0': '0x00000066', 'lane1': '0x00000077', 'lane2': '0x00000088', 'lane3': '0x00000099'}, 'pre1': {'lane0': '0x00000066', 'lane1': '0x00000077', 'lane2': '0x00000088', 'lane3': '0x00000099'}, 'ob_m2lp': {'lane0': '0x00000066', 'lane1': '0x00000077', 'lane2': '0x00000088', 'lane3': '0x00000099'}})
     ])
-    def test_get_media_settings_value(self, media_settings_dict, port, key, expected):
+    def test_get_traditional_media_settings_value(self, media_settings_dict, port, key, expected):
         with patch('xcvrd.xcvrd_utilities.media_settings_parser.g_dict', media_settings_dict):
-            result = media_settings_parser.get_media_settings_value(port, key)
+            result = media_settings_parser.get_traditional_media_settings_value(port, key)
             assert result == expected
 
     @patch('xcvrd.xcvrd_utilities.common.platform_chassis')
@@ -1759,23 +1851,110 @@ class TestXcvrdScript(object):
         self._check_notify_media_setting(6, True, {'preemphasis': ','.join(['0x124A08'] * 2)})
 
     @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.media_settings_parser.media_settings_present', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.media_settings_parser.get_media_settings_key',
+           MagicMock(return_value={'vendor_key': 'MOLEX-1064141421', 'media_key': 'QSFP-DD-active_cable_media_interface', 'lane_speed_key': 'speed:100GAUI-2', 'medium_lane_speed_key': 'UNKNOWN'}))
+    @patch('xcvrd.xcvrd_utilities.media_settings_parser.get_speed_lane_count_and_subport', MagicMock(return_value=(100000, 2, 1)))
+    def test_notify_media_setting_custom_only(self):
+        custom_media_dict = {
+            'CUSTOM:XYZ': {'lane0': 10, 'lane1': 11, 'lane2': 12, 'lane3': 13},
+        }
+        expected = '{"attributes":[{"XYZ":{"value":[10,11]}}]}'
+
+        xcvr_table_helper = MagicMock()
+        xcvr_table_helper.is_npu_si_settings_update_required = MagicMock(return_value=True)
+        xcvr_table_helper.get_cfg_port_tbl = MagicMock(return_value=MagicMock())
+        xcvr_table_helper.get_gearbox_line_lanes_dict = MagicMock(return_value={})
+        app_port_tbl = MagicMock()
+        xcvr_table_helper.get_app_port_tbl = MagicMock(return_value=app_port_tbl)
+        state_port_tbl = MagicMock()
+        xcvr_table_helper.get_state_port_tbl = MagicMock(return_value=state_port_tbl)
+
+        port_mapping = MagicMock()
+        port_mapping.get_asic_id_for_logical_port = MagicMock(return_value=0)
+        port_mapping.logical_port_name_to_physical_port_list = MagicMock(return_value=[1])
+
+        transceiver_dict = {
+            1: {
+                'manufacturer': 'Molex',
+                'model': '1064141421',
+                'cable_type': 'Length Cable Assembly(m)',
+                'cable_length': '255',
+                'specification_compliance': "{'10/40G Ethernet Compliance Code': '10GBase-SR'}",
+                'type_abbrv_name': 'QSFP+'
+            }
+        }
+        with patch.multiple('xcvrd.xcvrd_utilities.media_settings_parser',
+                            get_traditional_media_settings_value=MagicMock(return_value={}),
+                            get_custom_media_settings_value=MagicMock(return_value=custom_media_dict)):
+            media_settings_parser.notify_media_setting('Ethernet0', transceiver_dict, xcvr_table_helper, port_mapping)
+
+        assert app_port_tbl.set.called
+        set_key, fvs = app_port_tbl.set.call_args[0]
+        assert set_key == 'Ethernet0'
+        result_dict = dict(fvs)
+        assert result_dict == {CUSTOM_SERDES_ATTRS_KEY_IN_DB: expected}
+
+    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.media_settings_parser.media_settings_present', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd_utilities.media_settings_parser.get_media_settings_key',
+           MagicMock(return_value={'vendor_key': 'UNKOWN', 'media_key': 'QSFP-DD-active_cable_media_interface', 'lane_speed_key': 'speed:100GAUI-2', 'medium_lane_speed_key': 'UNKNOWN'}))
+    @patch('xcvrd.xcvrd_utilities.media_settings_parser.get_speed_lane_count_and_subport', MagicMock(return_value=(100000, 2, 1)))
+    def test_notify_media_setting_mixed_settings(self):
+        expected_custom = '{"attributes":[{"XYZ":{"value":[20,21]}}]}'
+        xcvr_table_helper = MagicMock()
+        xcvr_table_helper.is_npu_si_settings_update_required = MagicMock(return_value=True)
+        xcvr_table_helper.get_cfg_port_tbl = MagicMock(return_value=MagicMock())
+        xcvr_table_helper.get_gearbox_line_lanes_dict = MagicMock(return_value={})
+        app_port_tbl = MagicMock()
+        xcvr_table_helper.get_app_port_tbl = MagicMock(return_value=app_port_tbl)
+        state_port_tbl = MagicMock()
+        xcvr_table_helper.get_state_port_tbl = MagicMock(return_value=state_port_tbl)
+
+        port_mapping = MagicMock()
+        port_mapping.get_asic_id_for_logical_port = MagicMock(return_value=0)
+        port_mapping.logical_port_name_to_physical_port_list = MagicMock(return_value=[7])
+
+        transceiver_dict = {
+            7: {
+                'manufacturer': 'Molex',
+                'model': '1064141421',
+                'cable_type': 'Length Cable Assembly(m)',
+                'cable_length': '255',
+                'specification_compliance': "{'10/40G Ethernet Compliance Code': '10GBase-SR'}",
+                'type_abbrv_name': 'QSFP+'
+            }
+        }
+
+        with patch('xcvrd.xcvrd_utilities.media_settings_parser.g_dict',
+                   media_settings_custom_attrs_with_port_and_global):
+            media_settings_parser.notify_media_setting('Ethernet0', transceiver_dict, xcvr_table_helper, port_mapping)
+
+        set_key, fvs = app_port_tbl.set.call_args[0]
+        assert set_key == 'Ethernet0'
+        result_dict = dict(fvs)
+        assert result_dict == {
+            'pre1': '0x00000002,0x00000002',
+            'main': '0x00000020,0x00000020',
+            'post1': '0x00000006,0x00000006',
+            'regn_bfm1n': '0x000000aa,0x000000aa',
+            CUSTOM_SERDES_ATTRS_KEY_IN_DB: expected_custom,
+        }
+
+    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
     @patch('xcvrd.xcvrd.XcvrTableHelper.get_cfg_port_tbl', MagicMock())
     @patch('xcvrd.xcvrd_utilities.media_settings_parser.g_dict', gearbox_media_settings_dict)
     @patch('xcvrd.xcvrd_utilities.media_settings_parser.get_speed_lane_count_and_subport', MagicMock(return_value=(400000, 4, 0)))
     def test_notify_media_setting_with_gearbox(self):
         """
-        Test notify_media_setting() with gearbox media settings.
+        Verify notify_media_setting() preserves gearbox line-side lane widths.
 
-        This test verifies that the notify_media_setting() function correctly handles
-        gearbox-specific media settings from gearbox_media_settings.json. The test covers:
-        - COPPER50 settings with 8 line lanes and 4 system lanes
-        - OPTICAL50 settings with 8 line lanes and 4 system lanes
-        - COPPER25 settings with 4 line lanes and 4 system lanes
-        - OPTICAL25 settings with 4 line lanes and 4 system lanes
+        Args:
+            None
 
-        The gearbox settings include both line-side (gb_line_*) and system-side (gb_system_*)
-        SerDes parameters that need to be correctly extracted and formatted.
+        Returns:
+            None
         """
         # Test COPPER50 with gearbox (8 line lanes, 4 system lanes)
         with patch('xcvrd.xcvrd_utilities.media_settings_parser.get_media_settings_key',
@@ -1829,6 +2008,233 @@ class TestXcvrdScript(object):
         assert found == expected_found
         assert result_dict == expected_value
 
+    @pytest.mark.parametrize("media_dict, lane_count, subport_num, expected", [
+        (
+            {
+                'CUSTOM:XYZ': {'lane0': 10, 'lane1': 11, 'lane2': 12, 'lane3': 13},
+                'CUSTOM:ABC': {'lane0': 1, 'lane1': 2, 'lane2': 3, 'lane3': 4},
+                'main': {'lane0': '0x11', 'lane1': '0x12', 'lane2': '0x13', 'lane3': '0x14'},
+            },
+            2, 2,
+            '{"attributes":[{"XYZ":{"value":[12,13]}},{"ABC":{"value":[3,4]}}]}',
+        ),
+        (
+            {
+                'CUSTOM:XYZ': {'lane0': 'ADAPTIVE', 'lane1': 'ADAPTIVE', 'lane2': 'ADAPTIVE', 'lane3': 'ADAPTIVE'},
+                'CUSTOM:ABC': {'lane0': 1, 'lane1': 2, 'lane2': 3, 'lane3': 4},
+            },
+            2, 2,
+            '{"attributes":[{"XYZ":{"value":["ADAPTIVE","ADAPTIVE"]}},{"ABC":{"value":[3,4]}}]}',
+        ),
+        (
+            {'main': {'lane0': '0x11', 'lane1': '0x12', 'lane2': '0x13', 'lane3': '0x14'}},
+            2, 2,
+            None,
+        ),
+    ])
+    def test_custom_media_settings_to_db_value(self, media_dict, lane_count, subport_num, expected):
+        assert expected == media_settings_parser.CustomMediaSettingsParser.to_db_value(
+            media_dict, lane_count, subport_num)
+
+    def test_custom_media_settings_is_port_selected(self):
+        assert media_settings_parser.CustomMediaSettingsParser.is_port_selected('1, 3-4, 8', 8)
+        assert media_settings_parser.CustomMediaSettingsParser.is_port_selected('1,3-4,8', 4)
+        assert media_settings_parser.CustomMediaSettingsParser.is_port_selected('01', 1)
+        assert media_settings_parser.CustomMediaSettingsParser.is_port_selected('1 - 3', 2)
+        assert not media_settings_parser.CustomMediaSettingsParser.is_port_selected('1,3-4,8', 2)
+        assert not media_settings_parser.CustomMediaSettingsParser.is_port_selected('   ', 1)
+        assert not media_settings_parser.CustomMediaSettingsParser.is_port_selected('1,,3', 2)
+        assert not media_settings_parser.CustomMediaSettingsParser.is_port_selected('1-a', 1)
+        assert not media_settings_parser.CustomMediaSettingsParser.is_port_selected('1-2-3', 2)
+        assert not media_settings_parser.CustomMediaSettingsParser.is_port_selected('a', 2)
+        assert not media_settings_parser.CustomMediaSettingsParser.is_port_selected(123, 1)
+
+    def test_get_custom_media_settings_value(self):
+        key = {
+            'vendor_key': 'UNKOWN',
+            'media_key': 'QSFP-DD-active_cable_media_interface',
+            'lane_speed_key': 'speed:100GAUI-2',
+            'medium_lane_speed_key': 'UNKNOWN',
+        }
+        with patch('xcvrd.xcvrd_utilities.media_settings_parser.g_dict', media_settings_custom_attrs):
+            result = media_settings_parser.get_custom_media_settings_value(8, key)
+            assert result == {
+                'CUSTOM:XYZ': custom_serdes_attrs_xyz_10,
+                'CUSTOM:ABC': custom_serdes_attrs_abc_mode,
+            }
+
+            result = media_settings_parser.get_custom_media_settings_value(7, key)
+            assert result == {
+                'CUSTOM:XYZ': custom_serdes_attrs_xyz_20,
+            }
+
+            key_no_match = copy.deepcopy(key)
+            key_no_match['media_key'] = 'UNMATCHED_MEDIA'
+            result = media_settings_parser.get_custom_media_settings_value(8, key_no_match)
+            assert result == {
+                'CUSTOM:XYZ': custom_serdes_attrs_xyz_20,
+            }
+
+        with patch('xcvrd.xcvrd_utilities.media_settings_parser.g_dict', media_settings_custom_attrs_no_space):
+            result = media_settings_parser.get_custom_media_settings_value(4, key)
+            assert result == {
+                'CUSTOM:XYZ': custom_serdes_attrs_xyz_10,
+            }
+
+        with patch('xcvrd.xcvrd_utilities.media_settings_parser.g_dict', media_settings_custom_attrs_non_string_selector):
+            result = media_settings_parser.get_custom_media_settings_value(9, key)
+            assert result == {}
+
+        with patch('xcvrd.xcvrd_utilities.media_settings_parser.g_dict',
+                   media_settings_custom_attrs_empty_explicit_then_default):
+            result = media_settings_parser.get_custom_media_settings_value(8, key)
+            assert result == {
+                'CUSTOM:XYZ': custom_serdes_attrs_xyz_20,
+            }
+
+    def test_custom_media_settings_mixed_with_port_and_global(self):
+        key = {
+            'vendor_key': 'UNKOWN',
+            'media_key': 'QSFP-DD-active_cable_media_interface',
+            'lane_speed_key': 'speed:100GAUI-2',
+            'medium_lane_speed_key': 'UNKNOWN',
+        }
+        with patch('xcvrd.xcvrd_utilities.media_settings_parser.g_dict',
+                   media_settings_custom_attrs_with_port_and_global):
+            result = media_settings_parser.get_traditional_media_settings_value(7, key)
+            assert result == {
+                'pre1': {'lane0': '0x00000002', 'lane1': '0x00000002'},
+                'main': {'lane0': '0x00000020', 'lane1': '0x00000020'},
+                'post1': {'lane0': '0x00000006', 'lane1': '0x00000006'},
+                'regn_bfm1n': {'lane0': '0x000000aa', 'lane1': '0x000000aa'},
+            }
+
+            result = media_settings_parser.get_custom_media_settings_value(7, key)
+            assert result == {
+                'CUSTOM:XYZ': custom_serdes_attrs_xyz_20,
+            }
+
+    def test_custom_media_settings_medium_lane_key(self):
+        key = {
+            'vendor_key': 'UNKOWN',
+            'media_key': 'UNMATCHED_MEDIA',
+            'lane_speed_key': 'speed:100GAUI-2',
+            'medium_lane_speed_key': 'COPPER50',
+        }
+        with patch('xcvrd.xcvrd_utilities.media_settings_parser.g_dict',
+                   media_settings_custom_attrs_medium_lane):
+            result = media_settings_parser.get_custom_media_settings_value(7, key)
+            assert result == {
+                'CUSTOM:XYZ': custom_serdes_attrs_xyz_20,
+            }
+
+    @pytest.mark.parametrize("settings", [{}, [], None])
+    def test_custom_media_settings_parser_empty_or_invalid_settings(self, settings):
+        key = {
+            'vendor_key': 'UNKOWN',
+            'media_key': 'UNMATCHED_MEDIA',
+            'lane_speed_key': 'speed:100GAUI-2',
+            'medium_lane_speed_key': 'COPPER50',
+        }
+        parser = media_settings_parser.CustomMediaSettingsParser()
+        assert parser.parse(settings, 7, key) == ({}, {})
+
+    @pytest.mark.parametrize("media_dict, lane_count, subport_num, gearbox_line_lane_count, expected", [
+        (
+            {'main': {'lane0': '0x11', 'lane1': '0x12', 'lane2': '0x13', 'lane3': '0x14'}},
+            2, 2, None,
+            {'main': '0x13,0x14'},
+        ),
+        (
+            {'main': {'lane0': '0x11', 'lane1': '0x12'}, 'los_thresh': '7'},
+            2, 0, None,
+            {'main': '0x11,0x12', 'los_thresh': '7'},
+        ),
+        (
+            {},
+            2, 2, None,
+            {},
+        ),
+        (
+            {
+                'gb_line_main': {
+                    'lane0': '0x10', 'lane1': '0x11', 'lane2': '0x12', 'lane3': '0x13',
+                    'lane4': '0x14', 'lane5': '0x15', 'lane6': '0x16', 'lane7': '0x17',
+                },
+                'gb_system_main': {
+                    'lane0': '0x20', 'lane1': '0x21', 'lane2': '0x22', 'lane3': '0x23',
+                },
+            },
+            4, 0, 8,
+            {
+                'gb_line_main': '0x10,0x11,0x12,0x13,0x14,0x15,0x16,0x17',
+                'gb_system_main': '0x20,0x21,0x22,0x23',
+            },
+        ),
+    ])
+    def test_media_settings_to_db_value(self, media_dict, lane_count, subport_num,
+                                        gearbox_line_lane_count, expected):
+        assert expected == media_settings_parser.MediaSettingsParserBase.to_db_value(
+            media_dict, lane_count, subport_num, gearbox_line_lane_count)
+
+    @pytest.mark.parametrize("media_dict, custom_media_dict, lane_count, subport_num, gearbox_line_lane_count, expected", [
+        (
+            {'main': {'lane0': '0x11', 'lane1': '0x12', 'lane2': '0x13', 'lane3': '0x14'}},
+            {},
+            2, 2, None,
+            {'main': '0x13,0x14'},
+        ),
+        (
+            {},
+            {'CUSTOM:XYZ': {'lane0': 10, 'lane1': 11, 'lane2': 12, 'lane3': 13}},
+            2, 2, None,
+            {CUSTOM_SERDES_ATTRS_KEY_IN_DB: '{"attributes":[{"XYZ":{"value":[12,13]}}]}'},
+        ),
+        (
+            {'main': {'lane0': '0x11', 'lane1': '0x12', 'lane2': '0x13', 'lane3': '0x14'}},
+            {'CUSTOM:ABC': {'lane0': 1, 'lane1': 2, 'lane2': 3, 'lane3': 4}},
+            2, 2, None,
+            {
+                'main': '0x13,0x14',
+                CUSTOM_SERDES_ATTRS_KEY_IN_DB: '{"attributes":[{"ABC":{"value":[3,4]}}]}',
+            },
+        ),
+        (
+            {},
+            {},
+            2, 2, None,
+            {},
+        ),
+        (
+            {
+                'gb_line_main': {
+                    'lane0': '0x10', 'lane1': '0x11', 'lane2': '0x12', 'lane3': '0x13',
+                    'lane4': '0x14', 'lane5': '0x15', 'lane6': '0x16', 'lane7': '0x17',
+                },
+                'gb_system_main': {
+                    'lane0': '0x20', 'lane1': '0x21', 'lane2': '0x22', 'lane3': '0x23',
+                },
+            },
+            {},
+            4, 0, 8,
+            {
+                'gb_line_main': '0x10,0x11,0x12,0x13,0x14,0x15,0x16,0x17',
+                'gb_system_main': '0x20,0x21,0x22,0x23',
+            },
+        ),
+    ])
+    def test_resolve_media_settings_for_db(self, media_dict, custom_media_dict, lane_count,
+                                           subport_num, gearbox_line_lane_count, expected):
+        with patch.multiple(
+            'xcvrd.xcvrd_utilities.media_settings_parser',
+            get_traditional_media_settings_value=MagicMock(return_value=media_dict),
+            get_custom_media_settings_value=MagicMock(return_value=custom_media_dict),
+        ):
+            result = media_settings_parser.resolve_media_settings_for_db(
+                7, {}, lane_count, subport_num, gearbox_line_lane_count
+            )
+            assert result == expected
+
     def _check_notify_media_setting_with_gearbox(self, index, gearbox_line_lanes, system_lanes, xcvr_info_dict=None):
         """
         Helper method to test notify_media_setting with gearbox configuration.
@@ -1838,6 +2244,9 @@ class TestXcvrdScript(object):
             gearbox_line_lanes: Number of gearbox line lanes
             system_lanes: Number of system lanes
             xcvr_info_dict: Optional transceiver info dictionary
+
+        Returns:
+            None
         """
         xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         cfg_port_tbl = MagicMock()
@@ -5468,6 +5877,12 @@ class TestXcvrdScript(object):
         subport_num = 2
         media_str = get_serdes_si_setting_val_str(lane_dict, lane_count, subport_num)
         assert media_str == 'c,d'
+        # non-string lane values are coerced defensively for string output
+        lane_dict = {'lane0': 1, 'lane1': 2, 'lane2': 3, 'lane3': 4}
+        lane_count = 2
+        subport_num = 2
+        media_str = get_serdes_si_setting_val_str(lane_dict, lane_count, subport_num)
+        assert media_str == '3,4'
 
     class MockPortMapping:
         logical_port_list = [0, 1, 2]

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -26,9 +26,6 @@ RANGE_SEPARATOR = '-'
 COMMA_SEPARATOR = ','
 # This is useful if default value is desired when no match is found for lane speed key
 LANE_SPEED_DEFAULT_KEY = LANE_SPEED_KEY_PREFIX + DEFAULT_KEY
-CUSTOM_SERDES_ATTR_PREFIX = 'CUSTOM:'
-CUSTOM_SERDES_ATTRS_TOP_LEVEL_KEY = 'attributes'
-CUSTOM_SERDES_ATTRS_KEY_IN_DB = 'custom_serdes_attrs'
 SYSLOG_IDENTIFIER = "xcvrd"
 GLOBAL_MEDIA_SETTINGS_KEY = 'GLOBAL_MEDIA_SETTINGS'
 PORT_MEDIA_SETTINGS_KEY = 'PORT_MEDIA_SETTINGS'
@@ -66,9 +63,32 @@ class MediaSettingsParserBase(ABC):
         return None
 
     @staticmethod
+    def _get_lane_values_str(val_dict, lane_count, subport_num=0):
+        """
+        Slice per-lane SerDes settings and return them as a comma-separated string.
+
+        Args:
+            val_dict: dictionary containing SerDes settings for all lanes of the port
+            lane_count: number of lanes for this subport
+            subport_num: subport number (1-based), 0 for non-breakout case
+
+        Returns:
+            String containing SerDes settings for the given subport, separated by commas.
+        """
+        start_lane_idx = (subport_num - 1) * lane_count if subport_num else 0
+        if start_lane_idx + lane_count > len(val_dict):
+            helper_logger.log_notice(
+                "start_lane_idx + lane_count ({}) is beyond length of {}, "
+                "default start_lane_idx to 0 as a best effort".format(start_lane_idx + lane_count, val_dict)
+            )
+            start_lane_idx = 0
+        val_list = [val_dict[lane_key] for lane_key in natsorted(val_dict)]
+        return ','.join(str(val) for val in val_list[start_lane_idx:start_lane_idx + lane_count])
+
+    @staticmethod
     def to_db_value(media_dict, lane_count, subport_num, gearbox_line_lane_count=None):
         """
-        Convert traditional media settings to APP DB field/value pairs.
+        Convert traditional media settings to APP DB field/value tuples.
 
         Args:
             media_dict: dictionary containing traditional media settings
@@ -79,25 +99,27 @@ class MediaSettingsParserBase(ABC):
                 this width instead of the system-side ``lane_count``.
 
         Returns:
-            Dictionary containing APP DB-ready field/value pairs.
+            List of ``(field, value)`` tuples ready to publish to APP_DB.
         """
         if not media_dict:
-            return {}
+            return []
 
-        payload = {}
+        fvs_list = []
 
         for media_key, media_value in media_dict.items():
             if isinstance(media_value, dict):
                 lane_count_si = lane_count
                 if gearbox_line_lane_count is not None and "gb_line" in media_key:
                     lane_count_si = gearbox_line_lane_count
-                payload[media_key] = get_serdes_si_setting_val_str(
+                val_str = MediaSettingsParserBase._get_lane_values_str(
                     media_value, lane_count_si, subport_num
                 )
             else:
-                payload[media_key] = media_value
+                val_str = media_value
 
-        return payload
+            fvs_list.append((str(media_key), str(val_str)))
+
+        return fvs_list
 
 class GlobalMediaSettingsParser(MediaSettingsParserBase):
     def parse(self, settings, physical_port, key):
@@ -150,6 +172,10 @@ class PortMediaSettingsParser(MediaSettingsParserBase):
         return {}, {}
 
 class CustomMediaSettingsParser(MediaSettingsParserBase):
+    CUSTOM_SERDES_ATTR_PREFIX = 'CUSTOM:'
+    CUSTOM_SERDES_ATTRS_TOP_LEVEL_KEY = 'attributes'
+    CUSTOM_SERDES_ATTRS_KEY_IN_DB = 'custom_serdes_attrs'
+
     @staticmethod
     def is_port_selected(port_selector, physical_port):
         """
@@ -193,6 +219,25 @@ class CustomMediaSettingsParser(MediaSettingsParserBase):
         return False
 
     @staticmethod
+    def _get_lane_values(val_dict, lane_count, subport_num):
+        """
+        Slice per-lane SerDes settings and return them as a list.
+
+        Args:
+            val_dict: dictionary containing SerDes settings for all lanes of the port
+            lane_count: number of lanes for this subport
+            subport_num: subport number (1-based), 0 for non-breakout case
+
+        Returns:
+            List containing SerDes settings for the requested subport.
+        """
+        start_lane_idx = (subport_num - 1) * lane_count if subport_num else 0
+        val_list = [val_dict[lane_key] for lane_key in natsorted(val_dict)]
+        if start_lane_idx + lane_count > len(val_list):
+            start_lane_idx = 0
+        return val_list[start_lane_idx:start_lane_idx + lane_count]
+
+    @staticmethod
     def to_db_value(custom_media_dict, lane_count, subport_num):
         """
         Convert custom SerDes attributes to the JSON string used in APP DB.
@@ -211,12 +256,12 @@ class CustomMediaSettingsParser(MediaSettingsParserBase):
         attrs_list = []
 
         for key, value in custom_media_dict.items():
-            if not isinstance(key, str) or not key.startswith(CUSTOM_SERDES_ATTR_PREFIX):
+            if not isinstance(key, str) or not key.startswith(CustomMediaSettingsParser.CUSTOM_SERDES_ATTR_PREFIX):
                 continue
 
             attrs_list.append({
-                key[len(CUSTOM_SERDES_ATTR_PREFIX):]: {
-                    'value': get_serdes_si_setting_val(value, lane_count, subport_num)
+                key[len(CustomMediaSettingsParser.CUSTOM_SERDES_ATTR_PREFIX):]: {
+                    'value': CustomMediaSettingsParser._get_lane_values(value, lane_count, subport_num)
                 }
             })
 
@@ -224,7 +269,7 @@ class CustomMediaSettingsParser(MediaSettingsParserBase):
             return None
 
         return json.dumps(
-            {CUSTOM_SERDES_ATTRS_TOP_LEVEL_KEY: attrs_list},
+            {CustomMediaSettingsParser.CUSTOM_SERDES_ATTRS_TOP_LEVEL_KEY: attrs_list},
             separators=(',', ':')
         )
 
@@ -376,49 +421,6 @@ def is_si_per_speed_supported(media_dict):
     return LANE_SPEED_KEY_PREFIX in list(media_dict.keys())[0]
 
 
-def get_serdes_si_setting_val(val_dict, lane_count, subport_num=0):
-    """
-    Get ASIC side SerDes SI settings for the given logical port (subport)
-
-    Args:
-        val_dict: dictionary containing SerDes settings for all lanes of the port
-                  e.g. {'lane0': '0x1f', 'lane1': '0x1f', 'lane2': '0x1f', 'lane3': '0x1f'}
-        lane_count: number of lanes for this subport
-        subport_num: subport number (1-based), 0 for non-breakout case
-
-    Returns:
-        list containing SerDes settings for the given subport
-        e.g. ['0x1f', '0x1f', '0x1f', '0x1f']
-    """
-    start_lane_idx = (subport_num - 1) * lane_count if subport_num else 0
-    if start_lane_idx + lane_count > len(val_dict):
-        helper_logger.log_notice(
-            "start_lane_idx + lane_count ({}) is beyond length of {}, "
-            "default start_lane_idx to 0 as a best effort".format(start_lane_idx + lane_count, val_dict)
-        )
-        start_lane_idx = 0
-    val_list = [val_dict[lane_key] for lane_key in natsorted(val_dict)]
-    # If subport_num ('subport') is not specified in config_db, return values for first lane_count number of lanes
-    return val_list[start_lane_idx:start_lane_idx + lane_count]
-
-
-def get_serdes_si_setting_val_str(val_dict, lane_count, subport_num=0):
-    """
-    Get ASIC side SerDes SI settings string for the given logical port (subport)
-
-    Args:
-        val_dict: dictionary containing SerDes settings for all lanes of the port
-                  e.g. {'lane0': '0x1f', 'lane1': '0x1f', 'lane2': '0x1f', 'lane3': '0x1f'}
-        lane_count: number of lanes for this subport
-        subport_num: subport number (1-based), 0 for non-breakout case
-
-    Returns:
-        string containing SerDes settings for the given subport, separated by comma
-        e.g. '0x1f,0x1f,0x1f,0x1f'
-    """
-    return ','.join(str(val) for val in get_serdes_si_setting_val(val_dict, lane_count, subport_num))
-
-
 def get_media_settings_for_speed(settings_dict, lane_speed_key):
     """
     Get settings for the given lane speed key
@@ -450,7 +452,7 @@ def get_media_settings_for_speed(settings_dict, lane_speed_key):
     return settings_dict.get(LANE_SPEED_DEFAULT_KEY, {})
 
 
-def get_traditional_media_settings_value(physical_port, key):
+def get_media_settings_value(physical_port, key):
     """
     Resolve traditional media settings for a physical port.
 
@@ -549,54 +551,6 @@ def get_speed_lane_count_and_subport(port, cfg_port_tbl):
     return port_speed, lane_count, subport_num
 
 
-def resolve_media_settings_for_db(physical_port, key, lane_count, subport_num,
-                                  gearbox_line_lane_count=None):
-    """
-    Resolve the final APP_DB field/value payload for a port.
-
-    Args:
-        physical_port: physical port number for this logical port
-        key: media settings key dictionary with vendor/media and lane speed info
-        lane_count: number of lanes for this subport
-        subport_num: subport number (1-based), 0 for non-breakout case
-        gearbox_line_lane_count: optional gearbox line-side lane count used
-            for ``gb_line*`` traditional attributes
-
-    Returns:
-        Dictionary containing the final APP_DB field/value payload.
-
-    Example:
-        If traditional settings resolve to:
-        {'main': {'lane0': '0x11', 'lane1': '0x12', 'lane2': '0x13',
-                  'lane3': '0x14'}}
-        and custom settings resolve to:
-        {'CUSTOM:ABC': {'lane0': 1, 'lane1': 2, 'lane2': 3, 'lane3': 4}}
-        then for lane_count=2 and subport_num=2 this function returns:
-        {'main': '0x13,0x14',
-         'custom_serdes_attrs': '{"attributes":[{"ABC":{"value":[3,4]}}]}'}
-    """
-    # Keep traditional and custom lookups separate because they can coexist on
-    # the same port but resolve to different APP_DB shapes: traditional fields
-    # stay as normal per-attribute entries, while custom settings are later
-    # aggregated into a single 'custom_serdes_attrs' JSON payload.
-    media_dict = get_traditional_media_settings_value(physical_port, key)
-    custom_media_dict = get_custom_media_settings_value(physical_port, key)
-
-    if not media_dict and not custom_media_dict:
-        return {}
-
-    payload = MediaSettingsParserBase.to_db_value(
-        media_dict, lane_count, subport_num, gearbox_line_lane_count
-    )
-
-    custom_serdes_attrs = CustomMediaSettingsParser.to_db_value(
-        custom_media_dict, lane_count, subport_num)
-    if custom_serdes_attrs is not None:
-        payload[CUSTOM_SERDES_ATTRS_KEY_IN_DB] = custom_serdes_attrs
-
-    return payload
-
-
 def notify_media_setting(logical_port_name, transceiver_dict,
                          xcvr_table_helper, port_mapping):
 
@@ -651,22 +605,32 @@ def notify_media_setting(logical_port_name, transceiver_dict,
         else:
             key = get_media_settings_key(physical_port, transceiver_dict, port_speed, lane_count)
         helper_logger.log_notice("Retrieving media settings for port {} speed {} num_lanes {}, using key {}".format(logical_port_name, port_speed, lane_count, key))
-        payload = resolve_media_settings_for_db(
-            physical_port, key, lane_count, subport_num, gearbox_line_lane_count
-        )
+        media_dict = get_media_settings_value(physical_port, key)
+        custom_media_dict = get_custom_media_settings_value(physical_port, key)
 
-        if not payload:
+        if not media_dict and not custom_media_dict:
             helper_logger.log_info("Error in obtaining media setting for {}".format(logical_port_name))
             return
 
-        fvs = swsscommon.FieldValuePairs(len(payload))
+        fvs_list = MediaSettingsParserBase.to_db_value(
+            media_dict, lane_count, subport_num, gearbox_line_lane_count
+        )
 
-        index = 0
+        custom_db_value = CustomMediaSettingsParser.to_db_value(
+            custom_media_dict, lane_count, subport_num)
+        if custom_db_value is not None:
+            fvs_list.append((CustomMediaSettingsParser.CUSTOM_SERDES_ATTRS_KEY_IN_DB, custom_db_value))
+
+        if not fvs_list:
+            helper_logger.log_info("Error in obtaining media setting for {}".format(logical_port_name))
+            return
+
+        fvs = swsscommon.FieldValuePairs(len(fvs_list))
+
         helper_logger.log_notice("Publishing SI setting for port {} in APP_DB:".format(logical_port_name))
-        for media_key, val_str in payload.items():
+        for index, (media_key, val_str) in enumerate(fvs_list):
             helper_logger.log_notice("{}:({},{}) ".format(index, str(media_key), str(val_str)))
             fvs[index] = (str(media_key), str(val_str))
-            index += 1
 
         xcvr_table_helper.get_app_port_tbl(asic_index).set(port_name, fvs)
         xcvr_table_helper.get_state_port_tbl(asic_index).set(logical_port_name, [(NPU_SI_SETTINGS_SYNC_STATUS_KEY, NPU_SI_SETTINGS_NOTIFIED_VALUE)])

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -22,8 +22,13 @@ MEDIA_KEY = 'media_key'
 LANE_SPEED_KEY = 'lane_speed_key'
 MEDIUM_LANE_SPEED_KEY = 'medium_lane_speed_key'
 DEFAULT_KEY = 'Default'
+RANGE_SEPARATOR = '-'
+COMMA_SEPARATOR = ','
 # This is useful if default value is desired when no match is found for lane speed key
 LANE_SPEED_DEFAULT_KEY = LANE_SPEED_KEY_PREFIX + DEFAULT_KEY
+CUSTOM_SERDES_ATTR_PREFIX = 'CUSTOM:'
+CUSTOM_SERDES_ATTRS_TOP_LEVEL_KEY = 'attributes'
+CUSTOM_SERDES_ATTRS_KEY_IN_DB = 'custom_serdes_attrs'
 SYSLOG_IDENTIFIER = "xcvrd"
 GLOBAL_MEDIA_SETTINGS_KEY = 'GLOBAL_MEDIA_SETTINGS'
 PORT_MEDIA_SETTINGS_KEY = 'PORT_MEDIA_SETTINGS'
@@ -60,10 +65,42 @@ class MediaSettingsParserBase(ABC):
                 return get_media_settings_for_speed(media_dict[dict_key], key[LANE_SPEED_KEY])
         return None
 
+    @staticmethod
+    def to_db_value(media_dict, lane_count, subport_num, gearbox_line_lane_count=None):
+        """
+        Convert traditional media settings to APP DB field/value pairs.
+
+        Args:
+            media_dict: dictionary containing traditional media settings
+            lane_count: number of lanes for this subport
+            subport_num: subport number (1-based), 0 for non-breakout case
+            gearbox_line_lane_count: optional gearbox line-side lane count.
+                When provided, traditional keys prefixed with ``gb_line`` use
+                this width instead of the system-side ``lane_count``.
+
+        Returns:
+            Dictionary containing APP DB-ready field/value pairs.
+        """
+        if not media_dict:
+            return {}
+
+        payload = {}
+
+        for media_key, media_value in media_dict.items():
+            if isinstance(media_value, dict):
+                lane_count_si = lane_count
+                if gearbox_line_lane_count is not None and "gb_line" in media_key:
+                    lane_count_si = gearbox_line_lane_count
+                payload[media_key] = get_serdes_si_setting_val_str(
+                    media_value, lane_count_si, subport_num
+                )
+            else:
+                payload[media_key] = media_value
+
+        return payload
+
 class GlobalMediaSettingsParser(MediaSettingsParserBase):
     def parse(self, settings, physical_port, key):
-        RANGE_SEPARATOR = '-'
-        COMMA_SEPARATOR = ','
         default_dict = {}
         lane_speed_key = key[LANE_SPEED_KEY]
 
@@ -113,9 +150,102 @@ class PortMediaSettingsParser(MediaSettingsParserBase):
         return {}, {}
 
 class CustomMediaSettingsParser(MediaSettingsParserBase):
+    @staticmethod
+    def is_port_selected(port_selector, physical_port):
+        """
+        Return True if the port selector matches the given physical_port.
+
+        Supports:
+          - Single port: "7"
+          - Range: "1-4"
+          - List / list-of-ranges: "1,3-4,8"
+        Whitespace is ignored. Non-string selectors return False.
+        """
+        if not isinstance(port_selector, str):
+            helper_logger.log_notice("Malformed port selector '{}'".format(port_selector))
+            return False
+
+        for token in port_selector.split(COMMA_SEPARATOR):
+            token = token.strip()
+            if not token:
+                helper_logger.log_notice(
+                    "Malformed port selector token '' in '{}'".format(port_selector)
+                )
+                continue
+
+            if RANGE_SEPARATOR in token:
+                start_str, end_str = token.split(RANGE_SEPARATOR, 1)
+            else:
+                start_str = end_str = token
+
+            try:
+                start = int(start_str.strip())
+                end = int(end_str.strip())
+            except ValueError:
+                helper_logger.log_notice(
+                    "Malformed port selector token '{}' in '{}'".format(token, port_selector)
+                )
+                continue
+
+            if start <= physical_port <= end:
+                return True
+
+        return False
+
+    @staticmethod
+    def to_db_value(custom_media_dict, lane_count, subport_num):
+        """
+        Convert custom SerDes attributes to the JSON string used in APP DB.
+
+        Args:
+            custom_media_dict: dictionary containing custom SerDes settings for all lanes of the port
+            lane_count: number of lanes for this subport
+            subport_num: subport number (1-based), 0 for non-breakout case
+
+        Returns:
+            JSON string for custom SerDes attributes, or None if no custom attributes are present.
+        """
+        if not custom_media_dict:
+            return None
+
+        attrs_list = []
+
+        for key, value in custom_media_dict.items():
+            if not isinstance(key, str) or not key.startswith(CUSTOM_SERDES_ATTR_PREFIX):
+                continue
+
+            attrs_list.append({
+                key[len(CUSTOM_SERDES_ATTR_PREFIX):]: {
+                    'value': get_serdes_si_setting_val(value, lane_count, subport_num)
+                }
+            })
+
+        if not attrs_list:
+            return None
+
+        return json.dumps(
+            {CUSTOM_SERDES_ATTRS_TOP_LEVEL_KEY: attrs_list},
+            separators=(',', ':')
+        )
+
     def parse(self, settings, physical_port, key):
-        # TODO: Placeholder for custom media setting parser
-        return {}, {}
+        if not isinstance(settings, dict) or not settings:
+            return {}, {}
+
+        default_dict = {}
+        lane_speed_key = key[LANE_SPEED_KEY]
+
+        for port_selector, media_dict in settings.items():
+            if not self.is_port_selected(port_selector, physical_port):
+                continue
+
+            media_settings = self.get_media_settings(key, media_dict)
+            if media_settings:
+                return media_settings, {}
+            if DEFAULT_KEY in media_dict and not default_dict:
+                default_dict = get_media_settings_for_speed(media_dict[DEFAULT_KEY], lane_speed_key)
+
+        return {}, default_dict
 
 
 def load_media_settings():
@@ -246,9 +376,35 @@ def is_si_per_speed_supported(media_dict):
     return LANE_SPEED_KEY_PREFIX in list(media_dict.keys())[0]
 
 
-def get_serdes_si_setting_val_str(val_dict, lane_count, subport_num=0):
+def get_serdes_si_setting_val(val_dict, lane_count, subport_num=0):
     """
     Get ASIC side SerDes SI settings for the given logical port (subport)
+
+    Args:
+        val_dict: dictionary containing SerDes settings for all lanes of the port
+                  e.g. {'lane0': '0x1f', 'lane1': '0x1f', 'lane2': '0x1f', 'lane3': '0x1f'}
+        lane_count: number of lanes for this subport
+        subport_num: subport number (1-based), 0 for non-breakout case
+
+    Returns:
+        list containing SerDes settings for the given subport
+        e.g. ['0x1f', '0x1f', '0x1f', '0x1f']
+    """
+    start_lane_idx = (subport_num - 1) * lane_count if subport_num else 0
+    if start_lane_idx + lane_count > len(val_dict):
+        helper_logger.log_notice(
+            "start_lane_idx + lane_count ({}) is beyond length of {}, "
+            "default start_lane_idx to 0 as a best effort".format(start_lane_idx + lane_count, val_dict)
+        )
+        start_lane_idx = 0
+    val_list = [val_dict[lane_key] for lane_key in natsorted(val_dict)]
+    # If subport_num ('subport') is not specified in config_db, return values for first lane_count number of lanes
+    return val_list[start_lane_idx:start_lane_idx + lane_count]
+
+
+def get_serdes_si_setting_val_str(val_dict, lane_count, subport_num=0):
+    """
+    Get ASIC side SerDes SI settings string for the given logical port (subport)
 
     Args:
         val_dict: dictionary containing SerDes settings for all lanes of the port
@@ -260,16 +416,7 @@ def get_serdes_si_setting_val_str(val_dict, lane_count, subport_num=0):
         string containing SerDes settings for the given subport, separated by comma
         e.g. '0x1f,0x1f,0x1f,0x1f'
     """
-    start_lane_idx = (subport_num - 1) * lane_count if subport_num else 0
-    if start_lane_idx + lane_count > len(val_dict):
-        helper_logger.log_notice(
-            "start_lane_idx + lane_count ({}) is beyond length of {}, "
-            "default start_lane_idx to 0 as a best effort".format(start_lane_idx + lane_count, val_dict)
-        )
-        start_lane_idx = 0
-    val_list = [val_dict[lane_key] for lane_key in natsorted(val_dict)]
-    # If subport_num ('subport') is not specified in config_db, return values for first lane_count number of lanes
-    return ','.join(val_list[start_lane_idx:start_lane_idx + lane_count])
+    return ','.join(str(val) for val in get_serdes_si_setting_val(val_dict, lane_count, subport_num))
 
 
 def get_media_settings_for_speed(settings_dict, lane_speed_key):
@@ -303,15 +450,34 @@ def get_media_settings_for_speed(settings_dict, lane_speed_key):
     return settings_dict.get(LANE_SPEED_DEFAULT_KEY, {})
 
 
-def get_media_settings_value(physical_port, key):
+def get_traditional_media_settings_value(physical_port, key):
+    """
+    Resolve traditional media settings for a physical port.
+
+    Traditional settings are selected from GLOBAL_MEDIA_SETTINGS and
+    PORT_MEDIA_SETTINGS using the standard precedence order, and the returned
+    value is the raw media-settings dictionary before APP_DB serialization.
+
+    Args:
+        physical_port: physical port number for this logical port
+        key: media settings key dictionary with vendor/media and lane speed info
+
+    Returns:
+        Dictionary containing the matched traditional media settings before
+        APP_DB serialization. Returns {} if no traditional settings match.
+
+    Example:
+        A matching traditional profile may return:
+        {'main': {'lane0': '0x11', 'lane1': '0x12', 'lane2': '0x13',
+                  'lane3': '0x14'}}
+    """
     global_default = {}
 
-    # Priority order:
+    # Priority order for traditional media settings:
     #   1. GLOBAL explicit match (vendor/media/speed)
     #   2. PORT explicit match
     #   3. PORT Default
-    #   4. CUSTOM explicit match
-    #   5. GLOBAL Default (last-resort fallback)
+    #   4. GLOBAL Default (last-resort fallback)
 
     # Check global media settings first (can apply to ranges/lists of ports)
     if GLOBAL_MEDIA_SETTINGS_KEY in g_dict:
@@ -329,17 +495,44 @@ def get_media_settings_value(physical_port, key):
         if port_default:
             return port_default
 
-    if CUSTOM_MEDIA_SETTINGS_KEY in g_dict:
-        result, _ = CustomMediaSettingsParser().parse(
-            g_dict[CUSTOM_MEDIA_SETTINGS_KEY], physical_port, key)
-        if result:
-            return result
-
     # Fall back to global default if no explicit or port-default match found
     if global_default:
         return global_default
 
     return {}
+
+
+def get_custom_media_settings_value(physical_port, key):
+    """
+    Resolve custom media settings for a physical port.
+
+    Custom settings are selected only from CUSTOM_MEDIA_SETTINGS and the
+    returned value is the raw custom-attribute dictionary before it is
+    converted to the APP_DB custom_serdes_attrs payload.
+
+    Args:
+        physical_port: physical port number for this logical port
+        key: media settings key dictionary with vendor/media and lane speed info
+
+    Returns:
+        Dictionary containing the matched custom media settings before they are
+        converted to the APP_DB custom_serdes_attrs payload. Returns {} if no
+        custom settings match.
+
+    Example:
+        A matching custom profile may return:
+        {'CUSTOM:ABC': {'lane0': 1, 'lane1': 2, 'lane2': 3, 'lane3': 4}}
+    """
+    custom_settings = g_dict.get(CUSTOM_MEDIA_SETTINGS_KEY)
+    if not isinstance(custom_settings, dict) or not custom_settings:
+        return {}
+
+    result, default_dict = CustomMediaSettingsParser().parse(
+        custom_settings, physical_port, key)
+    if result:
+        return result
+
+    return default_dict
 
 
 def get_speed_lane_count_and_subport(port, cfg_port_tbl):
@@ -354,6 +547,54 @@ def get_speed_lane_count_and_subport(port, cfg_port_tbl):
     else:
         helper_logger.log_error("No info found for port {} in cfg_port_tbl".format(port))
     return port_speed, lane_count, subport_num
+
+
+def resolve_media_settings_for_db(physical_port, key, lane_count, subport_num,
+                                  gearbox_line_lane_count=None):
+    """
+    Resolve the final APP_DB field/value payload for a port.
+
+    Args:
+        physical_port: physical port number for this logical port
+        key: media settings key dictionary with vendor/media and lane speed info
+        lane_count: number of lanes for this subport
+        subport_num: subport number (1-based), 0 for non-breakout case
+        gearbox_line_lane_count: optional gearbox line-side lane count used
+            for ``gb_line*`` traditional attributes
+
+    Returns:
+        Dictionary containing the final APP_DB field/value payload.
+
+    Example:
+        If traditional settings resolve to:
+        {'main': {'lane0': '0x11', 'lane1': '0x12', 'lane2': '0x13',
+                  'lane3': '0x14'}}
+        and custom settings resolve to:
+        {'CUSTOM:ABC': {'lane0': 1, 'lane1': 2, 'lane2': 3, 'lane3': 4}}
+        then for lane_count=2 and subport_num=2 this function returns:
+        {'main': '0x13,0x14',
+         'custom_serdes_attrs': '{"attributes":[{"ABC":{"value":[3,4]}}]}'}
+    """
+    # Keep traditional and custom lookups separate because they can coexist on
+    # the same port but resolve to different APP_DB shapes: traditional fields
+    # stay as normal per-attribute entries, while custom settings are later
+    # aggregated into a single 'custom_serdes_attrs' JSON payload.
+    media_dict = get_traditional_media_settings_value(physical_port, key)
+    custom_media_dict = get_custom_media_settings_value(physical_port, key)
+
+    if not media_dict and not custom_media_dict:
+        return {}
+
+    payload = MediaSettingsParserBase.to_db_value(
+        media_dict, lane_count, subport_num, gearbox_line_lane_count
+    )
+
+    custom_serdes_attrs = CustomMediaSettingsParser.to_db_value(
+        custom_media_dict, lane_count, subport_num)
+    if custom_serdes_attrs is not None:
+        payload[CUSTOM_SERDES_ATTRS_KEY_IN_DB] = custom_serdes_attrs
+
+    return payload
 
 
 def notify_media_setting(logical_port_name, transceiver_dict,
@@ -402,30 +643,27 @@ def notify_media_setting(logical_port_name, transceiver_dict,
         ganged_member_num += 1
         # If the port has a gearbox, then we need to calculate the media settings key based on the number of
         # lanes on the line-side of the gearbox
-        if logical_port_name in gearbox_lanes_dict:
-            key = get_media_settings_key(physical_port, transceiver_dict, port_speed, gearbox_lanes_dict[logical_port_name])
+        gearbox_line_lane_count = gearbox_lanes_dict.get(logical_port_name)
+        if gearbox_line_lane_count is not None:
+            key = get_media_settings_key(
+                physical_port, transceiver_dict, port_speed, gearbox_line_lane_count
+            )
         else:
             key = get_media_settings_key(physical_port, transceiver_dict, port_speed, lane_count)
         helper_logger.log_notice("Retrieving media settings for port {} speed {} num_lanes {}, using key {}".format(logical_port_name, port_speed, lane_count, key))
-        media_dict = get_media_settings_value(physical_port, key)
+        payload = resolve_media_settings_for_db(
+            physical_port, key, lane_count, subport_num, gearbox_line_lane_count
+        )
 
-        if len(media_dict) == 0:
+        if not payload:
             helper_logger.log_info("Error in obtaining media setting for {}".format(logical_port_name))
             return
 
-        fvs = swsscommon.FieldValuePairs(len(media_dict))
+        fvs = swsscommon.FieldValuePairs(len(payload))
 
         index = 0
         helper_logger.log_notice("Publishing SI setting for port {} in APP_DB:".format(logical_port_name))
-        for media_key in media_dict:
-            if type(media_dict[media_key]) is dict:
-                if "gb_line" in media_key:
-                    lane_count_si = gearbox_lanes_dict[logical_port_name]
-                else:
-                    lane_count_si = lane_count
-                val_str = get_serdes_si_setting_val_str(media_dict[media_key], lane_count_si, subport_num)
-            else:
-                val_str = media_dict[media_key]
+        for media_key, val_str in payload.items():
             helper_logger.log_notice("{}:({},{}) ".format(index, str(media_key), str(val_str)))
             fvs[index] = (str(media_key), str(val_str))
             index += 1


### PR DESCRIPTION
HLD: https://github.com/sonic-net/SONiC/pull/2173

sonic-swss side change: https://github.com/sonic-net/sonic-swss/pull/3764

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Add support for custom serdes attrs [SAI_PORT_SERDES_ATTR_CUSTOM_COLLECTION](https://github.com/opencomputeproject/SAI/pull/2156)

In media_settings.json, custom attributes can be defined by using `CUSTOM:` as prefix, and existing parsing logic/format will be reused.

Example media_settings.json snippet
```
                    "CUSTOM:ABC": {
                        "lane0": "0x1",
                        "lane1": "0x1",
                        "lane2": "0x1",
                        "lane3": "0x1",
                        "lane4": "0x1",
                        "lane5": "0x1",
                        "lane6": "0x1",
                        "lane7": "0x1"
                    },
                    "CUSTOM:XYZ": {
                        "lane0": "0x10",
                        "lane1": "0x10",
                        "lane2": "0x10",
                        "lane3": "0x10",
                        "lane4": "0x10",
                        "lane5": "0x10",
                        "lane6": "0x10",
                        "lane7": "0x10"
                    },
                    "CUSTOM:XXX": {
                        "lane0": "0x7",
                        "lane1": "0x7",
                        "lane2": "0x7",
                        "lane3": "0x7",
                        "lane4": "0x7",
                        "lane5": "0x7",
                        "lane6": "0x7",
                        "lane7": "0x7"
                    },
``` 


#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Tested end-to-end xcvrd->OA->SAI/SDK on 8-hostlanes optics with both non-breakout and breakout modes.

#### Additional Information (Optional)
