### PR TITLE
Added regex parsing to optics si settings parser

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -4595,3 +4595,138 @@ def wait_until(total_wait_time, interval, call_back, *args, **kwargs):
         time.sleep(interval)
         wait_time += interval
     return False
+
+class TestOpticSiParser(object):
+    def test_match_optics_si_key_regex_error(self):
+        """Test _match_optics_si_key with invalid regex pattern (lines 31-32, 34)"""
+        from xcvrd.xcvrd_utilities.optics_si_parser import _match_optics_si_key
+        
+        # Test with invalid regex pattern that causes re.error
+        dict_key = "[invalid regex"  # Unclosed bracket causes regex error
+        key = "VENDOR-1234"
+        vendor_name_str = "VENDOR"
+        
+        # Should fall back to string comparison and return True for exact match
+        result = _match_optics_si_key(dict_key, key, vendor_name_str)
+        assert result == False  # No exact string match
+        
+        # Test with exact string match after regex error
+        result = _match_optics_si_key(dict_key, dict_key, vendor_name_str)
+        assert result == True  # Exact string match
+
+    def test_match_optics_si_key_fallback_string_match(self):
+        """Test _match_optics_si_key fallback string comparison (line 37)"""
+        from xcvrd.xcvrd_utilities.optics_si_parser import _match_optics_si_key
+        
+        # Test with invalid regex that falls back to string comparison
+        dict_key = "[invalid"
+        key = "VENDOR-1234"
+        vendor_name_str = "VENDOR"
+        
+        # Test exact key match
+        result = _match_optics_si_key(key, key, vendor_name_str)
+        assert result == True
+        
+        # Test vendor name match
+        result = _match_optics_si_key(vendor_name_str, key, vendor_name_str)
+        assert result == True
+        
+        # Test split key match
+        result = _match_optics_si_key("VENDOR", key, vendor_name_str)
+        assert result == True
+
+    def test_get_port_media_settings_speed_key_missing(self):
+        """Test _get_port_media_settings when SPEED_KEY not in optics_si_dict (line 126)"""
+        from xcvrd.xcvrd_utilities.optics_si_parser import _get_port_media_settings
+        import xcvrd.xcvrd_utilities.optics_si_parser as parser
+        
+        original_dict = parser.g_optics_si_dict
+        parser.g_optics_si_dict = {
+            'PORT_MEDIA_SETTINGS': {
+                '5': {
+                    # Missing SPEED_KEY (25G_SPEED)
+                }
+            }
+        }
+        
+        try:
+            result = _get_port_media_settings(5, 25, "VENDOR-1234", "VENDOR", {'default': 'value'})
+            assert result == {'default': 'value'}
+        finally:
+            parser.g_optics_si_dict = original_dict
+
+    def test_get_module_vendor_key_api_none(self):
+        """Test get_module_vendor_key when API is None (line 152)"""
+        from xcvrd.xcvrd_utilities.optics_si_parser import get_module_vendor_key
+        
+        # Mock SFP with None API
+        mock_sfp = MagicMock()
+        mock_sfp.get_xcvr_api.return_value = None
+        
+        result = get_module_vendor_key(1, mock_sfp)
+        assert result is None
+
+    def test_get_module_vendor_key_vendor_name_none(self):
+        """Test get_module_vendor_key when vendor name is None"""
+        from xcvrd.xcvrd_utilities.optics_si_parser import get_module_vendor_key
+        
+        # Mock API with None vendor name
+        mock_api = MagicMock()
+        mock_api.get_manufacturer.return_value = None
+        mock_sfp = MagicMock()
+        mock_sfp.get_xcvr_api.return_value = mock_api
+        
+        result = get_module_vendor_key(1, mock_sfp)
+        assert result is None
+
+    def test_get_module_vendor_key_vendor_pn_none(self):
+        """Test get_module_vendor_key when vendor part number is None"""
+        from xcvrd.xcvrd_utilities.optics_si_parser import get_module_vendor_key
+        
+        # Mock API with None vendor part number
+        mock_api = MagicMock()
+        mock_api.get_manufacturer.return_value = "VENDOR"
+        mock_api.get_model.return_value = None
+        mock_sfp = MagicMock()
+        mock_sfp.get_xcvr_api.return_value = mock_api
+        
+        result = get_module_vendor_key(1, mock_sfp)
+        assert result is None
+
+    def test_load_optics_si_settings_no_file(self):
+        """Test load_optics_si_settings when no file exists"""
+        from xcvrd.xcvrd_utilities.optics_si_parser import load_optics_si_settings
+        
+        with patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', 
+                return_value=('/nonexistent/platform', '/nonexistent/hwsku')):
+            with patch('os.path.isfile', return_value=False):
+                result = load_optics_si_settings()
+                assert result == {}
+
+    def test_optics_si_present_empty_dict(self):
+        """Test optics_si_present when global dict is empty"""
+        from xcvrd.xcvrd_utilities.optics_si_parser import optics_si_present
+        import xcvrd.xcvrd_utilities.optics_si_parser as parser
+        
+        original_dict = parser.g_optics_si_dict
+        parser.g_optics_si_dict = {}
+        
+        try:
+            result = optics_si_present()
+            assert result == False
+        finally:
+            parser.g_optics_si_dict = original_dict
+
+    def test_optics_si_present_with_data(self):
+        """Test optics_si_present when global dict has data"""
+        from xcvrd.xcvrd_utilities.optics_si_parser import optics_si_present
+        import xcvrd.xcvrd_utilities.optics_si_parser as parser
+        
+        original_dict = parser.g_optics_si_dict
+        parser.g_optics_si_dict = {'some': 'data'}
+        
+        try:
+            result = optics_si_present()
+            assert result == True
+        finally:
+            parser.g_optics_si_dict = original_dict

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/optics_si_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/optics_si_parser.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 
 from sonic_py_common import device_info, syslogger
 from xcvrd import xcvrd
@@ -9,21 +10,53 @@ g_optics_si_dict = {}
 SYSLOG_IDENTIFIER = "xcvrd"
 helper_logger = syslogger.SysLogger(SYSLOG_IDENTIFIER, enable_runtime_config=True)
 
-def get_optics_si_settings_value(physical_port, lane_speed, key, vendor_name_str):
+def _match_optics_si_key(dict_key, key, vendor_name_str):
+    """
+    Helper function to match optics SI key using regex patterns or string comparison
+
+    Args:
+        dict_key: Key from optics SI settings (can be regex pattern)
+        key: Vendor key to match (e.g., "ABCDE-1234")
+        vendor_name_str: Vendor name string (e.g., "ABCDE")
+
+    Returns:
+        True if match found, False otherwise
+    """
+    try:
+        # Use re.fullmatch to match the entire string with regex patterns
+        # This supports patterns like "ABCDE-(1234|56789)"
+        if (re.fullmatch(dict_key, key) or \
+            re.fullmatch(dict_key, key.split('-')[0]) or \
+            re.fullmatch(dict_key, vendor_name_str)):
+            return True
+    except re.error:
+        # If regex pattern is invalid, fall back to simple string comparison
+        if (dict_key == key or \
+            dict_key == key.split('-')[0] or \
+            dict_key == vendor_name_str):
+            return True
+    return False
+
+def _get_global_media_settings(physical_port, lane_speed, key, vendor_name_str):
+    """
+    Get optics SI settings from global media settings
+
+    Args:
+        physical_port: Physical port number
+        lane_speed: Lane speed value
+        key: Vendor key to match
+        vendor_name_str: Vendor name string
+
+    Returns:
+        Tuple of (settings_dict, default_dict)
+    """
     GLOBAL_MEDIA_SETTINGS_KEY = 'GLOBAL_MEDIA_SETTINGS'
-    PORT_MEDIA_SETTINGS_KEY = 'PORT_MEDIA_SETTINGS'
     DEFAULT_KEY = 'Default'
     SPEED_KEY = str(lane_speed) + 'G_SPEED'
     RANGE_SEPARATOR = '-'
     COMMA_SEPARATOR = ','
     default_dict = {}
     optics_si_dict = {}
-
-    # Keys under global media settings can be a list or range or list of ranges
-    # of physical port numbers. Below are some examples
-    # 1-32
-    # 1,2,3,4,5
-    # 1-4,9-12
 
     if GLOBAL_MEDIA_SETTINGS_KEY in g_optics_si_dict:
         for keys in g_optics_si_dict[GLOBAL_MEDIA_SETTINGS_KEY]:
@@ -42,18 +75,35 @@ def get_optics_si_settings_value(physical_port, lane_speed, key, vendor_name_str
                 if xcvrd.check_port_in_range(keys, physical_port):
                     optics_si_dict = g_optics_si_dict[GLOBAL_MEDIA_SETTINGS_KEY][keys]
 
-            key_dict = {}
             if SPEED_KEY in optics_si_dict:
-                if key in optics_si_dict[SPEED_KEY]:
-                    key_dict = optics_si_dict[SPEED_KEY]
-                    return  key_dict[key]
-                elif vendor_name_str in optics_si_dict[SPEED_KEY]:
-                    key_dict = optics_si_dict[SPEED_KEY]
-                    return  key_dict[vendor_name_str]
-                elif DEFAULT_KEY in optics_si_dict[SPEED_KEY]:
-                    key_dict = optics_si_dict[SPEED_KEY]
-                    default_dict = key_dict[DEFAULT_KEY]
+                # Iterate through each key in optics_si_dict[SPEED_KEY] and use regex matching
+                for dict_key in optics_si_dict[SPEED_KEY].keys():
+                    if _match_optics_si_key(dict_key, key, vendor_name_str):
+                        return optics_si_dict[SPEED_KEY][dict_key], default_dict
 
+                # If no match found, try default
+                if DEFAULT_KEY in optics_si_dict[SPEED_KEY]:
+                    default_dict = optics_si_dict[SPEED_KEY][DEFAULT_KEY]
+
+    return None, default_dict
+
+def _get_port_media_settings(physical_port, lane_speed, key, vendor_name_str, default_dict):
+    """
+    Get optics SI settings from port-specific media settings
+
+    Args:
+        physical_port: Physical port number
+        lane_speed: Lane speed value
+        key: Any key to match
+        vendor_name_str: Vendor name string
+        default_dict: Default settings from global media settings
+
+    Returns:
+        Settings dictionary or default_dict
+    """
+    PORT_MEDIA_SETTINGS_KEY = 'PORT_MEDIA_SETTINGS'
+    DEFAULT_KEY = 'Default'
+    SPEED_KEY = str(lane_speed) + 'G_SPEED'
     optics_si_dict = {}
 
     if PORT_MEDIA_SETTINGS_KEY in g_optics_si_dict:
@@ -61,6 +111,7 @@ def get_optics_si_settings_value(physical_port, lane_speed, key, vendor_name_str
             if int(keys) == physical_port:
                 optics_si_dict = g_optics_si_dict[PORT_MEDIA_SETTINGS_KEY][keys]
                 break
+
         if len(optics_si_dict) == 0:
             if len(default_dict) != 0:
                 return default_dict
@@ -68,21 +119,41 @@ def get_optics_si_settings_value(physical_port, lane_speed, key, vendor_name_str
                 helper_logger.log_error("Error: No values for physical port '{}'".format(physical_port))
             return {}
 
-        key_dict = {}
         if SPEED_KEY in optics_si_dict:
-            if key in optics_si_dict[SPEED_KEY]:
-                key_dict = optics_si_dict[SPEED_KEY]
-                return  key_dict[key]
-            elif vendor_name_str in optics_si_dict[SPEED_KEY]:
-                key_dict = optics_si_dict[SPEED_KEY]
-                return  key_dict[vendor_name_str]
-            elif DEFAULT_KEY in optics_si_dict[SPEED_KEY]:
-                key_dict = optics_si_dict[SPEED_KEY]
-                default_dict = key_dict[DEFAULT_KEY]
+            # Iterate through each key in optics_si_dict[SPEED_KEY] and use regex matching
+            for dict_key in optics_si_dict[SPEED_KEY].keys():
+                if _match_optics_si_key(dict_key, key, vendor_name_str):
+                    return optics_si_dict[SPEED_KEY][dict_key]
+
+            # If no match found, try default
+            if DEFAULT_KEY in optics_si_dict[SPEED_KEY]:
+                return optics_si_dict[SPEED_KEY][DEFAULT_KEY]
             elif len(default_dict) != 0:
                 return default_dict
 
     return default_dict
+
+def get_optics_si_settings_value(physical_port, lane_speed, key, vendor_name_str):
+    """
+    Get optics SI settings value for the given parameters
+
+    Args:
+        physical_port: Physical port number
+        lane_speed: Lane speed value
+        key: Any key to match
+        vendor_name_str: Vendor name string
+
+    Returns:
+        Settings dictionary
+    """
+    # Try to get settings from global media settings first
+    global_settings, default_dict = _get_global_media_settings(physical_port, lane_speed, key, vendor_name_str)
+    if global_settings is not None:
+        return global_settings
+
+    # If not found in global settings, try port-specific settings
+    port_settings = _get_port_media_settings(physical_port, lane_speed, key, vendor_name_str, default_dict)
+    return port_settings
 
 def get_module_vendor_key(physical_port, sfp):
     api = sfp.get_xcvr_api()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Added regex parsing to optics si settings parser
Refactored the code to make more readable 

#### Motivation and Context
Some platform may need per port or range of ports that needs different SI settings on the module. Adding a regex parsing in vendor part number helps to minimize the change in optics_si_settings.json

#### How Has This Been Tested?
Validated this change on platform already using GLOBAL_MEDIA_SETTINGS
Ensured the parser successfully parsed the SI settings for the required platform and optics Vendor name and PN.

#### Additional Information (Optional)
