### PR TITLE
Add support for LPO in media_settings_parser

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -4686,14 +4686,14 @@ class TestXcvrdScript(object):
 
         # For the case of extended media type matching enabled for LPO:
         media_settings_g_dict = {
-            ENABLE_EXTENDED_MEDIA_TYPE_MATCHING: [EXTENDED_MEDIA_OPTICAL_LPO]
+            ENABLE_EXTENDED_MEDIA_TYPE_MATCHING: [MEDIA_LPO]
         }
 
         # Test LPO module
         with patch('xcvrd.xcvrd_utilities.media_settings_parser.g_dict', media_settings_g_dict):
             with patch('xcvrd.xcvrd_utilities.media_settings_parser.get_is_copper', return_value=False):
                 with patch('xcvrd.xcvrd_utilities.media_settings_parser.get_is_lpo', return_value=True):
-                    assert media_settings_parser.get_media_type(physical_port) == EXTENDED_MEDIA_OPTICAL_LPO
+                    assert media_settings_parser.get_media_type(physical_port) == MEDIA_LPO
 
         # Test non-LPO optical module
         with patch('xcvrd.xcvrd_utilities.media_settings_parser.g_dict', media_settings_g_dict):

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -29,7 +29,7 @@ LANE_SPEED_DEFAULT_KEY = LANE_SPEED_KEY_PREFIX + DEFAULT_KEY
 MEDIA_COPPER = 'COPPER'
 MEDIA_OPTICAL = 'OPTICAL'
 # Extended media types:
-EXTENDED_MEDIA_OPTICAL_LPO = MEDIA_OPTICAL + '_LPO'
+MEDIA_LPO = 'LPO'
 
 # This is a top-level key in media_settings.json that can be added to enable
 # matching extended media types in addition to COPPER and OPTICAL. Its value is
@@ -120,8 +120,8 @@ def get_media_type(physical_port):
         return MEDIA_COPPER
 
     # For optical transceivers:
-    if is_extended_media_type_enabled(EXTENDED_MEDIA_OPTICAL_LPO) and get_is_lpo(physical_port):
-        return EXTENDED_MEDIA_OPTICAL_LPO
+    if is_extended_media_type_enabled(MEDIA_LPO) and get_is_lpo(physical_port):
+        return MEDIA_LPO
     return MEDIA_OPTICAL
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

dependency: https://github.com/sonic-net/sonic-platform-common/pull/599

#### Description
<!--
     Describe your changes in detail
-->

LPO (Linear Pluggable Optics) is a new type of optical module without DSP, in which case the role of DSP (retiming/etc) is offloaded to host/NPU side, which generally might require different NPU SI settings to achieve good signal quality compared to today's DSP-based optics.

1. Today's `medium_lane_speed_key` in media_settings.json only supports two media_types OPTICAL and COPPER, additionally LPO as (extended) media_type is needed.
2. To achieve backward compatibility on platforms which don't want to distinguish between DSP-based optics and LPO, have optional flag  ENABLE_EXTENDED_MEDIA_TYPE_MATCHING in media_settings.json: only distinguish between DSP-based optics and LPO in the case of this flag being set.
3. This infra is extensible: in the future, new media_types (in addition to OPTICAL, COPPER, OPTICAL_LPO) can be easily added and enabled optionally in ENABLE_EXTENDED_MEDIA_TYPE_MATCHING.

Example media_settings.json:
```
{
    "ENABLE_EXTENDED_MEDIA_TYPE_MATCHING": [
        “OPTICAL_LPO”
    ],
    "GLOBAL_MEDIA_SETTINGS": {
        "0-15,48-63": {
            “OPTICAL100": {
...
            “OPTICAL_LPO100": {
...
            "COPPER100": {
...
```

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->


#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
