### PR TITLE
Fix: Handle failure when getting platform device info during pcied init

### DIFF
--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -48,10 +48,10 @@ def load_platform_pcieutil():
     _platform_pcieutil = None
 
     try:
-       (platform_path, _) = device_info.get_paths_to_platform_and_hwsku_dirs()
-    except Exception as e:
-       log.log_error(f"Unable to get device info from Platform : {type(e).__name__} : {e}")
-       return _platform_pcieutil
+        (platform_path, _) = device_info.get_paths_to_platform_and_hwsku_dirs()
+    except (OSError, TypeError) as e:
+        log.log_error(f"Unable to get device info from Platform : {type(e).__name__} : {e}")
+        return _platform_pcieutil
 
     try:
         from sonic_platform.pcie import Pcie

--- a/sonic-pcied/tests/test_pcied.py
+++ b/sonic-pcied/tests/test_pcied.py
@@ -64,11 +64,11 @@ def test_load_platform_pcieutil():
             mock_log.log_error.assert_not_called()
 
         # Case 2: Exception when getting platform path
-        with patch('pcied.device_info.get_paths_to_platform_and_hwsku_dirs', side_effect=Exception("Platform info not available")):
+        with patch('pcied.device_info.get_paths_to_platform_and_hwsku_dirs', side_effect=TypeError("Platform info not available")):
             result = pcied.load_platform_pcieutil()
 
             assert result is None
-            mock_log.log_error.assert_called_once_with("Unable to get device info from Platform : Exception : Platform info not available")
+            mock_log.log_error.assert_called_once_with("Unable to get device info from Platform : TypeError : Platform info not available")
 
 
     # Cases 3-5: Test with /tmp as platform path


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

#### Description
In some scenarios during `pcied` initialization, the call to `load_platform_pcieutil()` can fail if the platform directory is missing or the HWSKU value cannot be retrieved. Specifically, this results in a `TypeError` being raised by `get_paths_to_platform_and_hwsku_dirs()` function, which causes the pcied daemon to exit unexpectedly.

This change adds exception handling around the platform info loading logic. If an error occurs, the exception is logged with its type and message, and the daemon exits gracefully with `error code 2 (PCIEUTIL_LOAD_ERROR).` This allows `supervisord` to detect the failure and automatically attempt to restart the daemon.

#### Motivation and Context
For example, if there is any exception in Redis connection or the Redis requests fails in line [`L70`](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-py-common/sonic_py_common/device_info.py#L70) when fetching the platform info (HWSKU) from the database, it will just silently return `None` and the pcied initialization fails because the `get_paths_to_platform_and_hwsku_dirs()` will raise a `TypeError` due to `NoneType` being passed to the `join()` function. This is the traceback which gets generated in the logs :
```
2025 Oct 14 19:58:52.644056 vlab-01 INFO pmon#supervisord 2025-10-14 19:58:52,643 INFO spawned: 'pcied' with pid 70
2025 Oct 14 19:58:52.728168 vlab-01 INFO pmon#supervisord: pcied Traceback (most recent call last):
2025 Oct 14 19:58:52.728252 vlab-01 INFO pmon#supervisord: pcied   File "/usr/local/bin/pcied", line 269, in <module>
2025 Oct 14 19:58:52.728398 vlab-01 INFO pmon#supervisord: pcied     sys.exit(main())
2025 Oct 14 19:58:52.728439 vlab-01 INFO pmon#supervisord: pcied              ^^^^^^
2025 Oct 14 19:58:52.728494 vlab-01 INFO pmon#supervisord: pcied   File "/usr/local/bin/pcied", line 257, in main
2025 Oct 14 19:58:52.728599 vlab-01 INFO pmon#supervisord: pcied     pcied = DaemonPcied(SYSLOG_IDENTIFIER)
2025 Oct 14 19:58:52.728658 vlab-01 INFO pmon#supervisord: pcied             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025 Oct 14 19:58:52.728733 vlab-01 INFO pmon#supervisord: pcied   File "/usr/local/bin/pcied", line 94, in __init__
2025 Oct 14 19:58:52.728801 vlab-01 INFO pmon#supervisord: pcied     platform_pcieutil = load_platform_pcieutil()
2025 Oct 14 19:58:52.728827 vlab-01 INFO pmon#supervisord: pcied                         ^^^^^^^^^^^^^^^^^^^^^^^^
2025 Oct 14 19:58:52.728906 vlab-01 INFO pmon#supervisord: pcied   File "/usr/local/bin/pcied", line 49, in load_platform_pcieutil
2025 Oct 14 19:58:52.729117 vlab-01 INFO pmon#supervisord: pcied     (platform_path, _) = device_info.get_paths_to_platform_and_hwsku_dirs()
2025 Oct 14 19:58:52.729221 vlab-01 INFO pmon#supervisord: pcied                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025 Oct 14 19:58:52.729221 vlab-01 INFO pmon#supervisord: pcied   File "/usr/local/lib/python3.11/dist-packages/sonic_py_common/device_info.py", line 414, in get_paths_to_platform_and_hwsku_dirs
2025 Oct 14 19:58:52.729221 vlab-01 INFO pmon#supervisord: pcied     hwsku_path = os.path.join(platform_path, hwsku)
2025 Oct 14 19:58:52.729233 vlab-01 INFO pmon#supervisord: pcied                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025 Oct 14 19:58:52.729246 vlab-01 INFO pmon#supervisord: pcied   File "<frozen posixpath>", line 90, in join
2025 Oct 14 19:58:52.729246 vlab-01 INFO pmon#supervisord: pcied   File "<frozen genericpath>", line 152, in _check_arg_types
2025 Oct 14 19:58:52.729254 vlab-01 INFO pmon#supervisord: pcied TypeError: join() argument must be str, bytes, or os.PathLike object, not 'NoneType'
```

#### How Has This Been Tested?
The change was tested locally by simulating a Redis DB connection failure in [`device_info.py`](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-py-common/sonic_py_common/device_info.py#L70) file, which results in a failure to retrieve platform or HWSKU information. With this fix in place, the error is now properly caught and logged, and `pcied` exits gracefully with the appropriate `error code 2`. So, the `supervisord` detects the failure and attempts to restart the daemon, as confirmed by the logs shown below : 
```
2025 Oct 14 21:54:18.031325 vlab-01 INFO pmon#supervisord 2025-10-14 21:54:18,030 INFO spawned: 'pcied' with pid 745
2025 Oct 14 21:54:18.120928 vlab-01 ERR pmon#pcied: Unable to get device info from Platform : TypeError : join() argument must be str, bytes, or os.PathLike object, not 'NoneType'
2025 Oct 14 21:54:18.131311 vlab-01 INFO pmon#supervisord 2025-10-14 21:54:18,130 WARN exited: pcied (exit status 2; not expected)
2025 Oct 14 21:54:19.152355 vlab-01 INFO pmon#supervisord 2025-10-14 21:54:19,151 INFO spawned: 'pcied' with pid 746
2025 Oct 14 21:54:19.241457 vlab-01 ERR pmon#pcied: Unable to get device info from Platform : TypeError : join() argument must be str, bytes, or os.PathLike object, not 'NoneType'
2025 Oct 14 21:54:19.253270 vlab-01 INFO pmon#supervisord 2025-10-14 21:54:19,252 WARN exited: pcied (exit status 2; not expected)
2025 Oct 14 21:54:21.280758 vlab-01 INFO pmon#supervisord 2025-10-14 21:54:21,280 INFO spawned: 'pcied' with pid 747
2025 Oct 14 21:54:21.368364 vlab-01 ERR pmon#pcied: Unable to get device info from Platform : TypeError : join() argument must be str, bytes, or os.PathLike object, not 'NoneType'
2025 Oct 14 21:54:21.380512 vlab-01 INFO pmon#supervisord 2025-10-14 21:54:21,379 WARN exited: pcied (exit status 2; not expected)
2025 Oct 14 21:54:24.413368 vlab-01 INFO pmon#supervisord 2025-10-14 21:54:24,412 INFO spawned: 'pcied' with pid 748
2025 Oct 14 21:54:24.498461 vlab-01 ERR pmon#pcied: Unable to get device info from Platform : TypeError : join() argument must be str, bytes, or os.PathLike object, not 'NoneType'
2025 Oct 14 21:54:24.510341 vlab-01 INFO pmon#supervisord 2025-10-14 21:54:24,509 WARN exited: pcied (exit status 2; not expected)
```

#### Additional Information (Optional)
