### PR TITLE
Keep track of per module DPInitPending state software to work around transceiver firmware issues

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -2348,6 +2348,7 @@ class TestXcvrdScript(object):
         mock_get_status_tbl = MagicMock()
         mock_get_status_tbl.set = MagicMock()
         task.xcvr_table_helper.get_status_sw_tbl.return_value = mock_get_status_tbl
+        task.port_dict['Ethernet0'] = dict(asic_id=0)
         task.update_port_transceiver_status_table_sw_cmis_state("Ethernet0", CMIS_STATE_INSERTED)
         assert mock_get_status_tbl.set.call_count == 1
 


### PR DESCRIPTION
Certain transceiver firmwares clear DPInitPending on other datapaths when setting it for currently transitioning datapaths. This requires keeping a track of DPInitPending state in software so that the config loop does not fail when two datapaths in a module are being configured in an interleaved manner.

<!-- Provide a general summary of your changes in the Title above -->

#### Description
Software state is maintained for the datapaths undergoing initialization and a second data path on a module is not configured when a different datapath is undergoing initialization. This serializes the initialization and does not cause the firmware to overwrite bits in the `DpInitPending` register.

When a datapath enters the `CMIS_INSERTED` or `CMIS_FAILED` state or if the datapath is configured successfully, the software state maintained is cleared to allow other datapaths on the transceiver to be initialized.

#### Motivation and Context
During reboot + link up testing, certain transceivers entered CMIS failed state due to `EthernetX: datapath init not pending`. Upon investigation it was found that affected transceivers' firmware clear a prior `DpInitPending` when it needs to be set on a different datapath leading to `xcvrd` missing the `DpInitPending` check and setting state to failed.

#### How Has This Been Tested?
Successfully ran 500+ reboot + link up tests with transceivers initializing every single time. Previously, links would fail to come up within 10 iterations.

#### Additional Information (Optional)
