### PR TITLE
Fix test failures in test_thermalctld.py by passing arguments to ThermalControlDaemon()

### DIFF
--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -813,7 +813,7 @@ class TestThermalControlDaemon(object):
             
             # ThermalControlDaemon should raise SystemExit with CHASSIS_GET_ERROR code when chassis initialization fails
             with pytest.raises(SystemExit) as exc_info:
-                daemon_thermalctld = thermalctld.ThermalControlDaemon()
+                daemon_thermalctld = thermalctld.ThermalControlDaemon(5, 60, 30)
             
             # Verify it exits with the correct error code
             assert exc_info.value.code == thermalctld.CHASSIS_GET_ERROR
@@ -836,7 +836,7 @@ class TestThermalControlDaemon(object):
             mock_platform_instance.get_chassis.return_value = mock_chassis
             mock_platform_class.return_value = mock_platform_instance
             
-            daemon_thermalctld = thermalctld.ThermalControlDaemon()
+            daemon_thermalctld = thermalctld.ThermalControlDaemon(5, 60, 30)
             
             # Verify chassis was set correctly
             assert daemon_thermalctld.chassis is mock_chassis


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Fix test failures in test_thermalctld.py, that was introduced in #652. `ThermalControlDaemon.__init__()` now requires 3 arguments, so we have to pass them.


#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

Fixes https://github.com/sonic-net/sonic-platform-daemons/issues/699, which will allow Azure Pipelines to pass.

`test_get_chassis_exception` and `test_get_chassis_success` were failing with the following error:
```
TypeError: ThermalControlDaemon.__init__() missing 3 required positional arguments: 'thermal_monitor_initial_interval', 'thermal_monitor_update_interval', and 'thermal_monitor_update_elapsed_threshold' 
```

because they didn't pass thermal-monitor-related args to `ThermalControlDaemon()`, which were introduced in https://github.com/sonic-net/sonic-platform-daemons/pull/635.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Ran unit tests locally and passed.

#### Additional Information (Optional)
