### PR TITLE
psud: Adding Redis Pipeline for performance improvement

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -460,7 +460,7 @@ class DaemonPsud(daemon_base.DaemonBase):
         if self.first_run:
             self.first_run = False
 
-        # flush any remaining requests on the pipeline to STAT_DB at end of every cycle
+        # flush any remaining requests on the pipeline to STATE_DB at end of every cycle
         try:
             self.statedb_redisPipeline.flush()
         except Exception as e:

--- a/sonic-psud/tests/mocked_libs/swsscommon/swsscommon.py
+++ b/sonic-psud/tests/mocked_libs/swsscommon/swsscommon.py
@@ -15,11 +15,10 @@ class RedisPipeline:
     def flush(self):
         # Mock flush operation - just clear the queue
         self.queue.clear()
-        pass
 
 class Table:
-    def __init__(self,  db_or_pipeline, table_name, buffered=False):
-        # Mock to support both both constructors (db, table_name) and (pipeline, table_name, buffered)
+    def __init__(self, db_or_pipeline, table_name, buffered=False):
+        # Mock to support both constructors (db, table_name) and (pipeline, table_name, buffered)
         self.table_name = table_name
         self.mock_dict = {}
 

--- a/sonic-psud/tests/test_DaemonPsud.py
+++ b/sonic-psud/tests/test_DaemonPsud.py
@@ -103,12 +103,14 @@ class TestDaemonPsud(object):
         daemon_psud.update_psu_data = mock.MagicMock()
         daemon_psud._update_led_color = mock.MagicMock()
         daemon_psud.update_psu_chassis_info = mock.MagicMock()
+        daemon_psud.statedb_redisPipeline = mock.MagicMock()
 
         daemon_psud.run()
         assert daemon_psud.first_run is False
+        daemon_psud.statedb_redisPipeline.flush.assert_called_once()
 
         # Test Redis pipeline flush exception scenario
-        daemon_psud.statedb_redisPipeline.flush = mock.MagicMock(side_effect=Exception("Flush error"))
+        daemon_psud.statedb_redisPipeline.flush.side_effect = Exception("Flush error")
         daemon_psud.log_error = mock.MagicMock()
 
         result = daemon_psud.run()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
This PR introduces significant performance improvements to the PSU daemon by optimizing Redis database operations through batching. The key change is Batching. 

The daemon now uses `RedisPipeline`, which instead of sending 1 request separately each time, batches multiple Redis request together and sends them. Also flushes any unfilled batches at the end of each monitoring cycle if any requests still remain. This reduces the number of round trips to the Redis database.

Additionally, existing tests were updated to include above change changes and to mock the new `RedisPipeline` and `FieldValuePairs` constructors. 


#### Motivation and Context
**Why RedisPipeline and Batching :**
Currently, the psud daemon creates and maintains a separate db connection internally for each table used and an additional initial connection to state_db as shown here [Table Constructor](https://github.com/sonic-net/sonic-swss-common/blob/master/common/table.cpp#L35) and [RedisPipeline Constructor](https://github.com/sonic-net/sonic-swss-common/blob/master/common/redispipeline.h#L30)

So in total we maintain 5 separate Redis database connections in psud (1 connection each for `CHASSIS_INFO_TABLE`, `PSU_INFO_TABLE`, `FAN_INFO_TABLE`, `PHYSICAL_ENTITY_INFO_TABLE` and the initial connection to `STATE_DB`) which is waste of Redis and system resources. Moreover, since psud purely a single process executing all requests in a sequential manner, we don't need multiple connections. Just one connection shared across all the tables is sufficient.

Also in the existing flow, individual `set()` calls are made for each device and their attribute. Rather we can collect all device data in batches using RedisPipeline and then do a single bulk update, which will be faster.

We can also optimize database cleanup operations, where we do multiple individual delete operations in `__del__` method for each table key across all tables. Rather we can also batch the delete operations using RedisPipeline for faster cleanup during daemon shutdown, which will be quick in signal handling and reboot scenarios.

**Overall benefit :**
- Reduced IO network overhead by batching requests
- Reduced Redis and system system resources by reusing the same connection for RedisPipeline rather than having a seperate connection to Redis for each table

#### How Has This Been Tested?
The changes were tested on both virtual and physical platforms. Performance benchmarking was conducted to compare the baseline and the updated implementation, capturing relevant metrics across all database operations.

#### Additional Information (Optional)
