### PR TITLE
[202505] [sff-mgr] Disable SFF manager support for all CMIS transceivers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
     include:
       - '*'
 
-pool: sonic-common
+pool: sonictest
 
 resources:
   containers:

--- a/sonic-xcvrd/xcvrd/sff_mgr.py
+++ b/sonic-xcvrd/xcvrd/sff_mgr.py
@@ -14,6 +14,7 @@ try:
 
     from .xcvrd_utilities.port_event_helper import PortChangeObserver
     from .xcvrd_utilities.xcvr_table_helper import XcvrTableHelper
+    from xcvrd import xcvrd
     from sonic_platform_base.sonic_xcvr.api.public.sff8472 import Sff8472Api
 except ImportError as e:
     raise ImportError(str(e) + " - required module not found")
@@ -348,8 +349,25 @@ class SffManagerTask(threading.Thread):
                     # TRANSCEIVER_INFO table's XCVR_TYPE is not ready, meaning xcvr is not present
                     continue
 
+                # double-check the HW presence before moving forward
+                sfp = self.platform_chassis.get_sfp(pport)
+                if not sfp.get_presence():
+                    self.log_error("{}: module not present!".format(lport))
+                    del self.port_dict[lport][self.XCVR_TYPE]
+                    continue
+                try:
+                    # Skip if XcvrApi is not supported
+                    api = sfp.get_xcvr_api()
+                    if api is None:
+                        self.log_error(
+                            "{}: skipping sff_mgr since no xcvr api!".format(lport))
+                        continue
+                except (AttributeError, NotImplementedError):
+                    # Skip if these essential routines are not available
+                    continue
+
                 # Procced only for QSFP28/QSFP+ transceiver
-                if not (xcvr_type.startswith('QSFP28') or xcvr_type.startswith('QSFP+')):
+                if not (xcvr_type.startswith('QSFP28') or xcvr_type.startswith('QSFP+')) or xcvrd.is_cmis_api(api):
                     continue
 
                 # Handle the case that host_tx_ready value in the local cache hasn't
@@ -403,20 +421,7 @@ class SffManagerTask(threading.Thread):
                     data[self.HOST_TX_READY], host_tx_ready_changed,
                     data[self.ADMIN_STATUS], admin_status_changed))
 
-                # double-check the HW presence before moving forward
-                sfp = self.platform_chassis.get_sfp(pport)
-                if not sfp.get_presence():
-                    self.log_error("{}: module not present!".format(lport))
-                    del self.port_dict[lport][self.XCVR_TYPE]
-                    continue
                 try:
-                    # Skip if XcvrApi is not supported
-                    api = sfp.get_xcvr_api()
-                    if api is None:
-                        self.log_error(
-                            "{}: skipping sff_mgr since no xcvr api!".format(lport))
-                        continue
-
                     # Skip if it's not a paged memory device
                     if api.is_flat_memory():
                         self.log_notice(


### PR DESCRIPTION
Cherry-pick PR for https://github.com/sonic-net/sonic-platform-daemons/pull/710

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
For certain CMIS transceivers which have transceiver type as "QSFP+ or later with CMIS", SFF manager also starts controlling Tx disable in addition to CMIS manager.
Hence, SFF manager needs to skip handling such CMIS transceivers. Following code needs to be modified to addressed this
https://github.com/sonic-net/sonic-platform-daemons/blob/69ce3870c5dcd5ab4d5a6ec0b784da827acb1d0e/sonic-xcvrd/xcvrd/sff_mgr.py#L387-L389

#### Motivation and Context
For certain CMIS transceivers which have transceiver type as "QSFP+ or later with CMIS", the SFF manager was also controlling Tx disable in addition to the CMIS manager. This created a conflict where both managers would attempt to control the same transceiver, leading to potential race conditions and unexpected behavior.

The previous type check only filtered based on the string prefix "QSFP28" or "QSFP+", which would incorrectly include CMIS modules that report as "QSFP+ or later with CMIS".

Added explicit CMIS API check using `common.is_cmis_api()` to the transceiver filtering logic

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
1. Verified CMIS transceivers with "QSFP+ or later with CMIS" type are now properly skipped by SFF manager
2. Confirmed QSFP28 module continue to be handled correctly

**Unrelated change**
The pipeline pool has been updated to sonictest since sonic-common is not supported anymore.

#### Additional Information (Optional)
MSFT ADO - 35947863