### PR TITLE
psud: adding led state change detection mechanism to prevent unnecessary updated to redis

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -296,6 +296,7 @@ class PsuStatus(object):
         self.check_psu_power_threshold = False
         self.power_exceeded_threshold = False
         self.logger = logger
+        self.led_status = NOT_AVAILABLE
 
     def set_presence(self, presence):
         """
@@ -356,6 +357,18 @@ class PsuStatus(object):
             return False
 
         self.power_exceeded_threshold = power_exceeded_threshold
+        return True
+
+    def set_led_status(self, led_status):
+        """
+        Set and cache PSU LED status
+        :param led_status: PSU LED status
+        :return: True if status changed else False
+        """
+        if led_status == self.led_status:
+            return False
+
+        self.led_status = led_status
         return True
 
     def is_ok(self):
@@ -670,10 +683,13 @@ class DaemonPsud(daemon_base.DaemonBase):
             return
 
         for index, psu_status in self.psu_status_dict.items():
-            fvs = swsscommon.FieldValuePairs([
-                ('led_status', str(try_get(psu_status.psu.get_status_led, NOT_AVAILABLE)))
-            ])
-            self.psu_tbl.set(get_psu_key(index), fvs)
+            led_status = try_get(psu_status.psu.get_status_led, NOT_AVAILABLE)
+            led_status_changed = psu_status.set_led_status(led_status)
+            if led_status_changed:
+                fvs = swsscommon.FieldValuePairs([
+                    ('led_status', str(led_status))
+                ])
+                self.psu_tbl.set(get_psu_key(index), fvs)
             self._update_psu_fan_led_status(psu_status.psu, index)
 
     def _update_psu_fan_led_status(self, psu, psu_index):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
This PR introduces improvements to the PSU daemon by preventing overwriting of values to Redis database even when no value has changed by introducing LED status change detection. 

LED status change detection - Adding a `led_status` instance variable to store the last recorded led status color and an instance method `set_led_status` to update and store the led status and return True if status changed else False. This reduces writing this value to PSU_INFO_TABLE every 3 seconds even though there was no change.

Additionally, existing tests were updated to include above change changes.
`test_update_led_color` Updates
 - Tests LED status change detection
 - Verifies DB writes only on status change
 - Comprehensive coverage of state transitions:
     - First run (OFF) → writes
     - No change (OFF→OFF) → no write
     - Change (OFF→GREEN) → writes
     - No change (GREEN→GREEN) → no write
     - change (GREEN→RED) → write
     - change (RED→GREEN) → write

#### Motivation and Context
Every 3 seconds the daemon writes `led_status` fields to Redis even though there isn't much changes during the normal execution. This results in unnecessarily Redis traffic and overwriting values in the database. Instead, we can keep track of this info and update it only when it changes. 

Also, adding an instance variable to the `PsuStatus` class will not be a burden since the value stored will be a class variable [predefined here](https://github.com/sonic-net/sonic-platform-common/blob/master/sonic_platform_base/device_base.py#L16) or [predefined and fetched here](https://github.com/sonic-net/sonic-platform-common/blob/master/sonic_platform_base/psu_base.py#L168) Hence no duplicate memory allocated but rather just be a reference to this class variable which will be stored here.

#### How Has This Been Tested?
The changes were tested on both virtual and physical platforms.

#### Additional Information (Optional)
