### PR TITLE
Enable sff_mgr for all non-cmis txvrs

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -2346,7 +2346,6 @@ class TestXcvrdScript(object):
         mock_xcvr_api.is_flat_memory.call_count = 0
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
-        assert mock_xcvr_api.is_flat_memory.call_count == 1
         assert mock_xcvr_api.tx_disable_channel.call_count == 2
         mock_xcvr_api.is_flat_memory = MagicMock(return_value=False)
 

--- a/sonic-xcvrd/xcvrd/sff_mgr.py
+++ b/sonic-xcvrd/xcvrd/sff_mgr.py
@@ -402,8 +402,8 @@ class SffManagerTask(threading.Thread):
                     # Skip if these essential routines are not available
                     continue
 
-                # Procced only for QSFP28/QSFP+ transceiver
-                if not (xcvr_type.startswith('QSFP28') or xcvr_type.startswith('QSFP+')) or common.is_cmis_api(api):
+                # Proceed only for non-cmis transceiver
+                if common.is_cmis_api(api):
                     continue
 
                 # Handle the case that host_tx_ready value in the local cache hasn't
@@ -458,12 +458,6 @@ class SffManagerTask(threading.Thread):
                     data[self.ADMIN_STATUS], admin_status_changed))
 
                 try:
-                    # Skip if it's not a paged memory device
-                    if api.is_flat_memory():
-                        self.log_notice(
-                            "{}: skipping sff_mgr for flat memory xcvr".format(lport))
-                        continue
-
                     # Skip if it's a copper cable
                     if api.is_copper():
                         self.log_notice(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Enable sff_mgr for all non-cmis modules.  
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Currently only QSFP+ and QSFP28 were supported by sff_mgr. It excluded the 10G SFP/SFP+ modules even if they had API methods required by sff_mgr. This exclusion didn't make sense since there were already checks for `is_copper` and `get_tx_disable_support`. Removed the QSFP+ and QSFP28 check. `is_flat_memory` check was also removed since it was not necessary. 
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
This has been tested on the following module types:
1. SFP/SFP+/SFP28
With this change, the module is set to low power mode once it is shutdown. 
Local DOM:
``` 
MonitorData:
                RXPower: -2.596dBm
                TXBias: 0.238mA
                TXPower: -16.99dBm
                Temperature: 16.918C
                Vcc: 3.354Volts
```
Remote interface DOM:
```
  MonitorData:
                RXPower: -infdBm
                TXBias: 7.866mA
                TXPower: -2.604dBm
                Temperature: 26.797C
                Vcc: 3.349Volts
```
Once it's started, the local tx power and remote rx power is restored. Relevant logs are seen in the syslog as well:
```
2025 Nov 20 21:29:46.832609 STR43-7060x6-512-C17-U10 NOTICE pmon#xcvrd[335]: SFF-PORT-UPDATE: *** ('Ethernet512', 'CONFIG_DB', 'PORT') handle_port_update_event() fvp {'admin_status': 'down', 'alias': 'etp65', 'index': '65', 'lanes': '513', 'speed': '10000', 'subport': '0', 'port_name': 'Ethernet512', 'asic_id': 0, 'op': 'SET'}
2025 Nov 20 21:29:46.853731 STR43-7060x6-512-C17-U10 NOTICE pmon#xcvrd[335]: SFF-MAIN: Ethernet512: xcvr=present(inserted=False), host_tx_ready=true(changed=False), admin_status=down(changed=True)
2025 Nov 20 21:29:46.861393 STR43-7060x6-512-C17-U10 NOTICE pmon#xcvrd[335]: SFF-MAIN: Ethernet512: TX was disabled with lanes mask: 0b1
2025 Nov 20 21:29:46.867028 STR43-7060x6-512-C17-U10 NOTICE pmon#xcvrd[335]: SFF-PORT-UPDATE: *** ('Ethernet512', 'STATE_DB', 'PORT_TABLE') handle_port_update_event() fvp {'host_tx_ready': 'false', 'index': '-1', 'port_name': 'Ethernet512', 'asic_id': 0, 'op': 'SET'}
2025 Nov 20 21:29:46.884154 STR43-7060x6-512-C17-U10 NOTICE pmon#xcvrd[335]: SFF-MAIN: Ethernet512: xcvr=present(inserted=False), host_tx_ready=false(changed=True), admin_status=down(changed=False)
2025 Nov 20 21:29:46.889654 STR43-7060x6-512-C17-U10 NOTICE pmon#xcvrd[335]: SFF-MAIN: Ethernet512: No change is needed for tx_disable value
```

2. 100G QSFP28 or later copper
sff_mgr skipped the module since it's a copper one. 

#### Additional Information (Optional)
ADO: 35811655
