### PR TITLE
Stop the `config_manager` child process on exception in `chassisd`

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -1334,6 +1334,7 @@ class ChassisdDaemon(daemon_base.DaemonBase):
         super(ChassisdDaemon, self).__init__(log_identifier)
 
         self.stop = threading.Event()
+        self.loop_interval = CHASSIS_INFO_UPDATE_PERIOD_SECS
 
         self.platform_chassis = chassis
 
@@ -1438,13 +1439,13 @@ class ChassisdDaemon(daemon_base.DaemonBase):
         try:
             # Start configuration manager task
             if self.smartswitch:
-                config_manager = SmartSwitchConfigManagerTask()
-                config_manager.task_run()
+                self.config_manager = SmartSwitchConfigManagerTask()
+                self.config_manager.task_run()
             elif self.module_updater.supervisor_slot == self.module_updater.my_slot:
-                config_manager = ConfigManagerTask()
-                config_manager.task_run()
+                self.config_manager = ConfigManagerTask()
+                self.config_manager.task_run()
             else:
-                config_manager = None
+                self.config_manager = None
 
             # Start main loop
             self.log_info("Start daemon main loop")
@@ -1453,7 +1454,7 @@ class ChassisdDaemon(daemon_base.DaemonBase):
             if self.smartswitch:
                 self.set_initial_dpu_admin_state()
 
-            while not self.stop.wait(CHASSIS_INFO_UPDATE_PERIOD_SECS):
+            while not self.stop.wait(self.loop_interval):
                 self.module_updater.module_db_update()
                 self.module_updater.check_midplane_reachability()
                 self.module_updater.module_down_chassis_db_cleanup()
@@ -1464,8 +1465,8 @@ class ChassisdDaemon(daemon_base.DaemonBase):
             # If we don't cleanup the config_manager process the chassisd process
             # won't die when an exception occurs.
             # https://github.com/sonic-net/sonic-buildimage/issues/24775
-            if config_manager is not None:
-                config_manager.task_stop()
+            if self.config_manager is not None:
+                self.config_manager.task_stop()
 
         # Delete all the information from DB and then exit
         self.module_updater.deinit()
@@ -1561,7 +1562,7 @@ class DpuChassisdDaemon(ChassisdDaemon):
         # Start main loop
         self.log_info("Start daemon main loop")
 
-        while not self.stop.wait(CHASSIS_INFO_UPDATE_PERIOD_SECS):
+        while not self.stop.wait(self.loop_interval):
             if poll_dpu_state:
                 dpu_updater.update_state()
 

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -1435,32 +1435,37 @@ class ChassisdDaemon(daemon_base.DaemonBase):
                 self.log_error("Chassisd not supported for this platform")
                 sys.exit(CHASSIS_NOT_SUPPORTED)
 
-        # Start configuration manager task
-        if self.smartswitch:
-            config_manager = SmartSwitchConfigManagerTask()
-            config_manager.task_run()
-        elif self.module_updater.supervisor_slot == self.module_updater.my_slot:
-            config_manager = ConfigManagerTask()
-            config_manager.task_run()
-        else:
-            config_manager = None
+        try:
+            # Start configuration manager task
+            if self.smartswitch:
+                config_manager = SmartSwitchConfigManagerTask()
+                config_manager.task_run()
+            elif self.module_updater.supervisor_slot == self.module_updater.my_slot:
+                config_manager = ConfigManagerTask()
+                config_manager.task_run()
+            else:
+                config_manager = None
 
-        # Start main loop
-        self.log_info("Start daemon main loop")
+            # Start main loop
+            self.log_info("Start daemon main loop")
 
-        # Set the initial DPU admin state for SmartSwitch
-        if self.smartswitch:
-            self.set_initial_dpu_admin_state()
+            # Set the initial DPU admin state for SmartSwitch
+            if self.smartswitch:
+                self.set_initial_dpu_admin_state()
 
-        while not self.stop.wait(CHASSIS_INFO_UPDATE_PERIOD_SECS):
-            self.module_updater.module_db_update()
-            self.module_updater.check_midplane_reachability()
-            self.module_updater.module_down_chassis_db_cleanup()
+            while not self.stop.wait(CHASSIS_INFO_UPDATE_PERIOD_SECS):
+                self.module_updater.module_db_update()
+                self.module_updater.check_midplane_reachability()
+                self.module_updater.module_down_chassis_db_cleanup()
 
-        self.log_info("Stop daemon main loop")
+            self.log_info("Stop daemon main loop")
 
-        if config_manager is not None:
-            config_manager.task_stop()
+        finally:
+            # If we don't cleanup the config_manager process the chassisd process
+            # won't die when an exception occurs.
+            # https://github.com/sonic-net/sonic-buildimage/issues/24775
+            if config_manager is not None:
+                config_manager.task_stop()
 
         # Delete all the information from DB and then exit
         self.module_updater.deinit()

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -2063,7 +2063,15 @@ def test_submit_dpu_callback():
 
 def test_chassis_daemon_assertion():
     chassis = MockChassis()
+
+    # Needs to be supervisor slot for config_manager thread to be spawned
+    chassis.get_supervisor_slot = Mock()
+    chassis.get_supervisor_slot.return_value = 0
+    chassis.get_my_slot = Mock()
+    chassis.get_my_slot.return_value = 0
+
     daemon_chassisd = ChassisdDaemon(SYSLOG_IDENTIFIER, chassis)
+
     # Reduce wait time from 10s to 1s to speed up test
     daemon_chassisd.loop_interval=1
 

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -2062,7 +2062,8 @@ def test_submit_dpu_callback():
         mock_set_admin_state_gracefully.assert_not_called()
 
 def test_chassis_daemon_assertion():
-    daemon_chassisd = ChassisdDaemon(SYSLOG_IDENTIFIER)
+    chassis = MockChassis()
+    daemon_chassisd = ChassisdDaemon(SYSLOG_IDENTIFIER, chassis)
     # Reduce wait time from 10s to 1s to speed up test
     daemon_chassisd.loop_interval=1
 


### PR DESCRIPTION
Context is in: https://github.com/sonic-net/sonic-buildimage/issues/24775

TLDR:
`chassisd` process doesn't die when a crash occurs because the `config_manager` child process is still running.
Adding `try/finally` to cleanup the `config_manager` properly when a crash occurs to let `chassisd` die and restart.

Confirmed that if I add an `assert False` after `config_manager` is created I see the `chassisd` process die and restart as expected (previously the process would live on).

Note: When reviewing the diff select `hide whitespaces` to make the diff easier to read.

Cast Request:
- 202405