### PR TITLE
[Xcvrd]Prioritize vendor specific over generic key match

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -236,8 +236,10 @@ def get_media_settings_value(physical_port, key):
                 re.match(dict_key, key[VENDOR_KEY].split('-')[0]) # e.g: 'AMPHENOL-1234'
                 or re.match(dict_key, key[MEDIA_KEY]) ): # e.g: 'QSFP28-40GBASE-CR4-1M'
                 return get_media_settings_for_speed(media_dict[dict_key], key[LANE_SPEED_KEY])
-            elif key[MEDIUM_LANE_SPEED_KEY] in media_dict:
-                return media_dict[key[MEDIUM_LANE_SPEED_KEY]]
+
+        if key[MEDIUM_LANE_SPEED_KEY] in media_dict:
+            return media_dict[key[MEDIUM_LANE_SPEED_KEY]]
+        
         return None
 
     # Keys under global media settings can be a list or range or list of ranges


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Priortize Vendor specific Key over generic key match for media settings.

#### Motivation and Context

There could be a scenario where the media_settings.json may have following keys to match:-

"VENDOR1" : {

},

"VENDOR2" : {

},

"OPTICAL100": {

"


In this case if VENDOR1 key does not match, Xcvrd should move to match VENDOR2. The PR ensures this.


#### How Has This Been Tested?
Tested the scenario where all 3 types of KEYs/VENDORs are present across different ports and ensured the correct media SI settings is published by Xcvrd.

#### Additional Information (Optional)
