### PR TITLE
Revert "Remove the SFP thermal data retrieval in thermalctld"

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -696,6 +696,15 @@ class TemperatureUpdater(logger.Logger):
                     available_thermals.add((thermal, parent_name, thermal_index))
                     self._refresh_temperature_status(parent_name, thermal, thermal_index)
 
+        for sfp_index, sfp in enumerate(self.chassis.get_all_sfps()):
+            parent_name = 'SFP {}'.format(sfp_index + 1)
+            for thermal_index, thermal in enumerate(sfp.get_all_thermals()):
+                if self.task_stopping_event.is_set():
+                    return
+
+                available_thermals.add((thermal, parent_name, thermal_index))
+                self._refresh_temperature_status(parent_name, thermal, thermal_index)
+
         # As there are no modules present in DPU, this IF condition is not updated to consider DPU chassis
         if self.is_chassis_system:
             for module_index, module in enumerate(self.chassis.get_all_modules()):
@@ -707,6 +716,15 @@ class TemperatureUpdater(logger.Logger):
 
                     available_thermals.add((thermal, module_name, thermal_index))
                     self._refresh_temperature_status(module_name, thermal, thermal_index)
+
+                for sfp_index, sfp in enumerate(module.get_all_sfps()):
+                    sfp_name = '{} SFP {}'.format(module_name, sfp_index + 1)
+                    for thermal_index, thermal in enumerate(sfp.get_all_thermals()):
+                        if self.task_stopping_event.is_set():
+                            return
+
+                        available_thermals.add((thermal, sfp_name, thermal_index))
+                        self._refresh_temperature_status(sfp_name, thermal, thermal_index)
 
                 for psu_index, psu in enumerate(module.get_all_psus()):
                     if psu.get_presence():

--- a/sonic-thermalctld/tests/mock_platform.py
+++ b/sonic-thermalctld/tests/mock_platform.py
@@ -440,9 +440,12 @@ class MockChassis(chassis_base.ChassisBase):
     def make_module_thermal(self):
         module = MockModule()
         self._module_list.append(module)
+        sfp = MockSfp()
+        sfp._thermal_list.append(MockThermal())
         psu = MockPsu()
         psu._thermal_list.append(MockThermal())
         fan = MockFan()
+        module._sfp_list.append(sfp)
         module._psu_list.append(psu)
         module._fan_list.append(fan)
         module._thermal_list.append(MockThermal())

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -707,6 +707,26 @@ class TestTemperatureUpdater(object):
         else:
             temperature_updater.log_warning.assert_called_with("Failed to update thermal status for PSU 1 Thermal 1 - Exception('Test message',)")
 
+    def test_update_sfp_thermals(self):
+        chassis = MockChassis()
+        sfp = MockSfp()
+        mock_thermal = MockThermal()
+        sfp._thermal_list.append(mock_thermal)
+        chassis._sfp_list.append(sfp)
+        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
+        temperature_updater.update()
+        assert temperature_updater.log_warning.call_count == 0
+
+        mock_thermal.get_temperature = mock.MagicMock(side_effect=Exception("Test message"))
+        temperature_updater.update()
+        assert temperature_updater.log_warning.call_count == 1
+
+        # TODO: Clean this up once we no longer need to support Python 2
+        if sys.version_info.major == 3:
+            temperature_updater.log_warning.assert_called_with("Failed to update thermal status for SFP 1 Thermal 1 - Exception('Test message')")
+        else:
+            temperature_updater.log_warning.assert_called_with("Failed to update thermal status for SFP 1 Thermal 1 - Exception('Test message',)")
+
     def test_update_thermal_with_exception(self):
         chassis = MockChassis()
         chassis.make_error_thermal()
@@ -737,7 +757,7 @@ class TestTemperatureUpdater(object):
         chassis.set_modular_chassis(True)
         temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
         temperature_updater.update()
-        assert len(temperature_updater.all_thermals) == 2
+        assert len(temperature_updater.all_thermals) == 3
 
         chassis._module_list = []
         temperature_updater.update()


### PR DESCRIPTION
Planning to Revert this PR : sonic-net/sonic-platform-daemons#739

This is because the supporting PR's https://github.com/sonic-net/sonic-snmpagent/pull/365 & https://github.com/sonic-net/sonic-utilities/pull/4232 needed more changes and testing to be backward compatible.

The idea is to update this logic and use redis DB pull from table populated by Transceiver to fill in the optics temperature data instead of reading via  platform API : Changes in this PR  https://github.com/sonic-net/sonic-platform-daemons/pull/747
