### PR TITLE
Xcvrd Refactor 7/13: Refactor CMIS_STATE_DP_DEINIT logic into handle_cmis_dp_deinit_state

### DIFF
--- a/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
+++ b/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
@@ -60,6 +60,7 @@ class CmisManagerTask(threading.Thread):
         self.namespaces = namespaces
         self.platform_chassis = platform_chassis
         self.xcvr_table_helper = XcvrTableHelper(self.namespaces)
+        self._is_fast_reboot_enabled = None
 
     def log_debug(self, message):
         helper_logger.log_debug(message)
@@ -69,6 +70,12 @@ class CmisManagerTask(threading.Thread):
 
     def log_error(self, message):
         helper_logger.log_error(message)
+
+    def is_fast_reboot_enabled(self):
+        """Check if fast reboot is enabled, caching the result"""
+        if self._is_fast_reboot_enabled is None:
+            self._is_fast_reboot_enabled = common.is_fast_reboot_enabled()
+        return self._is_fast_reboot_enabled
 
     def get_asic_id(self, lport):
         return self.port_dict.get(lport, {}).get("asic_id", -1)
@@ -731,7 +738,7 @@ class CmisManagerTask(threading.Thread):
         speed = port_info.get('speed')
         subport = port_info.get('subport')
         appl = port_info.get('appl', 0)
-        is_fast_reboot = common.is_fast_reboot_enabled()
+        is_fast_reboot = self.is_fast_reboot_enabled()
 
         self.port_dict[lport]['appl'] = common.get_cmis_application_desired(api, host_lane_count, speed)
         if self.port_dict[lport]['appl'] is None:
@@ -927,7 +934,7 @@ class CmisManagerTask(threading.Thread):
         subport = port_info.get('subport')
         pport = port_info.get('pport')
         sfp = port_info.get('sfp')
-        is_fast_reboot = common.is_fast_reboot_enabled()
+        is_fast_reboot = self.is_fast_reboot_enabled()
 
         # CMIS expiration and retries
         #


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
This change moves CMIS processing for dp deinit state into its own function. It also caches the result of is_fastboot_enabled.

- Introduced handle_cmis_dp_deinit_state() to encapsulate CMIS_STATE_DP_DEINIT processing.
- Replaced the inlined CMIS_STATE_DP_DEINIT block in process_cmis_state_machine() with a call to the new handler.
- Cache is_fastboot_enabled_result

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
xcvrd has gotten to 4000 lines long. To make things easier, we'd like to refactor it. This is the second PR in a series that aims to do the following:

| Task | PR |
|------|-------------|
| 1) Move functions used across multiple files in xcvrd to utils/common.py | https://github.com/sonic-net/sonic-platform-daemons/pull/654 |
| 2) Move CmisManagerTask into cmis/cmis_manager_task.py |  https://github.com/sonic-net/sonic-platform-daemons/pull/691 |
| 3) Split task_worker into process_single_lport |  https://github.com/sonic-net/sonic-platform-daemons/pull/701 |
| 4) Move cmis logic out of process_single_lport | https://github.com/sonic-net/sonic-platform-daemons/pull/716|
| 5) Add handle_cmis_inserted_state function | https://github.com/sonic-net/sonic-platform-daemons/pull/738 |
| 6) Add handle_cmis_dp_pre_init_check_state function | sonic-net/sonic-platform-daemons#741  |
| 7) Add handle_cmis_dpdeinit_state function | sonic-net/sonic-platform-daemons#748 |

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Transceivers continue to get programmed correctly with links up, unit tests pass

#### Additional Information (Optional)
