### PR TITLE
[Smartswitch] Set initial state before config manager task is up

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -1439,6 +1439,7 @@ class ChassisdDaemon(daemon_base.DaemonBase):
         try:
             # Start configuration manager task
             if self.smartswitch:
+                self.set_initial_dpu_admin_state()
                 self.config_manager = SmartSwitchConfigManagerTask()
                 self.config_manager.task_run()
             elif self.module_updater.supervisor_slot == self.module_updater.my_slot:
@@ -1449,10 +1450,6 @@ class ChassisdDaemon(daemon_base.DaemonBase):
 
             # Start main loop
             self.log_info("Start daemon main loop")
-
-            # Set the initial DPU admin state for SmartSwitch
-            if self.smartswitch:
-                self.set_initial_dpu_admin_state()
 
             while not self.stop.wait(self.loop_interval):
                 self.module_updater.module_db_update()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
This change sets the initial state of the DPU before the config manager task which subscribes to the CONFIG_DB table is started

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
This change is done because `set_initial_dpu_admin_state` clears the transition flags related to the DPU, but in a a second process while we are setting the state of the DPU using the config command which is handled by the `SmartSwitchConfigManagerTask`, so there would be an incorrect clear of the `transition_in_progress` flag
The states are cleared here in `set_initial_dpu_admin_state`:
https://github.com/sonic-net/sonic-platform-daemons/blob/40ccd149514634a96076b8f1a85aed30e0846329/sonic-chassisd/scripts/chassisd#L1379
And the admin state change happens in 
https://github.com/sonic-net/sonic-platform-daemons/blob/40ccd149514634a96076b8f1a85aed30e0846329/sonic-chassisd/scripts/chassisd#L1229


#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Manual testing:
Add config to Power on the DPU
```
"CHASSIS_MODULE": {
        "DPU0": {
            "admin_status": "up"
        },
        "DPU1": {
            "admin_status": "up"
        },
        "DPU2": {
            "admin_status": "up"
        },
        "DPU3": {
            "admin_status": "up"
        }
    },
```
Check that the `transition_in_progress` flag is not cleared
#### Additional Information (Optional)
