### PR TITLE
Set DOM polling interval based on the time at the start of the loop instead of the end

### DIFF
--- a/sonic-xcvrd/xcvrd/dom/dom_mgr.py
+++ b/sonic-xcvrd/xcvrd/dom/dom_mgr.py
@@ -272,7 +272,8 @@ class DomInfoUpdateTask(DomInfoUpdateBase):
         # Start loop to update dom info in DB periodically and handle port change events
         while not self.task_stopping_event.is_set():
             # Check if periodic db update is needed
-            if next_periodic_db_update_time <= datetime.datetime.now():
+            now = datetime.datetime.now()
+            if next_periodic_db_update_time <= now:
                 is_periodic_db_update_needed = True
 
             # Handle port change event from main thread
@@ -391,8 +392,7 @@ class DomInfoUpdateTask(DomInfoUpdateBase):
 
             # Set the periodic db update time after all the ports are processed
             if is_periodic_db_update_needed:
-                next_periodic_db_update_time = datetime.datetime.now() + \
-                                               datetime.timedelta(seconds=dom_info_update_periodic_secs)
+                next_periodic_db_update_time = now + datetime.timedelta(seconds=dom_info_update_periodic_secs)
                 is_periodic_db_update_needed = False
 
         self.log_notice("Stop DOM monitoring loop")


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

#### Description
During profiling we found that there was a significant period of time when transceiver information was not being updated.
Upon study, it was seen that for DOM_INFO_UPDATE_PERIOD_SECS after the last transceiver in the loop was polled, there were no updates.

#### Motivation and Context
fixes #756 
This improves DOM polling performance of transceivers in `xcvrd` and correctly ensures that DOM_INFO_UPDATE_PERIOD_SECS time elapses between updating a specific transceiver.

#### How Has This Been Tested?
We did a CPU profiling without and with the change over a 10 min window just after `xcvrd` starts
Before:
<img width="915" height="257" alt="image" src="https://github.com/user-attachments/assets/d09194ed-60a7-4a48-919d-52732347e980" />
After:
<img width="911" height="250" alt="image" src="https://github.com/user-attachments/assets/64814181-da73-48d7-ace1-357578e2cb10" />

The CPU is more uniformly utilized after the change instead of staying idle when more than DOM_INFO_UPDATE_PERIOD_SECS has already passed since a specific transceiver was polled.

#### Additional Information (Optional)
