### PR TITLE
[thermalctld] Use platform API for PSU fan name

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -201,6 +201,14 @@ class FanUpdater(logger.Logger):
         self.drawer_table = swsscommon.Table(state_db, FanUpdater.FAN_DRAWER_INFO_TABLE_NAME)
         self.phy_entity_table = swsscommon.Table(state_db, PHYSICAL_ENTITY_INFO_TABLE)
 
+    def get_psu_key(self, psu_index):
+        if self.chassis is not None:
+            try:
+                return self.chassis.get_psu(psu_index).get_name()
+            except (NotImplementedError, AttributeError):
+                pass
+        return 'PSU {}'.format(psu_index + 1)
+
     def __del__(self):
         if self.table:
             table_keys = self.table.getKeys()
@@ -308,7 +316,7 @@ class FanUpdater(logger.Logger):
         """
         drawer_name = NOT_AVAILABLE if fan_type != FanType.DRAWER else str(try_get(parent.get_name))
         if fan_type == FanType.PSU:
-            parent_name = try_get(parent.get_name, default='PSU {}'.format(parent_index + 1))
+            parent_name = self.get_psu_key(parent_index)
         elif fan_type == FanType.MODULE:
             parent_name = try_get(parent.get_name, default='Module {}'.format(parent_index + 1))
         else:

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -289,6 +289,37 @@ class TestFanUpdater(object):
         else:
             fan_updater.log_warning.assert_called_with("Failed to update module fan status - Exception('Test message',)")
 
+    def test_get_psu_key_returns_psu_name(self):
+        """Test get_psu_key returns PSU name from platform API"""
+        chassis = MockChassis()
+        psu = MockPsu()
+        psu._name = 'PSU0'
+        chassis._psu_list.append(psu)
+        fan_updater = thermalctld.FanUpdater(chassis, threading.Event())
+        assert fan_updater.get_psu_key(0) == 'PSU0'
+
+    def test_get_psu_key_attribute_error(self):
+        """Test get_psu_key falls back when get_psu returns None (AttributeError on .get_name())"""
+        chassis = MockChassis()
+        # No PSUs added, so get_psu(index) returns None and .get_name() raises AttributeError
+        fan_updater = thermalctld.FanUpdater(chassis, threading.Event())
+        assert fan_updater.get_psu_key(0) == 'PSU 1'
+        assert fan_updater.get_psu_key(1) == 'PSU 2'
+
+    def test_get_psu_key_not_implemented_error(self):
+        """Test get_psu_key falls back to 1-based 'PSU <index+1>' when get_name raises NotImplementedError"""
+        chassis = MockChassis()
+        psu = MockPsu()
+        psu.get_name = mock.MagicMock(side_effect=NotImplementedError)
+        chassis._psu_list.append(psu)
+        fan_updater = thermalctld.FanUpdater(chassis, threading.Event())
+        assert fan_updater.get_psu_key(0) == 'PSU 1'
+
+    def test_get_psu_key_chassis_none(self):
+        """Test get_psu_key falls back to 1-based 'PSU <index+1>' when chassis is None"""
+        fan_updater = thermalctld.FanUpdater(None, threading.Event())
+        assert fan_updater.get_psu_key(0) == 'PSU 1'
+
 class TestLiquidCoolingUpdater(object):
     def test_update(self):
         mock_chassis = MockChassis()


### PR DESCRIPTION
Fix PSU fan parent name mismatch between psud and thermalctld.

**Description**

psud was updated to use get_name() API for PSU keys in STATE_DB (#102), but thermalctld still used index-based 'PSU {index}' format. This inconsistency caused the SNMP subagent to fail when resolving the parent of PSU fans (e.g., PSU2_FAN1), as the parent name in FAN_INFO did not match any PSU key in PSU_INFO.

Add get_psu_key() method to FanUpdater that retrieves the PSU name via chassis.get_psu().get_name(), aligning with psud's behavior. Falls back to 'PSU {index+1}' on NotImplementedError or AttributeError (e.g., when get_psu() returns None for an out-of-range index).

Add unit tests for get_psu_key() covering:

- Successful PSU name retrieval from platform API

- AttributeError fallback when get_psu() returns None

- NotImplementedError fallback when get_name() is not implemented

- Fallback when chassis is None


**Motivation and Context**

The SNMP subagent resolves fan-to-parent relationships by looking up the parent name from FAN_INFO in PSU_INFO. After psud switched to using the platform API's get_name() for PSU keys, thermalctld's index-based naming ('PSU 1', 'PSU 2') no longer matched, breaking SNMP fan parent resolution for PSU fans. This change aligns thermalctld with psud so both daemons use consistent PSU naming in STATE_DB.

**How Has This Been Tested?**

- Confirmed SNMP subagent can correctly resolve the parent of PSU fans (e.g., PSU2_FAN1) after the fix.

- Added unit tests validating all get_psu_key() code paths including AttributeError, NotImplementedError, and None chassis fallback.

**Additional Information (Optional)**

- This is a minimal change scoped to the FanUpdater class in thermalctld. No new dependencies are introduced. Platforms that do not implement get_name() on PSU objects are unaffected due to the fallback behavior.