### PR TITLE
Delete only 'PHYSICAL_ENTITY_INFO' entries that daemon has added

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -503,6 +503,11 @@ class DaemonPsud(daemon_base.DaemonBase):
                 self.psu_tbl._del(get_psu_key(psu_index))
             except Exception as e:
                 self.log_error("Failed to delete PSU {} info from DB: {}".format(psu_index, e))
+            if self.phy_entity_tbl.get(get_psu_key(psu_index)) is not None:
+                try:
+                    self.phy_entity_tbl._del(get_psu_key(psu_index))
+                except:
+                    self.log_error("Failed to delete physical entity info from DB: {}".format(e))
 
         if self.chassis_tbl is not None:
             try:

--- a/sonic-psud/tests/test_DaemonPsud.py
+++ b/sonic-psud/tests/test_DaemonPsud.py
@@ -531,6 +531,40 @@ class TestDaemonPsud(object):
         daemon_psud._update_single_psu_entity_info(3, mock_psu1)
         daemon_psud.phy_entity_tbl.set.assert_called_with('PSU 3', expected_fvp)
 
+    def test_deinit(self):
+        psud.platform_chassis = MockChassis()
+        daemon_psud = psud.DaemonPsud(SYSLOG_IDENTIFIER)
+        daemon_psud.num_psus = 2
+        daemon_psud.psu_tbl = psud.swsscommon.Table("STATE_DB", "psu_table")
+        daemon_psud.psu_tbl._del = mock.MagicMock()
+        daemon_psud.phy_entity_tbl = psud.swsscommon.Table("STATE_DB", "phy_entity_table")
+        # Pre-populate physical entity table with PSU entries and extra entries
+        daemon_psud.phy_entity_tbl.mock_dict['PSU 1'] = {}
+        daemon_psud.phy_entity_tbl.mock_dict['PSU 2'] = {}
+        daemon_psud.phy_entity_tbl.mock_dict['FAN 1'] = {}  # Extra entry not owned by psud
+        daemon_psud.phy_entity_tbl._del = mock.MagicMock()
+        daemon_psud.chassis_tbl = psud.swsscommon.Table("STATE_DB", "chassis_table")
+        daemon_psud.chassis_tbl._del = mock.MagicMock()
+
+        daemon_psud.__del__()
+
+        # Verify PSU table entries are deleted for all PSUs
+        assert daemon_psud.psu_tbl._del.call_count == 2
+        expected_psu_calls = [mock.call('PSU 1'), mock.call('PSU 2')]
+        daemon_psud.psu_tbl._del.assert_has_calls(expected_psu_calls, any_order=True)
+
+        # Verify only physical entity entries for PSUs are deleted (not FAN 1)
+        assert daemon_psud.phy_entity_tbl._del.call_count == 2
+        daemon_psud.phy_entity_tbl._del.assert_has_calls(expected_psu_calls, any_order=True)
+
+        # Verify chassis table entries are deleted
+        assert daemon_psud.chassis_tbl._del.call_count == 2
+        expected_chassis_calls = [
+            mock.call(psud.CHASSIS_INFO_KEY),
+            mock.call(psud.CHASSIS_INFO_POWER_KEY_TEMPLATE.format(1))
+        ]
+        daemon_psud.chassis_tbl._del.assert_has_calls(expected_chassis_calls, any_order=True)
+
     @mock.patch('psud.datetime')
     def test_update_psu_fan_data(self, mock_datetime):
         fake_time = datetime.datetime(2021, 1, 1, 12, 34, 56)

--- a/sonic-sensormond/scripts/sensormond
+++ b/sonic-sensormond/scripts/sensormond
@@ -155,10 +155,6 @@ class SensorUpdater(logger.Logger):
                 self.table._del(tk)
                 if self.is_chassis_system and self.chassis_table is not None:
                     self.chassis_table._del(tk)
-        if self.phy_entity_table:
-            phy_entity_keys = self.phy_entity_table.getKeys()
-            for pek in phy_entity_keys:
-                self.phy_entity_table._del(pek)
 
     def _log_on_status_changed(self, normal_status, normal_log, abnormal_log):
         '''
@@ -193,6 +189,14 @@ class VoltageUpdater(SensorUpdater):
             self.module_voltage_sensors = set()
 
         self.fs_sensors = fs_sensors
+
+    def __del__(self):
+        # Call parent destructor to clean up sensor table entries
+        super().__del__()
+        # Delete only the physical entity entries added by this updater
+        if self.phy_entity_table:
+            for sensor_name in self.voltage_status_dict.keys():
+                self.phy_entity_table._del(sensor_name)
 
     def update(self, stop_event_signal = threading.Event()):
         '''
@@ -332,6 +336,14 @@ class CurrentUpdater(SensorUpdater):
             self.module_current_sensors = set()
 
         self.fs_sensors = fs_sensors
+
+    def __del__(self):
+        # Call parent destructor to clean up sensor table entries
+        super().__del__()
+        # Delete only the physical entity entries added by this updater
+        if self.phy_entity_table:
+            for sensor_name in self.current_status_dict.keys():
+                self.phy_entity_table._del(sensor_name)
 
     def update(self, stop_event_signal = threading.Event()):
         '''

--- a/sonic-sensormond/tests/test_sensormond.py
+++ b/sonic-sensormond/tests/test_sensormond.py
@@ -113,17 +113,26 @@ class TestVoltageUpdater(object):
         voltage_updater.table._del = mock.MagicMock()
         voltage_updater.table.getKeys = mock.MagicMock(return_value=['key1','key2'])
         voltage_updater.phy_entity_table = Table("STATE_DB", "ytable")
+        # Pre-populate physical entity table so .get() returns non-None
+        voltage_updater.phy_entity_table.mock_dict['key1'] = {}
+        voltage_updater.phy_entity_table.mock_dict['key2'] = {}
+        voltage_updater.phy_entity_table.mock_dict['keyredundant'] = {}
         voltage_updater.phy_entity_table._del = mock.MagicMock()
-        voltage_updater.phy_entity_table.getKeys = mock.MagicMock(return_value=['key1','key2'])
         voltage_updater.chassis_table = Table("STATE_DB", "ctable")
         voltage_updater.chassis_table._del = mock.MagicMock()
         voltage_updater.is_chassis_system = True
 
         voltage_updater.__del__()
+
+        # Verify voltage table entries are deleted
         assert voltage_updater.table.getKeys.call_count == 1
         assert voltage_updater.table._del.call_count == 2
         expected_calls = [mock.call('key1'), mock.call('key2')]
         voltage_updater.table._del.assert_has_calls(expected_calls, any_order=True)
+
+        # Verify only physical entity entries in voltage_status_dict are deleted (not redundant)
+        assert voltage_updater.phy_entity_table._del.call_count == 2
+        voltage_updater.phy_entity_table._del.assert_has_calls(expected_calls, any_order=True)
 
     def test_over_voltage(self):
         chassis = MockChassis()
@@ -228,17 +237,26 @@ class TestCurrentUpdater(object):
         current_updater.table._del = mock.MagicMock()
         current_updater.table.getKeys = mock.MagicMock(return_value=['key1','key2'])
         current_updater.phy_entity_table = Table("STATE_DB", "ytable")
+        # Pre-populate physical entity table so .get() returns non-None
+        current_updater.phy_entity_table.mock_dict['key1'] = {}
+        current_updater.phy_entity_table.mock_dict['key2'] = {}
+        current_updater.phy_entity_table.mock_dict['keyredundant'] = {}
         current_updater.phy_entity_table._del = mock.MagicMock()
-        current_updater.phy_entity_table.getKeys = mock.MagicMock(return_value=['key1','key2'])
         current_updater.chassis_table = Table("STATE_DB", "ctable")
         current_updater.chassis_table._del = mock.MagicMock()
         current_updater.is_chassis_system = True
 
         current_updater.__del__()
+
+        # Verify current table entries are deleted
         assert current_updater.table.getKeys.call_count == 1
         assert current_updater.table._del.call_count == 2
         expected_calls = [mock.call('key1'), mock.call('key2')]
         current_updater.table._del.assert_has_calls(expected_calls, any_order=True)
+
+        # Verify only physical entity entries in current_status_dict are deleted (not redundant)
+        assert current_updater.phy_entity_table._del.call_count == 2
+        current_updater.phy_entity_table._del.assert_has_calls(expected_calls, any_order=True)
 
     def test_over_current(self):
         chassis = MockChassis()

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -206,14 +206,16 @@ class FanUpdater(logger.Logger):
             table_keys = self.table.getKeys()
             for tk in table_keys:
                 self.table._del(tk)
+                if self.phy_entity_table:
+                    if self.phy_entity_table.get(tk) is not None:
+                        self.phy_entity_table._del(tk)
         if self.drawer_table:
             drawer_keys = self.drawer_table.getKeys()
             for dtk in drawer_keys:
                 self.drawer_table._del(dtk)
-        if self.phy_entity_table:
-            phy_entity_keys = self.phy_entity_table.getKeys()
-            for pek in phy_entity_keys:
-                self.phy_entity_table._del(pek)
+                if self.phy_entity_table:
+                    if self.phy_entity_table.get(dtk) is not None:
+                        self.phy_entity_table._del(dtk)
 
     def _log_on_status_changed(self, normal_status, normal_log, abnormal_log):
         """
@@ -668,10 +670,9 @@ class TemperatureUpdater(logger.Logger):
                     # to the supervisor and chassisdb. If this happens then we
                     # should simply remove our handle to chassisdb.
                     self.chassis_table = None
-        if self.phy_entity_table:
-            phy_entity_keys = self.phy_entity_table.getKeys()
-            for pek in phy_entity_keys:
-                self.phy_entity_table._del(pek)
+                if self.phy_entity_table:
+                    if self.phy_entity_table.get(tk) is not None:
+                        self.phy_entity_table._del(tk)
 
     def _init_sfp_util_helper(self):
         """

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -139,6 +139,46 @@ class TestFanUpdater(object):
 
     # TODO: Add a test case for _refresh_fan_drawer_status with a good fan drawer
 
+    def test_deinit(self):
+        chassis = MockChassis()
+        fan_updater = thermalctld.FanUpdater(chassis, threading.Event())
+        fan_updater.table = Table("STATE_DB", "fan_table")
+        fan_updater.table._del = mock.MagicMock()
+        fan_updater.table.getKeys = mock.MagicMock(return_value=['fan1', 'fan2'])
+        fan_updater.drawer_table = Table("STATE_DB", "drawer_table")
+        fan_updater.drawer_table._del = mock.MagicMock()
+        fan_updater.drawer_table.getKeys = mock.MagicMock(return_value=['drawer1', 'drawer2'])
+        fan_updater.phy_entity_table = Table("STATE_DB", "phy_entity_table")
+        # Pre-populate physical entity table so .get() returns non-None
+        fan_updater.phy_entity_table.mock_dict['fan1'] = {}
+        fan_updater.phy_entity_table.mock_dict['fan2'] = {}
+        fan_updater.phy_entity_table.mock_dict['fanExtra'] = {}
+        fan_updater.phy_entity_table.mock_dict['drawer1'] = {}
+        fan_updater.phy_entity_table.mock_dict['drawer2'] = {}
+        fan_updater.phy_entity_table.mock_dict['drawerExtra'] = {}
+
+        fan_updater.phy_entity_table._del = mock.MagicMock()
+
+        fan_updater.__del__()
+
+        # Verify fan table entries are deleted
+        assert fan_updater.table.getKeys.call_count == 1
+        assert fan_updater.table._del.call_count == 2
+        fan_table_calls = [mock.call('fan1'), mock.call('fan2')]
+        fan_updater.table._del.assert_has_calls(fan_table_calls, any_order=True)
+
+        # Verify drawer table entries are deleted
+        assert fan_updater.drawer_table.getKeys.call_count == 1
+        assert fan_updater.drawer_table._del.call_count == 2
+        drawer_table_calls = [mock.call('drawer1'), mock.call('drawer2')]
+        fan_updater.drawer_table._del.assert_has_calls(drawer_table_calls, any_order=True)
+
+        # Verify only physical entity entries matching fan and drawer keys are deleted
+        # Should be 4 calls total: 2 for fans + 2 for drawers, rather than 6 (all 4 + redundant)
+        assert fan_updater.phy_entity_table._del.call_count == 4
+        phy_entity_calls = [mock.call('fan1'), mock.call('fan2'), mock.call('drawer1'), mock.call('drawer2')]
+        fan_updater.phy_entity_table._del.assert_has_calls(phy_entity_calls, any_order=True)
+
     def test_update_fan_with_exception(self):
         chassis = MockChassis()
         chassis.make_error_fan()
@@ -622,19 +662,30 @@ class TestTemperatureUpdater(object):
         temp_updater.table._del = mock.MagicMock()
         temp_updater.table.getKeys = mock.MagicMock(return_value=['key1','key2'])
         temp_updater.phy_entity_table = Table("STATE_DB", "ytable")
+        # Pre-populate physical entity table so .get() returns non-None
+        temp_updater.phy_entity_table.mock_dict['key1'] = {}
+        temp_updater.phy_entity_table.mock_dict['key2'] = {}
+        temp_updater.phy_entity_table.mock_dict['keyredundant'] = {}
         temp_updater.phy_entity_table._del = mock.MagicMock()
-        temp_updater.phy_entity_table.getKeys = mock.MagicMock(return_value=['key1','key2'])
         temp_updater.chassis_table = Table("STATE_DB", "ctable")
         temp_updater.chassis_table._del = mock.MagicMock()
         temp_updater.is_chassis_system = True
         temp_updater.is_chassis_upd_required = True
 
         temp_updater.__del__()
+
+        # Verify temperature table entries are deleted
         assert temp_updater.table.getKeys.call_count == 1
         assert temp_updater.table._del.call_count == 2
         expected_calls = [mock.call('key1'), mock.call('key2')]
         temp_updater.table._del.assert_has_calls(expected_calls, any_order=True)
+
+        # Verify chassis table entries are deleted
         assert temp_updater.chassis_table._del.call_count == 2
+
+        # Verify only physical entity entries matching table keys are deleted (not redundant)
+        assert temp_updater.phy_entity_table._del.call_count == 2
+        temp_updater.phy_entity_table._del.assert_has_calls(expected_calls, any_order=True)
 
     def test_deinit_exception(self):
         chassis = MockChassis()
@@ -644,8 +695,10 @@ class TestTemperatureUpdater(object):
         temp_updater.table._del = mock.MagicMock()
         temp_updater.table.getKeys = mock.MagicMock(return_value=['key1','key2'])
         temp_updater.phy_entity_table = Table("STATE_DB", "ytable")
+        # Pre-populate physical entity table so .get() returns non-None
+        temp_updater.phy_entity_table.mock_dict['key1'] = {}
+        temp_updater.phy_entity_table.mock_dict['key2'] = {}
         temp_updater.phy_entity_table._del = mock.MagicMock()
-        temp_updater.phy_entity_table.getKeys = mock.MagicMock(return_value=['key1','key2'])
         temp_updater.chassis_table = Table("STATE_DB", "ctable")
         temp_updater.chassis_table._del = mock.Mock()
         temp_updater.chassis_table._del.side_effect = Exception('test')
@@ -653,10 +706,14 @@ class TestTemperatureUpdater(object):
         temp_updater.is_chassis_upd_required = True
 
         temp_updater.__del__()
+
+        # Verify temperature table entries are deleted
         assert temp_updater.table.getKeys.call_count == 1
         assert temp_updater.table._del.call_count == 2
         expected_calls = [mock.call('key1'), mock.call('key2')]
         temp_updater.table._del.assert_has_calls(expected_calls, any_order=True)
+
+        # Verify chassis_table is set to None after exception
         assert temp_updater.chassis_table is None
 
     def test_over_temper(self):


### PR DESCRIPTION
#### Description

In the current design, daemons like psud, sensormond, and thermalctld delete all entries in the `PHYSICAL_ENTITY_INFO` table of `STATE_DB` when their classes are being garbage collected.

This creates race conditions where one daemon might try to access its own data in the `PHYSICAL_ENTITY_INFO` table that another daemon has deleted.

For example, during system shutdown, if `thermalctld` daemon stops first, its class objects get garbage collected and all entries in the `PHYSICAL_ENTITY_INFO` table are deleted. If `psud` is still running and periodically updating its own data, SNMP queries between the deletion and re-population will fail to retrieve PSU entity information.

This patch fixes the issue by limiting what each daemon deletes to only the entries it
has added to the `PHYSICAL_ENTITY_INFO` table:
- `psud`: Deletes only PSU entries
- `thermalctld`: Deletes only fan, drawer, and temperature entries
- `sensormond`: Deletes only voltage and current entries

Additionally, defensive `.get()` checks are added before deletion to prevent KeyError exceptions if entries have already been removed by other processes.

This fixes https://github.com/sonic-net/sonic-buildimage/issues/25652

<!-- Provide a general summary of your changes in the Title above -->


#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

1. Ran the snmp sonic-mgmt test suite.
2. Ran a stress test which reboots the dut containing these changes over 100 times and didn't observe  https://github.com/sonic-net/sonic-buildimage/issues/25652.
3. Also added corresponding unit tests for this new design and ran those tests.
