### PR TITLE
SONiC BMC Support : New Module type to represent switch CPU card

### DIFF
--- a/sonic-chassisd/scripts/chassis_db_init
+++ b/sonic-chassisd/scripts/chassis_db_init
@@ -32,6 +32,7 @@ CHASSIS_INFO_CARD_NUM_FIELD = 'module_num'
 CHASSIS_INFO_SERIAL_FIELD = 'serial'
 CHASSIS_INFO_MODEL_FIELD = 'model'
 CHASSIS_INFO_REV_FIELD = 'revision'
+CHASSIS_INFO_SWITCH_HOST_SERIAL_FIELD = 'switch_host_serial'
 
 CHASSIS_LOAD_ERROR = 1
 
@@ -65,7 +66,6 @@ def try_get(callback, *args, **kwargs):
 #
 # Functions
 # 
-
 def provision_db(platform_chassis, log):
     # Init state db connection
     state_db = daemon_base.db_connect("STATE_DB")
@@ -77,6 +77,12 @@ def provision_db(platform_chassis, log):
                                         (CHASSIS_INFO_MODEL_FIELD, try_get(platform_chassis.get_model)),
                                         (CHASSIS_INFO_REV_FIELD, try_get(platform_chassis.get_revision))
                                     ])
+    if platform_chassis.is_bmc():
+        # BMC must also populate the switch host serial number
+        switch_host_serial = try_get(platform_chassis.get_switch_host_serial)
+    else:
+        switch_host_serial = NOT_AVAILABLE
+    fvs.append((CHASSIS_INFO_SWITCH_HOST_SERIAL_FIELD, switch_host_serial))
     chassis_table.set(CHASSIS_INFO_KEY_TEMPLATE.format(1), fvs)
     log.log_info("STATE_DB provisioned with chassis info.")
 

--- a/sonic-chassisd/scripts/chassis_db_init
+++ b/sonic-chassisd/scripts/chassis_db_init
@@ -71,18 +71,20 @@ def provision_db(platform_chassis, log):
     state_db = daemon_base.db_connect("STATE_DB")
     chassis_table = swsscommon.Table(state_db, CHASSIS_INFO_TABLE)
 
-    # Populate DB with chassis hardware info 
-    fvs = swsscommon.FieldValuePairs([
-                                        (CHASSIS_INFO_SERIAL_FIELD, try_get(platform_chassis.get_serial)),
-                                        (CHASSIS_INFO_MODEL_FIELD, try_get(platform_chassis.get_model)),
-                                        (CHASSIS_INFO_REV_FIELD, try_get(platform_chassis.get_revision))
-                                    ])
+    # Determine switch host serial number
     if platform_chassis.is_bmc():
         # BMC must also populate the switch host serial number
         switch_host_serial = try_get(platform_chassis.get_switch_host_serial)
     else:
         switch_host_serial = NOT_AVAILABLE
-    fvs.append((CHASSIS_INFO_SWITCH_HOST_SERIAL_FIELD, switch_host_serial))
+
+    # Populate DB with chassis hardware info
+    fvs = swsscommon.FieldValuePairs([
+                                        (CHASSIS_INFO_SERIAL_FIELD, try_get(platform_chassis.get_serial)),
+                                        (CHASSIS_INFO_MODEL_FIELD, try_get(platform_chassis.get_model)),
+                                        (CHASSIS_INFO_REV_FIELD, try_get(platform_chassis.get_revision)),
+                                        (CHASSIS_INFO_SWITCH_HOST_SERIAL_FIELD, switch_host_serial)
+                                    ])
     chassis_table.set(CHASSIS_INFO_KEY_TEMPLATE.format(1), fvs)
     log.log_info("STATE_DB provisioned with chassis info.")
 

--- a/sonic-chassisd/tests/mock_module_base.py
+++ b/sonic-chassisd/tests/mock_module_base.py
@@ -7,6 +7,7 @@ class ModuleBase():
     MODULE_TYPE_LINE = "LINE-CARD"
     MODULE_TYPE_FABRIC = "FABRIC-CARD"
     MODULE_TYPE_DPU = "DPU"
+    MODULE_TYPE_SWITCH_HOST = "SWITCH_HOST"
 
     # Possible card status for modular chassis
     # Module state is Empty if no module is inserted in the slot

--- a/sonic-chassisd/tests/mock_platform.py
+++ b/sonic-chassisd/tests/mock_platform.py
@@ -151,6 +151,9 @@ class MockChassis:
     def get_revision(self):
         return "Rev C"
 
+    def is_bmc(self):
+        return False
+
     def is_smartswitch(self):
         return self._is_smartswitch
 

--- a/sonic-chassisd/tests/test_chassis_db_init.py
+++ b/sonic-chassisd/tests/test_chassis_db_init.py
@@ -29,6 +29,7 @@ def test_provision_db():
     serial = "Serial No"
     model = "Model A"
     revision = "Rev C"
+    switch_host_serial = NOT_AVAILABLE
 
     chassis_table = provision_db(chassis, log)
 
@@ -38,6 +39,7 @@ def test_provision_db():
     assert serial == fvs[CHASSIS_INFO_SERIAL_FIELD]
     assert model == fvs[CHASSIS_INFO_MODEL_FIELD]
     assert revision == fvs[CHASSIS_INFO_REV_FIELD]
+    assert switch_host_serial == fvs[CHASSIS_INFO_SWITCH_HOST_SERIAL_FIELD]
 
 def test_try_get_timeout_error():
     def raise_timeout():

--- a/sonic-chassisd/tests/test_chassis_db_init.py
+++ b/sonic-chassisd/tests/test_chassis_db_init.py
@@ -41,6 +41,20 @@ def test_provision_db():
     assert revision == fvs[CHASSIS_INFO_REV_FIELD]
     assert switch_host_serial == fvs[CHASSIS_INFO_SWITCH_HOST_SERIAL_FIELD]
 
+def test_provision_db_bmc():
+    chassis = MockChassis()
+    log = MagicMock()
+    switch_host_serial = "Switch Host Serial"
+
+    with patch.object(chassis, 'is_bmc', return_value=True), \
+         patch.object(chassis, 'get_switch_host_serial', create=True, return_value=switch_host_serial):
+        chassis_table = provision_db(chassis, log)
+
+    fvs = chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
+    if isinstance(fvs, list):
+        fvs = dict(fvs[-1])
+    assert switch_host_serial == fvs[CHASSIS_INFO_SWITCH_HOST_SERIAL_FIELD]
+
 def test_try_get_timeout_error():
     def raise_timeout():
         raise TimeoutError("timeout")

--- a/sonic-psud/tests/mocked_libs/swsscommon/swsscommon.py
+++ b/sonic-psud/tests/mocked_libs/swsscommon/swsscommon.py
@@ -13,7 +13,8 @@ class Table:
         self.mock_dict = {}
 
     def _del(self, key):
-        del self.mock_dict[key]
+        if key in self.mock_dict:
+            del self.mock_dict[key]
         pass
 
     def hdel(self, key, value):


### PR DESCRIPTION
Add a new module type switch_host. This will be used to abstract the switch cpu as a module in SONiC BMC.
HLD Ref. https://github.com/sonic-net/SONiC/pull/2215/

#### Description
A new module type.


#### Motivation and Context
SONiC running on a BMC card would have a module to represent the Switch CPU card. So to support that abstraction, introduce a new module type

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
