### PR TITLE
[thermalctld] Add per-component polling intervals from platform.json

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -7,12 +7,13 @@
 
 from enum import Enum, auto
 import argparse
+import json
+import os
 import signal
 import sys
 import threading
 import time
 from datetime import datetime
-import argparse
 
 import sonic_platform
 from sonic_py_common import daemon_base, logger, device_info, multi_asic
@@ -38,6 +39,7 @@ TRANSCEIVER_DOM_TEMPERATURE_TABLE = 'TRANSCEIVER_DOM_TEMPERATURE'
 TRANSCEIVER_DOM_THRESHOLD_TABLE = 'TRANSCEIVER_DOM_THRESHOLD'
 TRANSCEIVER_DOM_SENSOR_TABLE = 'TRANSCEIVER_DOM_SENSOR'
 INVALID_SLOT_OR_DPU = -1
+PLATFORM_JSON_FILE = "/usr/share/sonic/platform/platform.json"
 
 ERR_UNKNOWN = 1
 CHASSIS_GET_ERROR = 2
@@ -71,6 +73,70 @@ def update_entity_info(table, parent_name, key, device, device_index):
         [('position_in_parent', str(try_get(device.get_position_in_parent, device_index))),
          ('parent_name', parent_name)])
     table.set(key, fvs)
+
+
+def _parse_platform_json_polling_intervals():
+    """Parse polling_interval values from platform.json for thermalctld components.
+
+    platform.json may contain per-component polling intervals:
+    - fan_drawers[0].polling_interval: interval in seconds for fan updates
+    - psus[0].polling_interval: interval in seconds for PSU updates
+    - thermals[*].polling_interval: per-thermal interval in seconds
+
+    The first entry in fan_drawers/psus without a 'name' key is treated as
+    configuration; subsequent entries with 'name' are actual devices.
+
+    Returns:
+        dict: {'fan_drawer': float|None, 'psu': float|None, 'thermals': {name: float}}
+    """
+    result = {'fan_drawer': None, 'psu': None, 'thermals': {}}
+    try:
+        if not os.path.isfile(PLATFORM_JSON_FILE):
+            return result
+        with open(PLATFORM_JSON_FILE, 'r') as f:
+            platform_data = json.load(f)
+    except Exception:
+        return result
+
+    if not platform_data:
+        return result
+
+    # platform.json nests components under 'chassis'
+    chassis = platform_data.get('chassis', platform_data)
+
+    # fan_drawers: config entry (no 'name') with polling_interval
+    for entry in chassis.get('fan_drawers', []):
+        if 'name' not in entry and 'polling_interval' in entry:
+            val = entry['polling_interval']
+            if val:
+                try:
+                    result['fan_drawer'] = float(val)
+                except (ValueError, TypeError):
+                    pass
+            break
+
+    # psus: config entry (no 'name') with polling_interval
+    for entry in chassis.get('psus', []):
+        if 'name' not in entry and 'polling_interval' in entry:
+            val = entry['polling_interval']
+            if val:
+                try:
+                    result['psu'] = float(val)
+                except (ValueError, TypeError):
+                    pass
+            break
+
+    # thermals: each device entry may have its own polling_interval
+    for entry in chassis.get('thermals', []):
+        name = entry.get('name')
+        val = entry.get('polling_interval', '')
+        if name and val:
+            try:
+                result['thermals'][name] = float(val)
+            except (ValueError, TypeError):
+                pass
+
+    return result
 
 
 class FanType(Enum):
@@ -621,10 +687,16 @@ class TemperatureUpdater(logger.Logger):
     # Temperature information table name in database
     TEMPER_INFO_TABLE_NAME = 'TEMPERATURE_INFO'
 
-    def __init__(self, chassis, task_stopping_event):
+    def __init__(self, chassis, task_stopping_event, psu_interval=None, thermal_intervals=None,
+                 default_interval=None):
         """
         Initializer of TemperatureUpdater
         :param chassis: Object representing a platform chassis
+        :param psu_interval: Polling interval for PSU thermals (seconds), None for default
+        :param thermal_intervals: Dict of {thermal_name: interval_seconds} for per-thermal polling
+        :param default_interval: Default polling interval for thermals not in thermal_intervals.
+                                 When set, thermals without an explicit interval are throttled to
+                                 this rate instead of updating every cycle.
         """
         super(TemperatureUpdater, self).__init__(SYSLOG_IDENTIFIER)
 
@@ -639,6 +711,13 @@ class TemperatureUpdater(logger.Logger):
         self.xcvr_dom_sensor_tbl = swsscommon.Table(state_db, TRANSCEIVER_DOM_SENSOR_TABLE)
         self.chassis_table = None
         self.all_thermals = set()
+
+        # Per-component polling intervals from platform.json
+        self._psu_interval = psu_interval
+        self._thermal_intervals = thermal_intervals or {}
+        self._default_interval = default_interval
+        self._last_psu_thermal_update = 0
+        self._last_thermal_update_times = {}
 
         # Initialize SfpUtilHelper for port index to logical port name mapping
         self.sfp_util = self._init_sfp_util_helper()
@@ -735,19 +814,37 @@ class TemperatureUpdater(logger.Logger):
         else:
             self.log_warning(abnormal_log)
 
-    def _collect_thermals(self, available_thermals, parent_name, thermals):
+    def _should_update_thermal(self, name):
+        """Check if a thermal should be updated based on its polling interval."""
+        interval = self._thermal_intervals.get(name, self._default_interval)
+        if interval is None:
+            return True
+        now = time.time()
+        last = self._last_thermal_update_times.get(name, 0)
+        if now - last >= interval:
+            self._last_thermal_update_times[name] = now
+            return True
+        return False
+
+    def _collect_thermals(self, available_thermals, parent_name, thermals, refresh=True):
         """
         Process thermals from a parent device and update DB.
         :param available_thermals: Set to track available thermals
         :param parent_name: Name of the parent device
         :param thermals: Iterable of thermal objects from get_all_thermals()
+        :param refresh: If False, only track thermals and update entity info without refreshing temperature
         :return: False if task_stopping_event is set, True otherwise
         """
         for thermal_index, thermal in enumerate(thermals):
             if self.task_stopping_event.is_set():
                 return False
             available_thermals.add((thermal, parent_name, thermal_index))
-            self._refresh_temperature_status(parent_name, thermal, thermal_index)
+            name = try_get(thermal.get_name, '{} Thermal {}'.format(parent_name, thermal_index + 1))
+            # Always update entity info so PHYSICAL_ENTITY_INFO is populated
+            if 'SFP' not in parent_name:
+                update_entity_info(self.phy_entity_table, parent_name, name, thermal, thermal_index + 1)
+            if refresh and self._should_update_thermal(name):
+                self._refresh_temperature_status(parent_name, thermal, thermal_index)
         return True
 
     def _collect_sfp_thermals(self, available_thermals, parent_name, sfp_index, thermals):
@@ -782,11 +879,19 @@ class TemperatureUpdater(logger.Logger):
         if not self._collect_thermals(available_thermals, CHASSIS_INFO_KEY, self.chassis.get_all_thermals()):
             return
 
+        now = time.time()
+        should_update_psu = (self._psu_interval is None or
+                             (now - self._last_psu_thermal_update) >= self._psu_interval)
+
         for psu_index, psu in enumerate(self.chassis.get_all_psus()):
             if psu.get_presence():
                 parent_name = try_get(psu.get_name, default='PSU {}'.format(psu_index + 1))
-                if not self._collect_thermals(available_thermals, parent_name, psu.get_all_thermals()):
+                if not self._collect_thermals(available_thermals, parent_name, psu.get_all_thermals(),
+                                              refresh=should_update_psu):
                     return
+
+        if should_update_psu:
+            self._last_psu_thermal_update = now
 
         for sfp_index, sfp in enumerate(self.chassis.get_all_sfps()):
             if not self._collect_sfp_thermals(available_thermals, 'SFP {}'.format(sfp_index + 1),
@@ -834,13 +939,6 @@ class TemperatureUpdater(logger.Logger):
         """
         try:
             name = try_get(thermal.get_name, '{} Thermal {}'.format(parent_name, thermal_index + 1))
-
-            # Only save entity info for thermals that belong to chassis and PSU
-            # for SFP thermal, they don't need save entity info because snmp can deduce the relation from TRANSCEIVER_DOM_SENSOR
-            # and as we save logical port in TRANSCEIVER_INFO table, for split cable, a SFP thermal might have multiple parent
-            # logical port
-            if 'SFP' not in parent_name and not is_sfp:
-                update_entity_info(self.phy_entity_table, parent_name, name, thermal, thermal_index + 1)
 
             if name not in self.temperature_status_dict:
                 self.temperature_status_dict[name] = TemperatureStatus()
@@ -1003,11 +1101,13 @@ class TemperatureUpdater(logger.Logger):
 
 class ThermalMonitor(ThreadTaskBase):
     def __init__(
-        self, chassis, initial_interval, update_interval, update_elapsed_threshold
+        self, chassis, initial_interval, update_interval, update_elapsed_threshold,
+        polling_intervals=None
     ):
         """
         Initializer for ThermalMonitor
         :param chassis: Object representing a platform chassis
+        :param polling_intervals: Dict from _parse_platform_json_polling_intervals()
         """
         super(ThermalMonitor, self).__init__()
 
@@ -1026,12 +1126,51 @@ class ThermalMonitor(ThreadTaskBase):
         # Set minimum logging level to INFO
         self.logger.set_min_log_priority_info()
 
+        polling_intervals = polling_intervals or {}
+        fan_drawer_interval = polling_intervals.get('fan_drawer')
+        psu_interval = polling_intervals.get('psu')
+        thermal_intervals = polling_intervals.get('thermals', {})
+
+        # Fan update interval: minimum of fan_drawer and psu intervals
+        fan_intervals = [i for i in [fan_drawer_interval, psu_interval] if i is not None]
+        self._fan_update_interval = min(fan_intervals) if fan_intervals else None
+        self._last_fan_update = 0
+
         self.fan_updater = FanUpdater(chassis, self.task_stopping_event)
-        self.temperature_updater = TemperatureUpdater(chassis, self.task_stopping_event)
+        # When any custom polling intervals are configured, thermals without an
+        # explicit interval should still run at the original update_interval (60s)
+        # rather than every fast-loop cycle.
+        default_thermal_interval = update_interval if thermal_intervals else None
+        self.temperature_updater = TemperatureUpdater(
+            chassis, self.task_stopping_event,
+            psu_interval=psu_interval,
+            thermal_intervals=thermal_intervals,
+            default_interval=default_thermal_interval
+        )
+
+        # Adjust main loop to accommodate faster polling intervals
+        all_intervals = fan_intervals + list(thermal_intervals.values())
+        if all_intervals:
+            min_interval = min(all_intervals)
+            if min_interval < self.update_interval:
+                self.logger.log_notice(
+                    'Adjusting update interval from {}s to {}s based on platform.json polling intervals'.format(
+                        self.update_interval, min_interval))
+                self.update_interval = min_interval
+
+        if any(v is not None for v in [fan_drawer_interval, psu_interval]) or thermal_intervals:
+            self.logger.log_notice(
+                'Platform polling intervals: fan_drawer={}, psu={}, thermals={}'.format(
+                    fan_drawer_interval, psu_interval,
+                    {k: v for k, v in thermal_intervals.items()} if thermal_intervals else 'default'))
 
     def main(self):
         begin = time.time()
-        self.fan_updater.update()
+
+        if self._fan_update_interval is None or (begin - self._last_fan_update) >= self._fan_update_interval:
+            self.fan_updater.update()
+            self._last_fan_update = begin
+
         self.temperature_updater.update()
         elapsed = time.time() - begin
         if elapsed < self.update_interval:
@@ -1094,11 +1233,15 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
             self.log_error("Failed to get chassis due to {}".format(repr(e)))
             sys.exit(CHASSIS_GET_ERROR)
 
+        # Load per-component polling intervals from platform.json
+        polling_intervals = _parse_platform_json_polling_intervals()
+
         self.thermal_monitor = ThermalMonitor(
             self.chassis,
             thermal_monitor_initial_interval,
             thermal_monitor_update_interval,
-            thermal_monitor_update_elapsed_threshold
+            thermal_monitor_update_elapsed_threshold,
+            polling_intervals=polling_intervals
         )
         self.thermal_monitor.task_run()
 

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -814,25 +814,30 @@ class TemperatureUpdater(logger.Logger):
         else:
             self.log_warning(abnormal_log)
 
-    def _should_update_thermal(self, name):
-        """Check if a thermal should be updated based on its polling interval."""
+    def _should_update_thermal(self, name, now=None):
+        """Check if a thermal should be updated based on its polling interval.
+        :param name: Thermal sensor name
+        :param now: Reference timestamp for this cycle (avoids mid-cycle drift)
+        """
         interval = self._thermal_intervals.get(name, self._default_interval)
         if interval is None:
             return True
-        now = time.time()
+        if now is None:
+            now = time.time()
         last = self._last_thermal_update_times.get(name, 0)
         if now - last >= interval:
             self._last_thermal_update_times[name] = now
             return True
         return False
 
-    def _collect_thermals(self, available_thermals, parent_name, thermals, refresh=True):
+    def _collect_thermals(self, available_thermals, parent_name, thermals, refresh=True, now=None):
         """
         Process thermals from a parent device and update DB.
         :param available_thermals: Set to track available thermals
         :param parent_name: Name of the parent device
         :param thermals: Iterable of thermal objects from get_all_thermals()
         :param refresh: If False, only track thermals and update entity info without refreshing temperature
+        :param now: Reference timestamp for this cycle
         :return: False if task_stopping_event is set, True otherwise
         """
         for thermal_index, thermal in enumerate(thermals):
@@ -843,7 +848,7 @@ class TemperatureUpdater(logger.Logger):
             # Always update entity info so PHYSICAL_ENTITY_INFO is populated
             if 'SFP' not in parent_name:
                 update_entity_info(self.phy_entity_table, parent_name, name, thermal, thermal_index + 1)
-            if refresh and self._should_update_thermal(name):
+            if refresh and self._should_update_thermal(name, now=now):
                 self._refresh_temperature_status(parent_name, thermal, thermal_index)
         return True
 
@@ -868,18 +873,20 @@ class TemperatureUpdater(logger.Logger):
                 self._refresh_temperature_status(parent_name, thermal, thermal_index, is_sfp=True, port_name=port_name)
         return True
 
-    def update(self):
+    def update(self, now=None):
         """
         Update all temperature information to database
+        :param now: Reference timestamp for this cycle (from ThermalMonitor.main begin)
         :return:
         """
         self.log_debug("Start temperature updating")
+        if now is None:
+            now = time.time()
         available_thermals = set()
 
-        if not self._collect_thermals(available_thermals, CHASSIS_INFO_KEY, self.chassis.get_all_thermals()):
+        if not self._collect_thermals(available_thermals, CHASSIS_INFO_KEY, self.chassis.get_all_thermals(), now=now):
             return
 
-        now = time.time()
         should_update_psu = (self._psu_interval is None or
                              (now - self._last_psu_thermal_update) >= self._psu_interval)
 
@@ -887,7 +894,7 @@ class TemperatureUpdater(logger.Logger):
             if psu.get_presence():
                 parent_name = try_get(psu.get_name, default='PSU {}'.format(psu_index + 1))
                 if not self._collect_thermals(available_thermals, parent_name, psu.get_all_thermals(),
-                                              refresh=should_update_psu):
+                                              refresh=should_update_psu, now=now):
                     return
 
         if should_update_psu:
@@ -1171,7 +1178,7 @@ class ThermalMonitor(ThreadTaskBase):
             self.fan_updater.update()
             self._last_fan_update = begin
 
-        self.temperature_updater.update()
+        self.temperature_updater.update(now=begin)
         elapsed = time.time() - begin
         if elapsed < self.update_interval:
             self.wait_time = self.update_interval - elapsed

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -852,13 +852,14 @@ class TemperatureUpdater(logger.Logger):
                 self._refresh_temperature_status(parent_name, thermal, thermal_index)
         return True
 
-    def _collect_sfp_thermals(self, available_thermals, parent_name, sfp_index, thermals):
+    def _collect_sfp_thermals(self, available_thermals, parent_name, sfp_index, thermals, now=None):
         """
         Process SFP thermals, reading temperature from Redis.
         :param available_thermals: Set to track available thermals
         :param parent_name: Name of the parent SFP
         :param sfp_index: SFP index for port name lookup
         :param thermals: Iterable of thermal objects from get_all_thermals()
+        :param now: Reference timestamp for this cycle
         :return: False if task_stopping_event is set, True otherwise
         """
         # TODO: This Redis-based approach for reading SFP temperature is temporary.
@@ -870,7 +871,9 @@ class TemperatureUpdater(logger.Logger):
                 return False
             available_thermals.add((thermal, parent_name, thermal_index))
             if port_name:
-                self._refresh_temperature_status(parent_name, thermal, thermal_index, is_sfp=True, port_name=port_name)
+                name = try_get(thermal.get_name, '{} Thermal {}'.format(parent_name, thermal_index + 1))
+                if self._should_update_thermal(name, now=now):
+                    self._refresh_temperature_status(parent_name, thermal, thermal_index, is_sfp=True, port_name=port_name)
         return True
 
     def update(self, now=None):
@@ -902,7 +905,7 @@ class TemperatureUpdater(logger.Logger):
 
         for sfp_index, sfp in enumerate(self.chassis.get_all_sfps()):
             if not self._collect_sfp_thermals(available_thermals, 'SFP {}'.format(sfp_index + 1),
-                                              sfp_index, sfp.get_all_thermals()):
+                                              sfp_index, sfp.get_all_thermals(), now=now):
                 return
 
         # As there are no modules present in DPU, this IF condition is not updated to consider DPU chassis
@@ -915,7 +918,7 @@ class TemperatureUpdater(logger.Logger):
 
                 for sfp_index, sfp in enumerate(module.get_all_sfps()):
                     if not self._collect_sfp_thermals(available_thermals, '{} SFP {}'.format(module_name, sfp_index + 1),
-                                                      sfp_index, sfp.get_all_thermals()):
+                                                      sfp_index, sfp.get_all_thermals(), now=now):
                         return
 
                 for psu_index, psu in enumerate(module.get_all_psus()):
@@ -1140,7 +1143,7 @@ class ThermalMonitor(ThreadTaskBase):
 
         # Fan update interval: minimum of fan_drawer and psu intervals
         fan_intervals = [i for i in [fan_drawer_interval, psu_interval] if i is not None]
-        self._fan_update_interval = min(fan_intervals) if fan_intervals else None
+        self._fan_update_interval = min(fan_intervals) if fan_intervals else update_interval
         self._last_fan_update = 0
 
         self.fan_updater = FanUpdater(chassis, self.task_stopping_event)

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -1945,10 +1945,10 @@ class TestThermalMonitorPollingIntervals(object):
             polling_intervals={'fan_drawer': 20, 'psu': 15, 'thermals': {}})
         assert monitor._fan_update_interval == 15
 
-    def test_fan_update_interval_none_when_no_intervals(self):
+    def test_fan_update_interval_defaults_to_update_interval(self):
         chassis = MockChassis()
         monitor = thermalctld.ThermalMonitor(chassis, 5, 60, 30)
-        assert monitor._fan_update_interval is None
+        assert monitor._fan_update_interval == 60
 
     def test_update_interval_adjusted_for_fast_polling(self):
         chassis = MockChassis()
@@ -2000,15 +2000,26 @@ class TestThermalMonitorPollingIntervals(object):
         monitor.main()
         assert monitor.fan_updater.update.call_count == 1
 
-    def test_main_always_updates_fans_when_no_interval(self):
+    def test_main_throttles_fan_update_at_default_interval(self):
         chassis = MockChassis()
         monitor = thermalctld.ThermalMonitor(chassis, 5, 60, 30)
         monitor.fan_updater.update = mock.MagicMock()
         monitor.temperature_updater.update = mock.MagicMock()
 
+        # First call — should update fans (last_fan_update == 0)
         monitor.main()
+        assert monitor.fan_updater.update.call_count == 1
+
+        monitor.fan_updater.update.reset_mock()
+
+        # Second call immediately — should skip fans (default 60s not elapsed)
         monitor.main()
-        assert monitor.fan_updater.update.call_count == 2
+        assert monitor.fan_updater.update.call_count == 0
+
+        # After interval elapses, should update again
+        monitor._last_fan_update = time.time() - 61
+        monitor.main()
+        assert monitor.fan_updater.update.call_count == 1
 
 
 class TestCollectFansEarlyReturn(object):
@@ -2068,3 +2079,24 @@ class TestCollectThermalsEarlyReturn(object):
         available = set()
         result = updater._collect_sfp_thermals(available, 'SFP 1', 0, [MockThermal()])
         assert result is False
+
+    def test_collect_sfp_thermals_throttled_by_default_interval(self):
+        chassis = MockChassis()
+        updater = thermalctld.TemperatureUpdater(
+            chassis, threading.Event(), default_interval=60)
+        updater._refresh_temperature_status = mock.MagicMock()
+        updater._get_port_name_by_index = mock.MagicMock(return_value='Ethernet0')
+        available = set()
+        now = time.time()
+
+        # First call — should refresh (last update time is 0)
+        result = updater._collect_sfp_thermals(available, 'SFP 1', 0, [MockThermal()], now=now)
+        assert result is True
+        assert updater._refresh_temperature_status.call_count == 1
+
+        updater._refresh_temperature_status.reset_mock()
+
+        # Second call immediately — should skip (60s not elapsed)
+        result = updater._collect_sfp_thermals(available, 'SFP 1', 0, [MockThermal()], now=now + 1)
+        assert result is True
+        assert updater._refresh_temperature_status.call_count == 0

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -1702,3 +1702,369 @@ class TestThermalControlDaemon(object):
 
             # Clean up
             daemon_thermalctld.deinit()
+
+
+class TestParsePollingIntervals(object):
+    """Tests for _parse_platform_json_polling_intervals()"""
+
+    def _mock_platform_json(self, data):
+        """Helper: return patch context managers for os.path.isfile + builtins.open."""
+        import io, json as _json
+        content = _json.dumps(data)
+        mock_open = mock.mock_open(read_data=content)
+        return (
+            mock.patch('thermalctld.os.path.isfile', return_value=True),
+            mock.patch('builtins.open', mock_open),
+        )
+
+    def test_returns_defaults_when_no_platform_json(self):
+        with mock.patch('thermalctld.os.path.isfile', return_value=False):
+            result = thermalctld._parse_platform_json_polling_intervals()
+        assert result == {'fan_drawer': None, 'psu': None, 'thermals': {}}
+
+    def test_returns_defaults_on_exception(self):
+        with mock.patch('thermalctld.os.path.isfile', return_value=True), \
+             mock.patch('builtins.open', side_effect=Exception("file not found")):
+            result = thermalctld._parse_platform_json_polling_intervals()
+        assert result == {'fan_drawer': None, 'psu': None, 'thermals': {}}
+
+    def test_parses_fan_drawer_interval(self):
+        p1, p2 = self._mock_platform_json({'fan_drawers': [{'polling_interval': '10'}]})
+        with p1, p2:
+            result = thermalctld._parse_platform_json_polling_intervals()
+        assert result['fan_drawer'] == 10.0
+
+    def test_parses_psu_interval(self):
+        p1, p2 = self._mock_platform_json({'psus': [{'polling_interval': '30'}]})
+        with p1, p2:
+            result = thermalctld._parse_platform_json_polling_intervals()
+        assert result['psu'] == 30.0
+
+    def test_parses_thermal_intervals(self):
+        p1, p2 = self._mock_platform_json({
+            'thermals': [
+                {'name': 'CPU Temp', 'polling_interval': '5'},
+                {'name': 'GPU Temp', 'polling_interval': '15'},
+            ]
+        })
+        with p1, p2:
+            result = thermalctld._parse_platform_json_polling_intervals()
+        assert result['thermals'] == {'CPU Temp': 5.0, 'GPU Temp': 15.0}
+
+    def test_skips_empty_polling_interval(self):
+        p1, p2 = self._mock_platform_json({
+            'fan_drawers': [{'polling_interval': ''}],
+            'psus': [{'polling_interval': ''}],
+            'thermals': [{'name': 'T1', 'polling_interval': ''}],
+        })
+        with p1, p2:
+            result = thermalctld._parse_platform_json_polling_intervals()
+        assert result == {'fan_drawer': None, 'psu': None, 'thermals': {}}
+
+    def test_skips_invalid_polling_interval(self):
+        p1, p2 = self._mock_platform_json({
+            'fan_drawers': [{'polling_interval': 'abc'}],
+            'psus': [{'polling_interval': 'xyz'}],
+            'thermals': [{'name': 'T1', 'polling_interval': 'bad'}],
+        })
+        with p1, p2:
+            result = thermalctld._parse_platform_json_polling_intervals()
+        assert result == {'fan_drawer': None, 'psu': None, 'thermals': {}}
+
+    def test_skips_named_fan_drawer_entries(self):
+        """Entries with 'name' are devices, not config — should be skipped."""
+        p1, p2 = self._mock_platform_json({
+            'fan_drawers': [
+                {'name': 'FanDrawer 1', 'polling_interval': '10'},
+            ]
+        })
+        with p1, p2:
+            result = thermalctld._parse_platform_json_polling_intervals()
+        assert result['fan_drawer'] is None
+
+    def test_thermals_without_name_skipped(self):
+        p1, p2 = self._mock_platform_json({
+            'thermals': [{'polling_interval': '5'}]
+        })
+        with p1, p2:
+            result = thermalctld._parse_platform_json_polling_intervals()
+        assert result['thermals'] == {}
+
+    def test_parses_chassis_nested_structure(self):
+        """Real platform.json nests components under a 'chassis' key."""
+        p1, p2 = self._mock_platform_json({
+            'chassis': {
+                'name': 'TestChassis',
+                'fan_drawers': [{'polling_interval': '10'}, {'name': 'FD1'}],
+                'psus': [{'polling_interval': '30'}, {'name': 'PSU1'}],
+                'thermals': [{'name': 'CPU', 'polling_interval': '5'}],
+            },
+            'interfaces': {}
+        })
+        with p1, p2:
+            result = thermalctld._parse_platform_json_polling_intervals()
+        assert result['fan_drawer'] == 10.0
+        assert result['psu'] == 30.0
+        assert result['thermals'] == {'CPU': 5.0}
+
+
+class TestShouldUpdateThermal(object):
+    """Tests for TemperatureUpdater._should_update_thermal()"""
+
+    def test_always_true_when_no_interval_configured(self):
+        chassis = MockChassis()
+        updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
+        assert updater._should_update_thermal('Unknown Thermal') is True
+
+    def test_default_interval_throttles_unconfigured_thermals(self):
+        chassis = MockChassis()
+        updater = thermalctld.TemperatureUpdater(
+            chassis, threading.Event(), default_interval=60)
+        # First call always returns True (last time is 0)
+        assert updater._should_update_thermal('Unknown Thermal') is True
+        # Immediately after, should be throttled
+        assert updater._should_update_thermal('Unknown Thermal') is False
+
+    def test_default_interval_allows_after_elapsed(self):
+        chassis = MockChassis()
+        updater = thermalctld.TemperatureUpdater(
+            chassis, threading.Event(), default_interval=1)
+        updater._should_update_thermal('Unknown Thermal')
+        updater._last_thermal_update_times['Unknown Thermal'] = time.time() - 2
+        assert updater._should_update_thermal('Unknown Thermal') is True
+
+    def test_true_on_first_call(self):
+        chassis = MockChassis()
+        updater = thermalctld.TemperatureUpdater(
+            chassis, threading.Event(), thermal_intervals={'CPU Temp': 10})
+        assert updater._should_update_thermal('CPU Temp') is True
+
+    def test_false_before_interval_elapses(self):
+        chassis = MockChassis()
+        updater = thermalctld.TemperatureUpdater(
+            chassis, threading.Event(), thermal_intervals={'CPU Temp': 100})
+        updater._should_update_thermal('CPU Temp')  # first call sets timestamp
+        assert updater._should_update_thermal('CPU Temp') is False
+
+    def test_true_after_interval_elapses(self):
+        chassis = MockChassis()
+        updater = thermalctld.TemperatureUpdater(
+            chassis, threading.Event(), thermal_intervals={'CPU Temp': 1})
+        updater._should_update_thermal('CPU Temp')
+        # Fake that last update was 2 seconds ago
+        updater._last_thermal_update_times['CPU Temp'] = time.time() - 2
+        assert updater._should_update_thermal('CPU Temp') is True
+
+    def test_explicit_interval_overrides_default(self):
+        chassis = MockChassis()
+        updater = thermalctld.TemperatureUpdater(
+            chassis, threading.Event(),
+            thermal_intervals={'CPU Temp': 5}, default_interval=60)
+        updater._should_update_thermal('CPU Temp')
+        # CPU Temp uses explicit 5s, not default 60s
+        updater._last_thermal_update_times['CPU Temp'] = time.time() - 6
+        assert updater._should_update_thermal('CPU Temp') is True
+
+
+class TestPsuIntervalGating(object):
+    """Tests for PSU thermal polling interval gating in TemperatureUpdater.update()"""
+
+    def test_psu_thermals_skipped_before_interval(self):
+        chassis = MockChassis()
+        psu = MockPsu()
+        psu._thermal_list.append(MockThermal())
+        chassis._psu_list.append(psu)
+
+        updater = thermalctld.TemperatureUpdater(
+            chassis, threading.Event(), psu_interval=300)
+        updater._refresh_temperature_status = mock.MagicMock()
+
+        # First update — should refresh PSU thermals (last_psu_thermal_update == 0)
+        updater.update()
+        first_count = updater._refresh_temperature_status.call_count
+        assert first_count > 0
+
+        updater._refresh_temperature_status.reset_mock()
+
+        # Second update — PSU interval not yet elapsed, PSU thermals should be
+        # collected (tracked in available_thermals) but NOT refreshed.
+        # Chassis thermals still refresh.
+        updater.update()
+        # Only chassis thermals refreshed (0 chassis thermals here, so 0 calls)
+        assert updater._refresh_temperature_status.call_count == 0
+
+    def test_psu_thermals_refreshed_after_interval(self):
+        chassis = MockChassis()
+        psu = MockPsu()
+        psu._thermal_list.append(MockThermal())
+        chassis._psu_list.append(psu)
+
+        updater = thermalctld.TemperatureUpdater(
+            chassis, threading.Event(), psu_interval=1)
+        updater._refresh_temperature_status = mock.MagicMock()
+
+        updater.update()
+        updater._refresh_temperature_status.reset_mock()
+
+        # Fake that last PSU update was 2 seconds ago
+        updater._last_psu_thermal_update = time.time() - 2
+        updater.update()
+        assert updater._refresh_temperature_status.call_count > 0
+
+    def test_psu_thermals_always_refreshed_when_no_interval(self):
+        chassis = MockChassis()
+        psu = MockPsu()
+        psu._thermal_list.append(MockThermal())
+        chassis._psu_list.append(psu)
+
+        updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
+        updater._refresh_temperature_status = mock.MagicMock()
+
+        updater.update()
+        first_count = updater._refresh_temperature_status.call_count
+        updater._refresh_temperature_status.reset_mock()
+
+        updater.update()
+        assert updater._refresh_temperature_status.call_count == first_count
+
+
+class TestThermalMonitorPollingIntervals(object):
+    """Tests for ThermalMonitor with polling_intervals parameter"""
+
+    def test_fan_update_interval_from_fan_drawer(self):
+        chassis = MockChassis()
+        monitor = thermalctld.ThermalMonitor(
+            chassis, 5, 60, 30,
+            polling_intervals={'fan_drawer': 10, 'psu': None, 'thermals': {}})
+        assert monitor._fan_update_interval == 10
+
+    def test_fan_update_interval_from_min_of_fan_drawer_and_psu(self):
+        chassis = MockChassis()
+        monitor = thermalctld.ThermalMonitor(
+            chassis, 5, 60, 30,
+            polling_intervals={'fan_drawer': 20, 'psu': 15, 'thermals': {}})
+        assert monitor._fan_update_interval == 15
+
+    def test_fan_update_interval_none_when_no_intervals(self):
+        chassis = MockChassis()
+        monitor = thermalctld.ThermalMonitor(chassis, 5, 60, 30)
+        assert monitor._fan_update_interval is None
+
+    def test_update_interval_adjusted_for_fast_polling(self):
+        chassis = MockChassis()
+        monitor = thermalctld.ThermalMonitor(
+            chassis, 5, 60, 30,
+            polling_intervals={'fan_drawer': 10, 'psu': None, 'thermals': {}})
+        assert monitor.update_interval == 10
+
+    def test_update_interval_not_adjusted_when_polling_is_slower(self):
+        chassis = MockChassis()
+        monitor = thermalctld.ThermalMonitor(
+            chassis, 5, 60, 30,
+            polling_intervals={'fan_drawer': 120, 'psu': None, 'thermals': {}})
+        assert monitor.update_interval == 60
+
+    def test_main_skips_fan_update_before_interval(self):
+        chassis = MockChassis()
+        monitor = thermalctld.ThermalMonitor(
+            chassis, 5, 60, 30,
+            polling_intervals={'fan_drawer': 300, 'psu': None, 'thermals': {}})
+        monitor.fan_updater.update = mock.MagicMock()
+        monitor.temperature_updater.update = mock.MagicMock()
+
+        # First call — should update fans (last_fan_update == 0)
+        monitor.main()
+        assert monitor.fan_updater.update.call_count == 1
+
+        monitor.fan_updater.update.reset_mock()
+
+        # Second call immediately — should skip fans
+        monitor.main()
+        assert monitor.fan_updater.update.call_count == 0
+        # Temperature always updates
+        assert monitor.temperature_updater.update.call_count == 2
+
+    def test_main_updates_fans_after_interval(self):
+        chassis = MockChassis()
+        monitor = thermalctld.ThermalMonitor(
+            chassis, 5, 60, 30,
+            polling_intervals={'fan_drawer': 1, 'psu': None, 'thermals': {}})
+        monitor.fan_updater.update = mock.MagicMock()
+        monitor.temperature_updater.update = mock.MagicMock()
+
+        monitor.main()
+        monitor.fan_updater.update.reset_mock()
+
+        # Fake that last fan update was 2 seconds ago
+        monitor._last_fan_update = time.time() - 2
+        monitor.main()
+        assert monitor.fan_updater.update.call_count == 1
+
+    def test_main_always_updates_fans_when_no_interval(self):
+        chassis = MockChassis()
+        monitor = thermalctld.ThermalMonitor(chassis, 5, 60, 30)
+        monitor.fan_updater.update = mock.MagicMock()
+        monitor.temperature_updater.update = mock.MagicMock()
+
+        monitor.main()
+        monitor.main()
+        assert monitor.fan_updater.update.call_count == 2
+
+
+class TestCollectFansEarlyReturn(object):
+    """Tests for FanUpdater._collect_fans() task_stopping_event handling"""
+
+    def test_collect_fans_returns_false_on_stopping_event(self):
+        chassis = MockChassis()
+        stopping_event = threading.Event()
+        stopping_event.set()  # Pre-set stopping event
+        fan_updater = thermalctld.FanUpdater(chassis, stopping_event)
+        fan_drawer = MockFanDrawer(0)
+        fan_drawer._fan_list.append(MockFan())
+        result = fan_updater._collect_fans(fan_drawer, 0, thermalctld.FanType.DRAWER)
+        assert result is False
+
+    def test_collect_fans_returns_true_normally(self):
+        chassis = MockChassis()
+        fan_updater = thermalctld.FanUpdater(chassis, threading.Event())
+        fan_updater._refresh_fan_status = mock.MagicMock()
+        fan_drawer = MockFanDrawer(0)
+        fan_drawer._fan_list.append(MockFan())
+        result = fan_updater._collect_fans(fan_drawer, 0, thermalctld.FanType.DRAWER)
+        assert result is True
+        assert fan_updater._refresh_fan_status.call_count == 1
+
+
+class TestCollectThermalsEarlyReturn(object):
+    """Tests for TemperatureUpdater._collect_thermals() and _collect_sfp_thermals()"""
+
+    def test_collect_thermals_returns_false_on_stopping_event(self):
+        chassis = MockChassis()
+        stopping_event = threading.Event()
+        stopping_event.set()
+        updater = thermalctld.TemperatureUpdater(chassis, stopping_event)
+        available = set()
+        result = updater._collect_thermals(available, 'test', [MockThermal()])
+        assert result is False
+
+    def test_collect_thermals_no_refresh_when_false(self):
+        chassis = MockChassis()
+        updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
+        updater._refresh_temperature_status = mock.MagicMock()
+        updater.phy_entity_table = mock.MagicMock()
+        available = set()
+        result = updater._collect_thermals(available, 'PSU 1', [MockThermal()], refresh=False)
+        assert result is True
+        assert len(available) == 1
+        updater._refresh_temperature_status.assert_not_called()
+        # Entity info should still be updated even without temperature refresh
+        updater.phy_entity_table.set.assert_called()
+
+    def test_collect_sfp_thermals_returns_false_on_stopping_event(self):
+        chassis = MockChassis()
+        stopping_event = threading.Event()
+        stopping_event.set()
+        updater = thermalctld.TemperatureUpdater(chassis, stopping_event)
+        available = set()
+        result = updater._collect_sfp_thermals(available, 'SFP 1', 0, [MockThermal()])
+        assert result is False


### PR DESCRIPTION
#### Description

Add support for configurable per-component polling intervals in thermalctld via platform.json. Each component type can specify its own polling rate:

- `fan_drawers[0].polling_interval`: interval in seconds for fan updates
- `psus[0].polling_interval`: interval in seconds for PSU thermal updates
- `thermals[*].polling_interval`: per-thermal sensor interval in seconds

Config entries (without a `name` key) are inserted at the beginning of `fan_drawers` / `psus` arrays. Each thermal device entry with a `name` can have its own `polling_interval`.

When any custom thermal intervals are configured, thermals without an explicit `polling_interval` fall back to the original 60s default instead of running at the fast-loop rate. This prevents unconfigured sensors from being polled too frequently when the main loop interval is reduced to accommodate fast-polling sensors.

The main loop interval adjusts to the minimum of all configured intervals so fast-polling components are serviced on time, while slower components are throttled via per-component timestamp tracking.

#### Motivation and Context

On platforms with many thermal sensors, polling all sensors every cycle can add unnecessary overhead. Some sensors (e.g., ASIC temperature) need frequent monitoring while others (e.g., ambient temps, SODIMM) can be polled less often. This change allows platform vendors to fine-tune polling rates per component via platform.json without code changes.

#### How Has This Been Tested?

1. **Unit tests**: Added tests for `_parse_platform_json_polling_intervals()`, `_should_update_thermal()` (including `default_interval` behavior), and PSU interval gating. All pass locally via `pytest`.

2. **Testbed verification on SN5640**: Ran tests on a physical testbed with the following platform.json intervals:
   - `fan_drawers`: `polling_interval: 40`
   - `psus`: `polling_interval: 30`
   - `thermals`: ASIC=5s, Ambient Fan Side=10s, Port Side=15s, CPU Pack=20s, SODIMM 2=25s

   Verified:
   - Each component updates at its configured rate (±tolerance for execution overhead)
   - Unconfigured thermals fall back to 60s default
   - Cross-check: fastest thermal (ASIC=5s) updates more often than fans (40s)
   - No errors in thermalctld syslog

3. **Backward compatibility**: Without any `polling_interval` in platform.json, behavior is identical to before (all components update every 60s cycle).

#### Additional Information (Optional)

Example platform.json snippet:
```json
{
    "chassis": {
        "fan_drawers": [
            {"polling_interval": "40"},
            {"name": "drawer1", "fans": [{"name": "fan1"}]}
        ],
        "psus": [
            {"polling_interval": "30"},
            {"name": "PSU 1", "thermals": [{"name": "PSU-1 Temp"}]}
        ],
        "thermals": [
            {"name": "ASIC", "polling_interval": "5"},
            {"name": "CPU Pack Temp", "polling_interval": "20"}
        ]
    }
}
```