### PR TITLE
[CI] Fix libswsscommon boost dependency mismatch on 202505 branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,6 +90,15 @@ jobs:
       displayName: "Download artifacts from latest sonic-buildimage build"
 
     - script: |
+        set -ex
+        # Install .NET CORE
+        curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+        sudo apt-add-repository https://packages.microsoft.com/debian/12/prod
+        sudo apt-get update
+        sudo apt-get install -y dotnet-sdk-8.0
+      displayName: "Install .NET CORE"
+
+    - script: |
         set -xe
         sudo apt-get -y purge libnl-3-dev libnl-route-3-dev || true
         sudo dpkg -i libnl-3-200_*.deb
@@ -97,8 +106,8 @@ jobs:
         sudo dpkg -i libnl-route-3-200_*.deb
         sudo dpkg -i libnl-nf-3-200_*.deb
         sudo dpkg -i libyang_1.0.73_amd64.deb
-        sudo dpkg -i libswsscommon_1.0.0_amd64.deb
-        sudo dpkg -i python3-swsscommon_1.0.0_amd64.deb
+        sudo dpkg --force-depends -i libswsscommon_1.0.0_amd64.deb
+        sudo dpkg --force-depends -i python3-swsscommon_1.0.0_amd64.deb
       workingDirectory: $(Pipeline.Workspace)/target/debs/bookworm/
       displayName: 'Install Debian dependencies'
 
@@ -112,15 +121,6 @@ jobs:
         sudo pip3 install sonic_platform_common-1.0-py3-none-any.whl
       workingDirectory: $(Pipeline.Workspace)/target/python-wheels/bookworm/
       displayName: 'Install Python dependencies'
-
-    - script: |
-        set -ex
-        # Install .NET CORE
-        curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-        sudo apt-add-repository https://packages.microsoft.com/debian/12/prod
-        sudo apt-get update
-        sudo apt-get install -y dotnet-sdk-8.0
-      displayName: "Install .NET CORE"
 
     - ${{ each project in parameters.project_list }}:
       # Python 3


### PR DESCRIPTION
#### Description

Fix CI pipeline failure on the `202505` branch with two changes to `azure-pipelines.yml`:

1. **Add `--force-depends`** to `dpkg -i` for `libswsscommon` and `python3-swsscommon` — the deb artifact depends on `libboost-serialization1.74.0` (Bullseye) but the `sonic-slave-bookworm` container only has boost 1.83 (Bookworm).

2. **Move "Install .NET CORE" step before "Install Debian dependencies"** — the `--force-depends` leaves libswsscommon in an unconfigured state, which causes `apt-get install dotnet-sdk-8.0` to fail with unmet dependencies if it runs after.

#### Motivation and Context

All PRs targeting the `202505` branch are blocked due to this CI failure. See https://github.com/sonic-net/sonic-platform-daemons/pull/781 for an example.

Error 1 (before this fix):
```
dpkg: dependency problems prevent configuration of libswsscommon:
 libswsscommon depends on libboost-serialization1.74.0 (>= 1.74.0+ds1); however:
  Package libboost-serialization1.74.0 is not installed.
```

Error 2 (when .NET install runs after force-depends):
```
dotnet-sdk-8.0 : Depends: dotnet-runtime-8.0 (>= 8.0.25) but it is not going to be installed
libswsscommon : Depends: libboost-serialization1.74.0 (>= 1.74.0+ds1) but it is not going to be installed
```

#### How Has This Been Tested?

- `--force-depends` is safe because the Python unit tests mock `swsscommon` and do not exercise the boost serialization codepath at runtime.
- Moving the .NET install before dpkg ensures `apt-get` runs before any broken dependency state is introduced.

#### Additional Information (Optional)

The `master` branch does not have this issue because its sonic-buildimage artifacts are built with Bookworm-native boost 1.83.

---
> :robot: *Created by DevAce, Jianquan's AI Agent, on his behalf.*