### PR TITLE
Speed up execution of thermalctld unit tests

### DIFF
--- a/sonic-thermalctld/tests/mock_swsscommon.py
+++ b/sonic-thermalctld/tests/mock_swsscommon.py
@@ -27,6 +27,9 @@ class Table:
     def get_size(self):
         return (len(self.mock_dict))
 
+    def getKeys(self):
+        return list(self.mock_dict.keys())
+
 
 class FieldValuePairs:
     def __init__(self, fvs):

--- a/sonic-thermalctld/tests/mocked_libs/swsscommon/swsscommon.py
+++ b/sonic-thermalctld/tests/mocked_libs/swsscommon/swsscommon.py
@@ -2,9 +2,31 @@
     Mock implementation of swsscommon package for unit testing
 '''
 
-from swsssdk import ConfigDBConnector, SonicDBConfig, SonicV2Connector
-
 STATE_DB = ''
+
+class ConfigDBConnector:
+    """
+    Mock ConfigDBConnector that avoids real Redis connections.
+    """
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def connect(self, *args, **kwargs):
+        pass
+
+    def get_table(self, table_name):
+        return {}
+
+    def get_entry(self, table, key):
+        return {}
+
+
+class SonicV2Connector:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def connect(self, *args, **kwargs):
+        pass
 
 
 class Table:

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -31,10 +31,6 @@ from .mock_swsscommon import Table
 daemon_base.db_connect = mock.MagicMock()
 device_info.get_path_to_port_config_file = mock.MagicMock(return_value=None)
 
-import portconfig
-portconfig.db_connect_configdb = mock.MagicMock(return_value=None)
-device_info.get_localhost_info = mock.MagicMock(return_value=None)
-
 # Add path to the file under test so that we can load it
 modules_path = os.path.dirname(tests_path)
 scripts_path = os.path.join(modules_path, 'scripts')

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -31,6 +31,10 @@ from .mock_swsscommon import Table
 daemon_base.db_connect = mock.MagicMock()
 device_info.get_path_to_port_config_file = mock.MagicMock(return_value=None)
 
+import portconfig
+portconfig.db_connect_configdb = mock.MagicMock(return_value=None)
+device_info.get_localhost_info = mock.MagicMock(return_value=None)
+
 # Add path to the file under test so that we can load it
 modules_path = os.path.dirname(tests_path)
 scripts_path = os.path.join(modules_path, 'scripts')


### PR DESCRIPTION
#### Description

Replace the real `swsssdk` imports in `mocked_libs/swsscommon/swsscommon.py` with mock stubs for `ConfigDBConnector` and `SonicV2Connector`, eliminating all `swsssdk` dependencies from the test environment, and add the missing `getKeys()` method to `mock_swsscommon.Table`.

#### Motivation and Context

The thermalctld test suite was taking ~36 minutes to run due to Redis connection timeouts incurred on every `TemperatureUpdater` construction.

`TemperatureUpdater.__init__` calls `_init_sfp_util_helper()`, which invokes `SfpUtilHelper().read_porttab_mappings()`. This triggers up to 7 calls to `device_info.get_localhost_info()` per construction through three call chains: `get_platform_and_hwsku()`, `get_port_config()`, and `get_path_to_port_config_file()`. Each call creates a `ConfigDBConnector` (from `swsscommon.swsscommon`) that retries connecting to Redis ~3 times with ~7s sleep per retry.

The root cause is that `mocked_libs/swsscommon/swsscommon.py` was re-exporting the real `ConfigDBConnector` and `SonicV2Connector` from `swsssdk` instead of providing mock stubs. Since `device_info.py` imports these via `from swsscommon.swsscommon import ConfigDBConnector, SonicV2Connector`, and the mocked package is first in `sys.path` during tests, replacing them with no-op stubs is sufficient to prevent all Redis connection attempts with no other test changes required.

`mock_swsscommon.Table` was also missing `getKeys()`, which `TemperatureUpdater.__del__` calls during cleanup, causing an `AttributeError` warning on every test that constructs a `TemperatureUpdater`.

#### How Has This Been Tested?

Profiled `test_dpu_chassis_thermals` (the worst offender) using `cProfile`:

```
28880 function calls in 49.403 seconds

device_info.get_localhost_info   7 calls × 7.057s = 49.4s total
  └─ swsssdk ConfigDBConnector.connect
     └─ redis retry: 21 × time.sleep(2.35s) = 49.4s
```

After fix:
- `test_dpu_chassis_thermals`: **~230s → 0.07s**
- Full suite: **~36 minutes → ~1 minute**

#### Additional Information (Optional)

The mock stubs follow the same pattern used in `sonic-chassisd/tests/mock_swsscommon.py`.

`SonicV2Connector` is stubbed alongside `ConfigDBConnector` because `device_info.py` imports both in a single statement (`from swsscommon.swsscommon import ConfigDBConnector, SonicV2Connector`). `swsssdk` conditionally bypasses its own deprecation `ImportError` when `mock` or `unittest` are already in `sys.modules` — so during pytest the real `SonicV2Connector` would be importable. Stubbing it explicitly removes the dependency on this behavior and ensures `swsssdk` is never imported in the test environment.

fixes #788 