### PR TITLE
[202511 only] [cmis] Optimize data path state machine by reducing the time spent checking the fast reboot flag

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -5345,6 +5345,7 @@ class TestXcvrdScript(object):
     @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/tmp', '/tmp')))
     @patch('swsscommon.swsscommon.WarmStart', MagicMock())
     @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
+    @patch('xcvrd.xcvrd_utilities.common.is_fast_reboot_enabled', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd_utilities.common.del_port_sfp_dom_info_from_db')
     def test_DaemonXcvrd_init_deinit_fastboot_enabled(self, mock_del_port_sfp_dom_info_from_db):
         xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER)
@@ -5391,6 +5392,7 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
     @patch('xcvrd.xcvrd.DaemonXcvrd.initialize_sfp_obj_dict', MagicMock())
     @patch('subprocess.check_output', MagicMock(return_value='false'))
+    @patch('xcvrd.xcvrd_utilities.common.is_fast_reboot_enabled', MagicMock(return_value=False))
     @patch('xcvrd.xcvrd_utilities.common.del_port_sfp_dom_info_from_db')
     def test_DaemonXcvrd_init_deinit_cold(self, mock_del_port_sfp_dom_info_from_db):
         xcvrd.platform_chassis = MagicMock()

--- a/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
+++ b/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
@@ -60,6 +60,7 @@ class CmisManagerTask(threading.Thread):
         self.namespaces = namespaces
         self.platform_chassis = platform_chassis
         self.xcvr_table_helper = XcvrTableHelper(self.namespaces)
+        self.is_fast_reboot_enabled = False
 
     def log_debug(self, message):
         helper_logger.log_debug(message)
@@ -715,8 +716,6 @@ class CmisManagerTask(threading.Thread):
         return expired_time <= current_time
 
     def process_single_lport(self, lport, info, gearbox_lanes_dict):
-        is_fast_reboot = common.is_fast_reboot_enabled()
-
         state = common.get_cmis_state_from_state_db(lport, self.xcvr_table_helper.get_status_sw_tbl(self.get_asic_id(lport)))
         if state in CMIS_TERMINAL_STATES or state == CMIS_STATE_UNKNOWN:
             if state != CMIS_STATE_READY:
@@ -874,7 +873,7 @@ class CmisManagerTask(threading.Thread):
 
                 if self.port_dict[lport]['host_tx_ready'] != 'true' or \
                         self.port_dict[lport]['admin_status'] != 'up':
-                    if is_fast_reboot and self.check_datapath_state(api, host_lanes_mask, ['DataPathActivated']):
+                    if self.is_fast_reboot_enabled and self.check_datapath_state(api, host_lanes_mask, ['DataPathActivated']):
                         self.log_notice("{} Skip datapath re-init in fast-reboot".format(lport))
                     else:
                         self.log_notice("{} Forcing Tx laser OFF".format(lport))
@@ -1106,6 +1105,9 @@ class CmisManagerTask(threading.Thread):
 
             # Cache gearbox line lanes dictionary once per iteration over all ports
             gearbox_lanes_dict = self.xcvr_table_helper.get_gearbox_line_lanes_dict()
+
+            # Cache fast reboot enabled state once per iteration over all ports
+            self.is_fast_reboot_enabled = common.is_fast_reboot_enabled()
 
             for lport, info in self.port_dict.items():
                 if self.task_stopping_event.is_set():

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/common.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/common.py
@@ -11,7 +11,7 @@ try:
     import traceback
     import threading
     from swsscommon import swsscommon
-    from sonic_py_common import syslogger, daemon_base
+    from sonic_py_common import syslogger, daemon_base, device_info
     from . import sfp_status_helper
     from sonic_platform_base.sonic_xcvr.api.public.c_cmis import CmisApi
 
@@ -121,8 +121,7 @@ def _wrapper_get_presence(physical_port):
 
 def is_fast_reboot_enabled():
     """Check if fast reboot is enabled"""
-    fastboot_enabled = subprocess.check_output('sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable', shell=True, universal_newlines=True)
-    return "true" in fastboot_enabled
+    return device_info.is_fast_reboot_enabled()
 
 def is_warm_reboot_enabled():
     """Check if warm reboot is enabled"""


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
We observe an issue that toggling a logical port on SN5640 takes more than 40 seconds to be up. The log shows a significant delay between each CMIS state machine transition. The PR is to optimize the flow.

#### Motivation and Context
In `CmisManagerTask.process_single_lport`, it checks fast reboot flag for each logical port even if the port does not need run data path state machine. There are 2 issues:

1. We don't have to check fast reboot flag for each logical port. We can move this check out of the for loop. It reduces the call times from N to 1 where N is the logical port number
2. The existing implementation for checking fast reboot flag is via subproces which potentially create a new process. This is too heavy. We can replace it with existing function provided in `device_info.py` which use DB API to get the flag.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Manual test
Unit test

#### Additional Information (Optional)
