### PR TITLE
[202511] Stop the config_manager child process on exception in chassisd

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -1333,6 +1333,7 @@ class ChassisdDaemon(daemon_base.DaemonBase):
         super(ChassisdDaemon, self).__init__(log_identifier)
 
         self.stop = threading.Event()
+        self.loop_interval = CHASSIS_INFO_UPDATE_PERIOD_SECS
 
         self.platform_chassis = chassis
 
@@ -1425,29 +1426,34 @@ class ChassisdDaemon(daemon_base.DaemonBase):
                 self.log_error("Chassisd not supported for this platform")
                 sys.exit(CHASSIS_NOT_SUPPORTED)
 
-        # Start configuration manager task
-        if self.smartswitch:
-            self.set_initial_dpu_admin_state()
-            config_manager = SmartSwitchConfigManagerTask()
-            config_manager.task_run()
-        elif self.module_updater.supervisor_slot == self.module_updater.my_slot:
-            config_manager = ConfigManagerTask()
-            config_manager.task_run()
-        else:
-            config_manager = None
+        try:
+            # Start configuration manager task
+            if self.smartswitch:
+                self.set_initial_dpu_admin_state()
+                self.config_manager = SmartSwitchConfigManagerTask()
+                self.config_manager.task_run()
+            elif self.module_updater.supervisor_slot == self.module_updater.my_slot:
+                self.config_manager = ConfigManagerTask()
+                self.config_manager.task_run()
+            else:
+                self.config_manager = None
 
-        # Start main loop
-        self.log_info("Start daemon main loop")
+            # Start main loop
+            self.log_info("Start daemon main loop")
 
-        while not self.stop.wait(CHASSIS_INFO_UPDATE_PERIOD_SECS):
-            self.module_updater.module_db_update()
-            self.module_updater.check_midplane_reachability()
-            self.module_updater.module_down_chassis_db_cleanup()
+            while not self.stop.wait(self.loop_interval):
+                self.module_updater.module_db_update()
+                self.module_updater.check_midplane_reachability()
+                self.module_updater.module_down_chassis_db_cleanup()
 
-        self.log_info("Stop daemon main loop")
+            self.log_info("Stop daemon main loop")
 
-        if config_manager is not None:
-            config_manager.task_stop()
+        finally:
+            # If we don't cleanup the config_manager process the chassisd process
+            # won't die when an exception occurs.
+            # https://github.com/sonic-net/sonic-buildimage/issues/24775
+            if self.config_manager is not None:
+                self.config_manager.task_stop()
 
         # Delete all the information from DB and then exit
         self.module_updater.deinit()
@@ -1543,7 +1549,7 @@ class DpuChassisdDaemon(ChassisdDaemon):
         # Start main loop
         self.log_info("Start daemon main loop")
 
-        while not self.stop.wait(CHASSIS_INFO_UPDATE_PERIOD_SECS):
+        while not self.stop.wait(self.loop_interval):
             if poll_dpu_state:
                 dpu_updater.update_state()
 

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -3,6 +3,8 @@ import sys
 import mock
 import tempfile
 import json
+import pytest
+import time
 from imp import load_source
 
 from mock import Mock, MagicMock, patch, mock_open
@@ -2044,3 +2046,32 @@ def test_submit_dpu_callback():
         daemon_chassisd.submit_dpu_callback(index, MODULE_ADMIN_DOWN)
         mock_set_admin_state_gracefully.assert_called_once_with(MODULE_ADMIN_DOWN)
 
+
+def test_chassis_daemon_assertion():
+    chassis = MockChassis()
+
+    # Needs to be supervisor slot for config_manager thread to be spawned
+    chassis.get_supervisor_slot = Mock()
+    chassis.get_supervisor_slot.return_value = 0
+    chassis.get_my_slot = Mock()
+    chassis.get_my_slot.return_value = 0
+
+    daemon_chassisd = ChassisdDaemon(SYSLOG_IDENTIFIER, chassis)
+
+    # Reduce wait time from 10s to 1s to speed up test
+    daemon_chassisd.loop_interval=1
+
+    # Simulate an Assertion occurring in the forever loop
+    with patch('chassisd.ModuleUpdater.module_db_update', MagicMock(side_effect=AssertionError)):
+        with pytest.raises(AssertionError):
+            daemon_chassisd.run()
+
+    # Wait for the child thread to die
+    start = time.time()
+    timeout = 30
+    while time.time() - start < timeout:
+        if not daemon_chassisd.config_manager._task_process.is_alive():
+            break
+        time.sleep(1)
+    else:
+        assert False, "config_manager thread never died"


### PR DESCRIPTION
202511 Cherry-pick of https://github.com/sonic-net/sonic-platform-daemons/pull/727
