### PR TITLE
Add support for pdb object of psud

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -36,6 +36,7 @@ PLATFORM_SPECIFIC_CLASS_NAME = "PsuUtil"
 CHASSIS_INFO_TABLE = 'CHASSIS_INFO'
 CHASSIS_INFO_KEY = 'chassis 1'
 CHASSIS_INFO_PSU_NUM_FIELD = 'psu_num'
+CHASSIS_INFO_PDB_NUM_FIELD = 'pdb_num'
 
 CHASSIS_INFO_POWER_CONSUMER_FIELD = 'Consumed Power {}'
 CHASSIS_INFO_POWER_SUPPLIER_FIELD = 'Supplied Power {}'
@@ -64,6 +65,9 @@ PSU_INFO_FRU_FIELD = 'is_replaceable'
 PSU_INFO_IN_VOLTAGE_FIELD = 'input_voltage'
 PSU_INFO_IN_CURRENT_FIELD = 'input_current'
 PSU_INFO_POWER_MAX_FIELD = 'max_power'
+PSU_INFO_TIMESTAMP_FIELD = 'timestamp'
+
+PDB_INFO_KEY_TEMPLATE = 'PDB {}'
 
 PHYSICAL_ENTITY_INFO_TABLE = 'PHYSICAL_ENTITY_INFO'
 
@@ -92,11 +96,17 @@ exit_code = 0
 
 
 def _wrapper_get_num_psus(logger):
+    """Get total number of PSUs when using psuutil; total PSUs+PDBs when using chassis (for __del__ iteration)."""
     if platform_chassis is not None:
         try:
-            return platform_chassis.get_num_psus()
+            n_psu = platform_chassis.get_num_psus()
         except NotImplementedError:
-            pass
+            n_psu = 0
+        try:
+            n_pdb = platform_chassis.get_num_pdbs()
+        except NotImplementedError:
+            n_pdb = 0
+        return n_psu + n_pdb
     if platform_psuutil is not None:
         return platform_psuutil.get_num_psus()
     if logger:
@@ -110,19 +120,45 @@ def _wrapper_get_psu(logger, psu_index):
     :param logger: Logger instance for error/warning messages
     :param psu_index: PSU index (1-based)
     :return: PSU object if available, None otherwise
-
-    Note:
-        If logger is None, errors and warnings encountered during execution will not be logged.
     """
-    if platform_chassis is not None:
-        try:
-            return platform_chassis.get_psu(psu_index - 1)
-        except NotImplementedError as e:
-            if logger:
-                logger.log_warning("get_psu() not implemented by platform chassis: {}".format(str(e)))
-        except Exception as e:
-            if logger:
-                logger.log_error("Failed to get PSU {} from platform chassis: {}".format(psu_index, str(e)))
+    if platform_chassis is None:
+        return None
+    if psu_index < 1:
+        return None
+    try:
+        psu = platform_chassis.get_psu(psu_index - 1)
+        if psu is not None:
+            return psu
+    except NotImplementedError:
+        if logger:
+            logger.log_warning("get_psu() not implemented by platform chassis: Not implemented")
+    except Exception as e:
+        if logger:
+            logger.log_error("Failed to get PSU {} from platform chassis: {}".format(psu_index, str(e)))
+    return None
+
+
+def _wrapper_get_pdb(logger, pdb_index):
+    """
+    Get PDB object from platform chassis
+    :param logger: Logger instance for error/warning messages
+    :param pdb_index: PDB index (1-based)
+    :return: PDB object if available, None otherwise
+    """
+    if platform_chassis is None:
+        return None
+    if pdb_index < 1:
+        return None
+    try:
+        pdb = platform_chassis.get_pdb(pdb_index - 1)
+        if pdb is not None:
+            return pdb
+    except NotImplementedError:
+        if logger:
+            logger.log_warning("get_pdb() not implemented by platform chassis: Not implemented")
+    except Exception as e:
+        if logger:
+            logger.log_error("Failed to get PDB {} from platform chassis: {}".format(pdb_index, str(e)))
     return None
 
 
@@ -150,6 +186,22 @@ def _wrapper_get_psu_presence(logger, psu_index):
     return False
 
 
+def _wrapper_get_pdb_presence(logger, pdb_index):
+    if platform_chassis is None:
+        return False
+    pdb = _wrapper_get_pdb(logger, pdb_index)
+    if not pdb:
+        return False
+    try:
+        return pdb.get_presence()
+    except NotImplementedError:
+        return False
+    except Exception as e:
+        if logger:
+            logger.log_warning("Exception in pdb.get_presence() for PDB {}: {}".format(pdb_index, str(e)))
+        return False
+
+
 def _wrapper_get_psu_status(logger, psu_index):
     if platform_chassis is not None:
         psu = _wrapper_get_psu(logger, psu_index)
@@ -174,19 +226,46 @@ def _wrapper_get_psu_status(logger, psu_index):
     return False
 
 
+def _wrapper_get_pdb_status(logger, pdb_index):
+    if platform_chassis is None:
+        return False
+    pdb = _wrapper_get_pdb(logger, pdb_index)
+    if not pdb:
+        return False
+    try:
+        return pdb.get_powergood_status()
+    except NotImplementedError:
+        return False
+    except Exception as e:
+        if logger:
+            logger.log_warning("Exception in pdb.get_powergood_status() for PDB {}: {}".format(pdb_index, str(e)))
+        return False
+
+
 #
 # Helper functions =============================================================
 #
 
 def get_psu_key(psu_index):
-    if platform_chassis is not None:
-        psu = _wrapper_get_psu(None, psu_index)
-        if psu:
-            try:
-                return psu.get_name()
-            except Exception:
-                pass
+    """Return PSU_INFO key (object name) for 1-based PSU index. Used for legacy psuutil path."""
+    psu = _wrapper_get_psu(None, psu_index)
+    if psu is not None:
+        try:
+            return psu.get_name()
+        except Exception:
+            pass
     return PSU_INFO_KEY_TEMPLATE.format(psu_index)
+
+
+def get_pdb_key(pdb_index):
+    """Return PDB_INFO_KEY_TEMPLATE key (object name) for 1-based PDB index."""
+    pdb = _wrapper_get_pdb(None, pdb_index)
+    if pdb is not None:
+        try:
+            return pdb.get_name()
+        except Exception:
+            pass
+    return PDB_INFO_KEY_TEMPLATE.format(pdb_index)
 
 
 # try get information from platform API and return a default value if we catch NotImplementedError
@@ -213,6 +292,30 @@ def try_get(callback, default=None):
         ret = default
 
     return ret
+
+
+def _sum_system_power_from_other_psus_and_pdbs(chassis, entity, system_power):
+    """
+    Add get_power() from every other PSU and every other PDB to system_power.
+    Uses two separate loops (does not build a combined PSUs+PDBs list).
+    """
+    try:
+        for other in chassis.get_all_psus():
+            if other is not entity:
+                power_str = try_get(other.get_power, NOT_AVAILABLE)
+                if power_str != NOT_AVAILABLE:
+                    system_power += float(power_str)
+    except NotImplementedError:
+        pass
+    try:
+        for other in chassis.get_all_pdbs():
+            if other is not entity:
+                power_str = try_get(other.get_power, NOT_AVAILABLE)
+                if power_str != NOT_AVAILABLE:
+                    system_power += float(power_str)
+    except NotImplementedError:
+        pass
+    return system_power
 
 
 def log_on_status_changed(logger, normal_status, normal_log, abnormal_log):
@@ -258,34 +361,52 @@ class PsuChassisInfo(logger.Logger):
 
         dict_index = 0
         total_entries_len = 2  # For total supplied and consumed
-        dict_len = self.chassis.get_num_psus() +\
+        psu_list = []
+        pdb_list = []
+        try:
+            psu_list = list(self.chassis.get_all_psus())
+            pdb_list = list(self.chassis.get_all_pdbs())
+        except NotImplementedError:
+            pdb_list = []
+            try:
+                psu_list = list(self.chassis.get_all_psus())
+            except NotImplementedError:
+                psu_list = []
+        num_suppliers = len(psu_list) + len(pdb_list)
+        dict_len = num_suppliers +\
             self.chassis.get_num_fan_drawers() +\
             self.chassis.get_num_modules() + \
             total_entries_len
 
         fvs = swsscommon.FieldValuePairs(dict_len)
 
-        for index, psu in enumerate(self.chassis.get_all_psus()):
-            name = try_get(psu.get_name, 'PSU {}'.format(index + 1))
-            presence = try_get(psu.get_presence)
+        def _process_power_supplier(supplier, index, default_prefix):
+            nonlocal dict_index, total_supplied_power
+            name = try_get(supplier.get_name, '{} {}'.format(default_prefix, index + 1))
+            presence = try_get(supplier.get_presence)
             if not presence:
                 try:
                     chassis_tbl.hdel(CHASSIS_INFO_POWER_KEY_TEMPLATE.format(1), CHASSIS_INFO_POWER_SUPPLIER_FIELD.format(name))
                 except RuntimeError as e:
-                    self.log_error("Failed to delete PSU {} power info from DB: {}".format(name, e))
-                continue
+                    self.log_error("Failed to delete {} power info from DB: {}".format(name, e))
+                return
 
-            power_good = try_get(psu.get_powergood_status)
+            power_good = try_get(supplier.get_powergood_status)
             if not power_good:
                 supplied_power = 0.0
                 fvs[dict_index] = (CHASSIS_INFO_POWER_SUPPLIER_FIELD.format(name), str(supplied_power))
                 dict_index += 1
-                continue
+                return
 
-            supplied_power = try_get(psu.get_maximum_supplied_power, 0.0)
+            supplied_power = try_get(supplier.get_maximum_supplied_power, 0.0)
             total_supplied_power = total_supplied_power + supplied_power
             fvs[dict_index] = (CHASSIS_INFO_POWER_SUPPLIER_FIELD.format(name), str(supplied_power))
             dict_index += 1
+
+        for index, supplier in enumerate(psu_list):
+            _process_power_supplier(supplier, index, 'PSU')
+        for index, supplier in enumerate(pdb_list):
+            _process_power_supplier(supplier, index, 'PDB')
 
         for index, power_consumer in enumerate(self.chassis.get_all_fan_drawers()):
             presence = try_get(power_consumer.get_presence)
@@ -362,9 +483,10 @@ class PsuChassisInfo(logger.Logger):
 
 
 class PsuStatus(object):
-    def __init__(self, logger, psu, psu_index):
-        self.psu = psu
-        self.psu_index = psu_index
+    def __init__(self, logger, entity, name):
+        """entity: PSU or PDB object (PsuBase/PdbBase). name: DB key e.g. 'PSU 1' or 'PDB 1'."""
+        self.psu = entity
+        self.psu_index = name  # used in log messages
         self.presence = True
         self.power_good = True
         self.voltage_good = True
@@ -488,36 +610,73 @@ class DaemonPsud(daemon_base.DaemonBase):
             self.log_error("Failed to connect to STATE_DB: {}".format(e))
             sys.exit(PSU_DB_CONNECT_ERROR)
 
-        # Post psu number info to STATE_DB
+        # Post psu/pdb number info to STATE_DB (once at boot/reload)
         self.num_psus = _wrapper_get_num_psus(self)
-        fvs = swsscommon.FieldValuePairs([(CHASSIS_INFO_PSU_NUM_FIELD, str(self.num_psus))])
+        num_psus_chassis = 0
+        num_pdbs_chassis = 0
+        self.all_power_entity_names = []
+        if platform_chassis is not None:
+            try:
+                num_psus_chassis = platform_chassis.get_num_psus()
+                self.all_power_entity_names.extend([p.get_name() for p in platform_chassis.get_all_psus()])
+            except NotImplementedError:
+                pass
+            try:
+                num_pdbs_chassis = platform_chassis.get_num_pdbs()
+                self.all_power_entity_names.extend([p.get_name() for p in platform_chassis.get_all_pdbs()])
+            except NotImplementedError:
+                pass
+        fvs = swsscommon.FieldValuePairs([
+            (CHASSIS_INFO_PSU_NUM_FIELD, str(num_psus_chassis)),
+            (CHASSIS_INFO_PDB_NUM_FIELD, str(num_pdbs_chassis)),
+        ])
         try:
             self.chassis_tbl.set(CHASSIS_INFO_KEY, fvs)
         except RuntimeError as e:
-            self.log_error("Failed to set PSU number to DB: {}".format(e))
+            self.log_error("Failed to set PSU/PDB number to DB: {}".format(e))
 
     def __del__(self):
-        # Delete all the information from DB and then exit
-        for psu_index in range(1, self.num_psus + 1):
-            try:
-                self.psu_tbl._del(get_psu_key(psu_index))
-            except Exception as e:
-                self.log_error("Failed to delete PSU {} info from DB: {}".format(psu_index, e))
-            if self.phy_entity_tbl.get(get_psu_key(psu_index)) is not None:
-                try:
-                    self.phy_entity_tbl._del(get_psu_key(psu_index))
-                except:
-                    self.log_error("Failed to delete physical entity info from DB: {}".format(e))
+        # Delete all the information from DB and then exit. Do not use log_error here:
+        # during interpreter shutdown logging may be broken and can raise.
+        psu_tbl = getattr(self, 'psu_tbl', None)
+        phy_entity_tbl = getattr(self, 'phy_entity_tbl', None)
 
-        if self.chassis_tbl is not None:
+        def _del_phy_entity(key):
+            if phy_entity_tbl is None:
+                return
+            try:
+                if phy_entity_tbl.get(key) is not None:
+                    phy_entity_tbl._del(key)
+            except Exception:
+                pass
+
+        if psu_tbl is not None:
+            names = getattr(self, 'all_power_entity_names', None)
+            if names:
+                for name in names:
+                    try:
+                        psu_tbl._del(name)
+                    except Exception:
+                        pass
+                    _del_phy_entity(name)
+            else:
+                for psu_index in range(1, getattr(self, 'num_psus', 0) + 1):
+                    key = get_psu_key(psu_index)
+                    try:
+                        psu_tbl._del(key)
+                    except Exception:
+                        pass
+                    _del_phy_entity(key)
+
+        if getattr(self, 'chassis_tbl', None) is not None:
             try:
                 self.chassis_tbl._del(CHASSIS_INFO_KEY)
-            except Exception as e:
-                self.log_error("Failed to delete chassis info from DB: {}".format(e))
+            except Exception:
+                pass
             try:
                 self.chassis_tbl._del(CHASSIS_INFO_POWER_KEY_TEMPLATE.format(1))
-            except Exception as e:
-                self.log_error("Failed to delete chassis power info from DB: {}".format(e))
+            except Exception:
+                pass
 
     # Override signal handler from DaemonBase
     def signal_handler(self, sig, frame):
@@ -548,7 +707,9 @@ class DaemonPsud(daemon_base.DaemonBase):
         # hence move it to the iteration run, so the key will be filled again after removed.
         self._update_psu_entity_info()
 
+        self.psu_threshold_exceeded_logged = False
         self.update_psu_data()
+        self.update_pdb_data()
         self._update_led_color()
 
         if platform_chassis and platform_chassis.is_modular_chassis():
@@ -563,17 +724,47 @@ class DaemonPsud(daemon_base.DaemonBase):
         if not platform_chassis:
             return
 
-        self.psu_threshold_exceeded_logged = False
-        for index, psu in enumerate(platform_chassis.get_all_psus()):
-            try:
-                self._update_single_psu_data(index + 1, psu)
-            except Exception as e:
-                self.log_warning("Failed to update PSU data - {}".format(e))
+        try:
+            for psu in platform_chassis.get_all_psus():
+                try:
+                    self._update_single_psu_data(psu)
+                except Exception as e:
+                    self.log_warning("Failed to update PSU data - {}".format(e))
+        except NotImplementedError:
+            pass
 
-    def _update_single_psu_data(self, index, psu):
-        name = get_psu_key(index)
-        presence = _wrapper_get_psu_presence(self, index)
-        power_good = False
+    def update_pdb_data(self):
+        if not platform_chassis:
+            return
+
+        try:
+            for pdb in platform_chassis.get_all_pdbs():
+                try:
+                    self._update_single_pdb_data(pdb)
+                except Exception as e:
+                    self.log_warning("Failed to update PDB data - {}".format(e))
+        except NotImplementedError:
+            pass
+
+    def _update_single_psu_data(self, entity):
+        """Update STATE_DB for one PSU (PsuBase)."""
+        self._update_single_power_entity_data(entity, 'psu')
+
+    def _update_single_pdb_data(self, entity):
+        """Update STATE_DB for one PDB (PdbBase)."""
+        self._update_single_power_entity_data(entity, 'pdb')
+
+    def _update_single_power_entity_data(self, entity, kind):
+        """
+        Shared STATE_DB update for one PSU or PDB. kind is 'psu' or 'pdb'.
+        """
+        label = 'PSU' if kind == 'psu' else 'PDB'
+        name = try_get(entity.get_name, NOT_AVAILABLE)
+        if name == NOT_AVAILABLE:
+            idx = getattr(entity, 'index', 'unknown')
+            name = '{} {}'.format(label, idx) if isinstance(idx, int) else str(idx)
+        presence = try_get(entity.get_presence, False)
+        power_good = try_get(entity.get_powergood_status, False) if presence else False
         voltage = NOT_AVAILABLE
         voltage_high_threshold = NOT_AVAILABLE
         voltage_low_threshold = NOT_AVAILABLE
@@ -581,37 +772,40 @@ class DaemonPsud(daemon_base.DaemonBase):
         temperature_threshold = NOT_AVAILABLE
         current = NOT_AVAILABLE
         power = NOT_AVAILABLE
-        is_replaceable = try_get(psu.is_replaceable, False)
+        is_replaceable = try_get(entity.is_replaceable, False)
         in_voltage = NOT_AVAILABLE
         in_current = NOT_AVAILABLE
         max_power = NOT_AVAILABLE
         if presence:
-            power_good = _wrapper_get_psu_status(self, index)
-            voltage = try_get(psu.get_voltage, NOT_AVAILABLE)
-            voltage_high_threshold = try_get(psu.get_voltage_high_threshold, NOT_AVAILABLE)
-            voltage_low_threshold = try_get(psu.get_voltage_low_threshold, NOT_AVAILABLE)
-            temperature = try_get(psu.get_temperature, NOT_AVAILABLE)
-            temperature_threshold = try_get(psu.get_temperature_high_threshold, NOT_AVAILABLE)
-            current = try_get(psu.get_current, NOT_AVAILABLE)
-            power = try_get(psu.get_power, NOT_AVAILABLE)
-            in_current = try_get(psu.get_input_current, NOT_AVAILABLE)
-            in_voltage = try_get(psu.get_input_voltage, NOT_AVAILABLE)
-            max_power = try_get(psu.get_maximum_supplied_power, NOT_AVAILABLE)
+            voltage = try_get(entity.get_voltage, NOT_AVAILABLE)
+            voltage_high_threshold = try_get(entity.get_voltage_high_threshold, NOT_AVAILABLE)
+            voltage_low_threshold = try_get(entity.get_voltage_low_threshold, NOT_AVAILABLE)
+            temperature = try_get(entity.get_temperature, NOT_AVAILABLE)
+            temperature_threshold = try_get(entity.get_temperature_high_threshold, NOT_AVAILABLE)
+            current = try_get(entity.get_current, NOT_AVAILABLE)
+            power = try_get(entity.get_power, NOT_AVAILABLE)
+            in_current = try_get(entity.get_input_current, NOT_AVAILABLE)
+            in_voltage = try_get(entity.get_input_voltage, NOT_AVAILABLE)
+            max_power = try_get(entity.get_maximum_supplied_power, NOT_AVAILABLE)
 
-        if index not in self.psu_status_dict:
-            self.psu_status_dict[index] = PsuStatus(self, psu, index)
+        if name not in self.psu_status_dict:
+            self.psu_status_dict[name] = PsuStatus(self, entity, name)
 
-        psu_status = self.psu_status_dict[index]
+        psu_status = self.psu_status_dict[name]
         set_led = self.first_run
         presence_changed = psu_status.set_presence(presence)
         if presence_changed:
             set_led = True
             log_on_status_changed(self, psu_status.presence,
-                                  'PSU absence warning cleared: {} is inserted back.'.format(name),
-                                  'PSU absence warning: {} is not present.'.format(name)
+                                  '{} absence warning cleared: {} is inserted back.'.format(label, name),
+                                  '{} absence warning: {} is not present.'.format(label, name)
                                   )
             if not psu_status.presence:
                  psu_status.check_psu_power_threshold = False
+            if not psu_status.presence:
+                self.log_error("{} is not present.".format(name))
+        elif self.first_run and not presence:
+            self.log_error("{} is not present.".format(name))
 
         if presence_changed or self.first_run:
             # Have to update PSU fan data here because PSU presence status changed. If we don't
@@ -619,7 +813,7 @@ class DaemonPsud(daemon_base.DaemonBase):
             # and "show platform fan". For example, say PSU 1 is removed, and psud query PSU status every 3 seconds,
             # it will update PSU state to "Not OK" and PSU LED to "red"; but thermalctld query PSU fan status
             # every 60 seconds, it may still treat PSU state to "OK" and PSU LED to "red".
-            self._update_psu_fan_data(psu, index)
+            self._update_psu_fan_data(entity)
 
         power_good_changed = psu_status.set_power_good(power_good)
         if presence and power_good_changed:
@@ -634,22 +828,15 @@ class DaemonPsud(daemon_base.DaemonBase):
             if psu_status.power_good:
                 # power_good has been updated and it is True, which means it was False
                 # Initialize power exceeding threshold state in this case
-                if (try_get(psu.get_psu_power_critical_threshold) and try_get(psu.get_psu_power_warning_suppress_threshold) and power != NOT_AVAILABLE):
+                if (try_get(entity.get_psu_power_critical_threshold) and try_get(entity.get_psu_power_warning_suppress_threshold) and power != NOT_AVAILABLE):
                     psu_status.check_psu_power_threshold = True
 
         power_exceeded_threshold = psu_status.power_exceeded_threshold
-        power_warning_suppress_threshold = try_get(psu.get_psu_power_warning_suppress_threshold, NOT_AVAILABLE)
-        power_critical_threshold = try_get(psu.get_psu_power_critical_threshold, NOT_AVAILABLE)
+        power_warning_suppress_threshold = try_get(entity.get_psu_power_warning_suppress_threshold, NOT_AVAILABLE)
+        power_critical_threshold = try_get(entity.get_psu_power_critical_threshold, NOT_AVAILABLE)
         if psu_status.check_psu_power_threshold:
-            # Calculate total power
-            system_power = float(power)
-            for _, other_psu in enumerate(platform_chassis.get_all_psus()):
-                if other_psu is psu:
-                    # Skip the current PSU
-                    continue
-                power_str = try_get(other_psu.get_power, NOT_AVAILABLE)
-                if power_str != NOT_AVAILABLE:
-                    system_power += float(power_str)
+            # Calculate total power from all power entities (PSUs + PDBs)
+            system_power = _sum_system_power_from_other_psus_and_pdbs(platform_chassis, entity, float(power))
 
             if power_warning_suppress_threshold == NOT_AVAILABLE or power_critical_threshold == NOT_AVAILABLE:
                 self.log_error("PSU power thresholds become invalid: threshold {} critical threshold {}".format(power_warning_suppress_threshold, power_critical_threshold))
@@ -676,26 +863,26 @@ class DaemonPsud(daemon_base.DaemonBase):
         if presence and psu_status.set_voltage(voltage, voltage_high_threshold, voltage_low_threshold):
             set_led = True
             log_on_status_changed(self, psu_status.voltage_good,
-                                  'PSU voltage warning cleared: {} voltage is back to normal.'.format(name),
-                                  'PSU voltage warning: {} voltage out of range, current voltage={}, valid range=[{}, {}].'.format(
+                                  'Voltage warning cleared: {} voltage is back to normal.'.format(name),
+                                  'Voltage warning: {} voltage out of range, current voltage={}, valid range=[{}, {}].'.format(
                                       name, voltage, voltage_high_threshold, voltage_low_threshold)
                                   )
 
         if presence and psu_status.set_temperature(temperature, temperature_threshold):
             set_led = True
             log_on_status_changed(self, psu_status.temperature_good,
-                                  'PSU temperature warning cleared: {} temperature is back to normal.'.format(name),
-                                  'PSU temperature warning: {} temperature too hot, temperature={}, threshold={}.'.format(
+                                  'Temperature warning cleared: {} temperature is back to normal.'.format(name),
+                                  'Temperature warning: {} temperature too hot, temperature={}, threshold={}.'.format(
                                       name, temperature, temperature_threshold)
                                   )
 
         if set_led:
-            self._set_psu_led(psu, psu_status)
+            self._set_psu_led(entity, psu_status)
 
         fvs = swsscommon.FieldValuePairs(
-            [(PSU_INFO_MODEL_FIELD, str(try_get(psu.get_model, NOT_AVAILABLE))),
-             (PSU_INFO_SERIAL_FIELD, str(try_get(psu.get_serial, NOT_AVAILABLE))),
-             (PSU_INFO_REV_FIELD, str(try_get(psu.get_revision, NOT_AVAILABLE))),
+            [(PSU_INFO_MODEL_FIELD, str(try_get(entity.get_model, NOT_AVAILABLE))),
+             (PSU_INFO_SERIAL_FIELD, str(try_get(entity.get_serial, NOT_AVAILABLE))),
+             (PSU_INFO_REV_FIELD, str(try_get(entity.get_revision, NOT_AVAILABLE))),
              (PSU_INFO_TEMP_FIELD, str(temperature)),
              (PSU_INFO_TEMP_TH_FIELD, str(temperature_threshold)),
              (PSU_INFO_VOLTAGE_FIELD, str(voltage)),
@@ -710,44 +897,53 @@ class DaemonPsud(daemon_base.DaemonBase):
              (PSU_INFO_IN_CURRENT_FIELD, str(in_current)),
              (PSU_INFO_IN_VOLTAGE_FIELD, str(in_voltage)),
              (PSU_INFO_POWER_MAX_FIELD, str(max_power)),
-             (PSU_INFO_PRESENCE_FIELD, 'true' if _wrapper_get_psu_presence(self, index) else 'false'),
-             (PSU_INFO_STATUS_FIELD, 'true' if _wrapper_get_psu_status(self, index) else 'false'),
+             (PSU_INFO_PRESENCE_FIELD, 'true' if presence else 'false'),
+             (PSU_INFO_STATUS_FIELD, 'true' if power_good else 'false'),
+             (PSU_INFO_TIMESTAMP_FIELD, str(datetime.now().timestamp())),
              ])
         try:
             self.psu_tbl.set(name, fvs)
         except RuntimeError as e:
-            self.log_error("Failed to update PSU {} info to DB: {}".format(name, e))
+            self.log_error("Failed to update {} info to DB: {}".format(name, e))
 
     def _update_psu_entity_info(self):
         if not platform_chassis:
             return
 
-        for index, psu in enumerate(platform_chassis.get_all_psus()):
-            try:
-                self._update_single_psu_entity_info(index + 1, psu)
-            except Exception as e:
-                self.log_warning("Failed to update PSU data - {}".format(e))
+        try:
+            for psu in platform_chassis.get_all_psus():
+                try:
+                    self._update_single_psu_entity_info(psu)
+                except Exception as e:
+                    self.log_warning("Failed to update PSU entity data - {}".format(e))
+        except NotImplementedError:
+            pass
+        try:
+            for pdb in platform_chassis.get_all_pdbs():
+                try:
+                    self._update_single_psu_entity_info(pdb)
+                except Exception as e:
+                    self.log_warning("Failed to update PDB entity data - {}".format(e))
+        except NotImplementedError:
+            pass
 
-    def _update_single_psu_entity_info(self, psu_index, psu):
-        position = try_get(psu.get_position_in_parent, psu_index)
+    def _update_single_psu_entity_info(self, entity):
+        name = try_get(entity.get_name, 'unknown')
+        position = try_get(entity.get_position_in_parent, 0)
         fvs = swsscommon.FieldValuePairs(
             [('position_in_parent', str(position)),
              ('parent_name', CHASSIS_INFO_KEY),
              ])
         try:
-            self.phy_entity_tbl.set(get_psu_key(psu_index), fvs)
+            self.phy_entity_tbl.set(name, fvs)
         except RuntimeError as e:
-            self.log_error("Failed to update PSU {} entity info to DB: {}".format(psu_index, e))
+            self.log_error("Failed to update {} entity info to DB: {}".format(name, e))
 
-    def _update_psu_fan_data(self, psu, psu_index):
-        """
-        :param psu:
-        :param psu_index:
-        :return:
-        """
-        psu_name = get_psu_key(psu_index)
-        presence = _wrapper_get_psu_presence(self, psu_index)
-        fan_list = psu.get_all_fans()
+    def _update_psu_fan_data(self, entity):
+        """Update FAN_INFO for fans belonging to this PSU/PDB (entity)."""
+        psu_name = try_get(entity.get_name, 'unknown')
+        presence = try_get(entity.get_presence, False)
+        fan_list = entity.get_all_fans()
         for index, fan in enumerate(fan_list):
             fan_name = try_get(fan.get_name, '{} FAN {}'.format(psu_name, index + 1))
             direction = try_get(fan.get_direction, NOT_AVAILABLE) if presence else NOT_AVAILABLE
@@ -765,10 +961,10 @@ class DaemonPsud(daemon_base.DaemonBase):
             except RuntimeError as e:
                 self.log_error("Failed to update fan {} info to DB: {}".format(fan_name, e))
 
-    def _set_psu_led(self, psu, psu_status):
+    def _set_psu_led(self, entity, psu_status):
         try:
-            color = psu.STATUS_LED_COLOR_GREEN if psu_status.is_ok() else psu.STATUS_LED_COLOR_RED
-            psu.set_status_led(color)
+            color = entity.STATUS_LED_COLOR_GREEN if psu_status.is_ok() else entity.STATUS_LED_COLOR_RED
+            entity.set_status_led(color)
         except NotImplementedError:
             self.log_warning("set_status_led() not implemented")
 
@@ -776,21 +972,21 @@ class DaemonPsud(daemon_base.DaemonBase):
         if not platform_chassis:
             return
 
-        for index, psu_status in self.psu_status_dict.items():
+        for name, psu_status in self.psu_status_dict.items():
             fvs = swsscommon.FieldValuePairs([
                 ('led_status', str(try_get(psu_status.psu.get_status_led, NOT_AVAILABLE)))
             ])
             try:
-                self.psu_tbl.set(get_psu_key(index), fvs)
+                self.psu_tbl.set(name, fvs)
             except RuntimeError as e:
-                self.log_error("Failed to update PSU {} LED status to DB: {}".format(get_psu_key(index), e))
-            self._update_psu_fan_led_status(psu_status.psu, index)
+                self.log_error("Failed to update {} LED status to DB: {}".format(name, e))
+            self._update_psu_fan_led_status(psu_status.psu, name)
 
-    def _update_psu_fan_led_status(self, psu, psu_index):
-        psu_name = get_psu_key(psu_index)
-        fan_list = psu.get_all_fans()
+    def _update_psu_fan_led_status(self, entity, entity_name):
+        """entity: PSU or PDB object; entity_name: its name (e.g. 'PSU 1', 'PDB 1')."""
+        fan_list = entity.get_all_fans()
         for index, fan in enumerate(fan_list):
-            fan_name = try_get(fan.get_name, '{} FAN {}'.format(psu_name, index + 1))
+            fan_name = try_get(fan.get_name, '{} FAN {}'.format(entity_name, index + 1))
             fvs = swsscommon.FieldValuePairs([
                 (FAN_INFO_LED_STATUS_FIELD, str(try_get(fan.get_status_led, NOT_AVAILABLE)))
             ])

--- a/sonic-psud/tests/mock_platform.py
+++ b/sonic-psud/tests/mock_platform.py
@@ -24,12 +24,13 @@ class MockChassis(chassis_base.ChassisBase):
         self._psu_list = []
         self._fan_drawer_list = []
         self._module_list = []
+        self._pdb_list = []
 
     def get_num_psus(self):
         return len(self._psu_list)
 
     def get_all_psus(self):
-        return self._psu_list
+        return self._psu_list  
 
     def get_psu(self, index):
         return self._psu_list[index]
@@ -45,6 +46,12 @@ class MockChassis(chassis_base.ChassisBase):
 
     def get_all_modules(self):
         return self._module_list
+
+    def get_num_pdbs(self):
+        return len(self._pdb_list)
+
+    def get_all_pdbs(self):
+        return self._pdb_list
 
     def get_status_led(self):
         return self._status_led_color

--- a/sonic-psud/tests/mocked_libs/swsscommon/swsscommon.py
+++ b/sonic-psud/tests/mocked_libs/swsscommon/swsscommon.py
@@ -22,7 +22,14 @@ class Table:
         pass
 
     def set(self, key, fvs):
-        self.mock_dict[key] = fvs.fv_dict
+        if hasattr(fvs, 'fv_dict'):
+            self.mock_dict[key] = fvs.fv_dict
+        else:
+            # Real swsscommon.FieldValuePairs (C extension): iterable as (field, value) pairs
+            try:
+                self.mock_dict[key] = dict(fvs)
+            except (TypeError, ValueError):
+                self.mock_dict[key] = dict(list(fvs))
         pass
 
     def get(self, key):

--- a/sonic-psud/tests/test_DaemonPsud.py
+++ b/sonic-psud/tests/test_DaemonPsud.py
@@ -101,6 +101,7 @@ class TestDaemonPsud(object):
         daemon_psud = psud.DaemonPsud(SYSLOG_IDENTIFIER)
         daemon_psud._update_psu_entity_info = mock.MagicMock()
         daemon_psud.update_psu_data = mock.MagicMock()
+        daemon_psud.update_pdb_data = mock.MagicMock()
         daemon_psud._update_led_color = mock.MagicMock()
         daemon_psud.update_psu_chassis_info = mock.MagicMock()
 
@@ -127,7 +128,7 @@ class TestDaemonPsud(object):
         psud.platform_chassis._psu_list = [mock_psu1, mock_psu2]
         daemon_psud.update_psu_data()
         assert daemon_psud._update_single_psu_data.call_count == 2
-        expected_calls = [mock.call(1, mock_psu1), mock.call(2, mock_psu2)]
+        expected_calls = [mock.call(mock_psu1), mock.call(mock_psu2)]
         assert daemon_psud._update_single_psu_data.mock_calls == expected_calls
         assert daemon_psud.log_warning.call_count == 0
 
@@ -137,13 +138,55 @@ class TestDaemonPsud(object):
         daemon_psud._update_single_psu_data.side_effect = Exception("Test message")
         daemon_psud.update_psu_data()
         assert daemon_psud._update_single_psu_data.call_count == 2
-        expected_calls = [mock.call(1, mock_psu1), mock.call(2, mock_psu2)]
+        expected_calls = [mock.call(mock_psu1), mock.call(mock_psu2)]
         assert daemon_psud._update_single_psu_data.mock_calls == expected_calls
         assert daemon_psud.log_warning.call_count == 2
         expected_calls = [mock.call("Failed to update PSU data - Test message")] * 2
         assert daemon_psud.log_warning.mock_calls == expected_calls
 
-    def _construct_expected_fvp(self, power=100.0, power_warning_suppress_threshold='N/A', power_critical_threshold='N/A', power_overload=False):
+    def test_update_pdb_data(self):
+        mock_pdb1 = MockPsu("PDB 1", 0, True, True)
+        mock_pdb2 = MockPsu("PDB 2", 1, True, True)
+
+        psud.platform_chassis = MockChassis()
+        daemon_psud = psud.DaemonPsud(SYSLOG_IDENTIFIER)
+        daemon_psud._update_single_pdb_data = mock.MagicMock()
+        daemon_psud.log_warning = mock.MagicMock()
+
+        # Test platform_chassis is None
+        psud.platform_chassis = None
+        daemon_psud.update_pdb_data()
+        assert daemon_psud._update_single_pdb_data.call_count == 0
+        assert daemon_psud.log_warning.call_count == 0
+
+        # Test with mocked platform_chassis
+        psud.platform_chassis = MockChassis()
+        psud.platform_chassis._pdb_list = [mock_pdb1, mock_pdb2]
+        daemon_psud.update_pdb_data()
+        assert daemon_psud._update_single_pdb_data.call_count == 2
+        expected_calls = [mock.call(mock_pdb1), mock.call(mock_pdb2)]
+        assert daemon_psud._update_single_pdb_data.mock_calls == expected_calls
+        assert daemon_psud.log_warning.call_count == 0
+
+        daemon_psud._update_single_pdb_data.reset_mock()
+
+        # Test _update_single_pdb_data() throws exception
+        daemon_psud._update_single_pdb_data.side_effect = Exception("Test message")
+        daemon_psud.update_pdb_data()
+        assert daemon_psud._update_single_pdb_data.call_count == 2
+        expected_calls = [mock.call(mock_pdb1), mock.call(mock_pdb2)]
+        assert daemon_psud._update_single_pdb_data.mock_calls == expected_calls
+        assert daemon_psud.log_warning.call_count == 2
+        expected_calls = [mock.call("Failed to update PDB data - Test message")] * 2
+        assert daemon_psud.log_warning.mock_calls == expected_calls
+
+    # Fixed timestamp for FieldValuePairs matching (psud uses datetime.now().timestamp())
+    _FIXED_PSU_TS = 1234567890.0
+
+    def _construct_expected_fvp(self, power=100.0, power_warning_suppress_threshold='N/A', power_critical_threshold='N/A', power_overload=False,
+                                timestamp=None):
+        if timestamp is None:
+            timestamp = self._FIXED_PSU_TS
         expected_fvp = psud.swsscommon.FieldValuePairs(
             [(psud.PSU_INFO_MODEL_FIELD, 'Fake Model'),
              (psud.PSU_INFO_SERIAL_FIELD, '12345678'),
@@ -164,12 +207,18 @@ class TestDaemonPsud(object):
              (psud.PSU_INFO_POWER_MAX_FIELD, 'N/A'),
              (psud.PSU_INFO_PRESENCE_FIELD, 'true'),
              (psud.PSU_INFO_STATUS_FIELD, 'true'),
+             (psud.PSU_INFO_TIMESTAMP_FIELD, str(timestamp)),
              ])
         return expected_fvp
 
+    @mock.patch('psud.datetime')
     @mock.patch('psud._wrapper_get_psu_presence', mock.MagicMock())
     @mock.patch('psud._wrapper_get_psu_status', mock.MagicMock())
-    def test_update_single_psu_data(self):
+    def test_update_single_psu_data(self, mock_datetime):
+        mock_now = mock.MagicMock()
+        mock_now.timestamp.return_value = self._FIXED_PSU_TS
+        mock_datetime.now.return_value = mock_now
+
         psud._wrapper_get_psu_presence.return_value = True
         psud._wrapper_get_psu_status.return_value = True
 
@@ -181,12 +230,17 @@ class TestDaemonPsud(object):
 
         daemon_psud = psud.DaemonPsud(SYSLOG_IDENTIFIER)
         daemon_psud.psu_tbl = mock.MagicMock()
-        daemon_psud._update_single_psu_data(1, psu1)
-        daemon_psud.psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
-        assert not daemon_psud.psu_status_dict[1].check_psu_power_threshold
+        daemon_psud._update_single_psu_data(psu1)
+        daemon_psud.psu_tbl.set.assert_called_with('PSU 1', expected_fvp)
+        assert not daemon_psud.psu_status_dict['PSU 1'].check_psu_power_threshold
 
+    @mock.patch('psud.datetime')
     @mock.patch('psud.daemon_base.db_connect', mock.MagicMock())
-    def test_power_threshold(self):
+    def test_power_threshold(self, mock_datetime):
+        mock_now = mock.MagicMock()
+        mock_now.timestamp.return_value = self._FIXED_PSU_TS
+        mock_datetime.now.return_value = mock_now
+
         psu = MockPsu('PSU 1', 0, True, 'Fake Model', '12345678', '1234')
         psud.platform_chassis = MockChassis()
         psud.platform_chassis._psu_list.append(psu)
@@ -202,11 +256,11 @@ class TestDaemonPsud(object):
 
         # Normal start. All good and all thresholds are supported
         # Power is in normal range (below warning threshold)
-        daemon_psud._update_single_psu_data(1, psu)
-        assert daemon_psud.psu_status_dict[1].check_psu_power_threshold
-        assert not daemon_psud.psu_status_dict[1].power_exceeded_threshold
+        daemon_psud._update_single_psu_data(psu)
+        assert daemon_psud.psu_status_dict['PSU 1'].check_psu_power_threshold
+        assert not daemon_psud.psu_status_dict['PSU 1'].power_exceeded_threshold
         expected_fvp = self._construct_expected_fvp(100.0, 120.0, 130.0, False)
-        daemon_psud.psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+        daemon_psud.psu_tbl.set.assert_called_with('PSU 1', expected_fvp)
         daemon_psud._update_led_color()
         assert psu.STATUS_LED_COLOR_GREEN == psu.get_status_led()
 
@@ -215,115 +269,115 @@ class TestDaemonPsud(object):
         # Power is increasing across the warning threshold
         # Normal => (warning, critical)
         psu.set_power(115.0)
-        daemon_psud._update_single_psu_data(1, psu)
-        assert daemon_psud.psu_status_dict[1].check_psu_power_threshold
-        assert not daemon_psud.psu_status_dict[1].power_exceeded_threshold
+        daemon_psud._update_single_psu_data(psu)
+        assert daemon_psud.psu_status_dict['PSU 1'].check_psu_power_threshold
+        assert not daemon_psud.psu_status_dict['PSU 1'].power_exceeded_threshold
         expected_fvp = self._construct_expected_fvp(115.0, 120.0, 130.0, False)
-        daemon_psud.psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+        daemon_psud.psu_tbl.set.assert_called_with('PSU 1', expected_fvp)
         daemon_psud._update_led_color()
         assert psu.STATUS_LED_COLOR_GREEN == psu.get_status_led()
 
         # Power is increasing across the critical threshold. Alarm raised
         # (warning, critical) => (critical, )
         psu.set_power(125.0)
-        daemon_psud._update_single_psu_data(1, psu)
-        assert daemon_psud.psu_status_dict[1].check_psu_power_threshold
-        assert daemon_psud.psu_status_dict[1].power_exceeded_threshold
+        daemon_psud._update_single_psu_data(psu)
+        assert daemon_psud.psu_status_dict['PSU 1'].check_psu_power_threshold
+        assert daemon_psud.psu_status_dict['PSU 1'].power_exceeded_threshold
         expected_fvp = self._construct_expected_fvp(125.0, 120.0, 130.0, True)
-        daemon_psud.psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+        daemon_psud.psu_tbl.set.assert_called_with('PSU 1', expected_fvp)
         daemon_psud._update_led_color()
         assert psu.STATUS_LED_COLOR_GREEN == psu.get_status_led()
 
         # Power is decreasing across the critical threshold. Alarm not cleared
         # (critical, ) => (warning, critical)
         psu.set_power(115.0)
-        daemon_psud._update_single_psu_data(1, psu)
-        assert daemon_psud.psu_status_dict[1].check_psu_power_threshold
-        assert daemon_psud.psu_status_dict[1].power_exceeded_threshold
+        daemon_psud._update_single_psu_data(psu)
+        assert daemon_psud.psu_status_dict['PSU 1'].check_psu_power_threshold
+        assert daemon_psud.psu_status_dict['PSU 1'].power_exceeded_threshold
         expected_fvp = self._construct_expected_fvp(115.0, 120.0, 130.0, True)
-        daemon_psud.psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+        daemon_psud.psu_tbl.set.assert_called_with('PSU 1', expected_fvp)
         daemon_psud._update_led_color()
         assert psu.STATUS_LED_COLOR_GREEN == psu.get_status_led()
 
         # Power is decreasing across the warning threshold. Alarm cleared
         # (warning, critical) => Normal
         psu.set_power(105.0)
-        daemon_psud._update_single_psu_data(1, psu)
-        assert daemon_psud.psu_status_dict[1].check_psu_power_threshold
-        assert not daemon_psud.psu_status_dict[1].power_exceeded_threshold
+        daemon_psud._update_single_psu_data(psu)
+        assert daemon_psud.psu_status_dict['PSU 1'].check_psu_power_threshold
+        assert not daemon_psud.psu_status_dict['PSU 1'].power_exceeded_threshold
         expected_fvp = self._construct_expected_fvp(105.0, 120.0, 130.0, False)
-        daemon_psud.psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+        daemon_psud.psu_tbl.set.assert_called_with('PSU 1', expected_fvp)
         assert psu.STATUS_LED_COLOR_GREEN == psu.get_status_led()
         daemon_psud._update_led_color()
 
         # Power is increasing across the critical threshold. Alarm raised
         # Normal => (critical, )
         psu.set_power(125.0)
-        daemon_psud._update_single_psu_data(1, psu)
-        assert daemon_psud.psu_status_dict[1].check_psu_power_threshold
-        assert daemon_psud.psu_status_dict[1].power_exceeded_threshold
+        daemon_psud._update_single_psu_data(psu)
+        assert daemon_psud.psu_status_dict['PSU 1'].check_psu_power_threshold
+        assert daemon_psud.psu_status_dict['PSU 1'].power_exceeded_threshold
         expected_fvp = self._construct_expected_fvp(125.0, 120.0, 130.0, True)
-        daemon_psud.psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+        daemon_psud.psu_tbl.set.assert_called_with('PSU 1', expected_fvp)
         daemon_psud._update_led_color()
         assert psu.STATUS_LED_COLOR_GREEN == psu.get_status_led()
 
         # Power is increasing across the critical threshold. Alarm raised
         # (critical, ) => Normal
         psu.set_power(105.0)
-        daemon_psud._update_single_psu_data(1, psu)
-        assert daemon_psud.psu_status_dict[1].check_psu_power_threshold
-        assert not daemon_psud.psu_status_dict[1].power_exceeded_threshold
+        daemon_psud._update_single_psu_data(psu)
+        assert daemon_psud.psu_status_dict['PSU 1'].check_psu_power_threshold
+        assert not daemon_psud.psu_status_dict['PSU 1'].power_exceeded_threshold
         expected_fvp = self._construct_expected_fvp(105.0, 120.0, 130.0, False)
-        daemon_psud.psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+        daemon_psud.psu_tbl.set.assert_called_with('PSU 1', expected_fvp)
         daemon_psud._update_led_color()
         assert psu.STATUS_LED_COLOR_GREEN == psu.get_status_led()
 
         # PSU power becomes down
         psu.set_status(False)
-        daemon_psud._update_single_psu_data(1, psu)
+        daemon_psud._update_single_psu_data(psu)
         daemon_psud._update_led_color()
-        assert not daemon_psud.psu_status_dict[1].check_psu_power_threshold
-        assert not daemon_psud.psu_status_dict[1].power_exceeded_threshold
+        assert not daemon_psud.psu_status_dict['PSU 1'].check_psu_power_threshold
+        assert not daemon_psud.psu_status_dict['PSU 1'].power_exceeded_threshold
         assert psu.STATUS_LED_COLOR_RED == psu.get_status_led()
 
         # PSU power becomes up
         psu.set_status(True)
-        daemon_psud._update_single_psu_data(1, psu)
+        daemon_psud._update_single_psu_data(psu)
         daemon_psud._update_led_color()
-        assert daemon_psud.psu_status_dict[1].check_psu_power_threshold
-        assert not daemon_psud.psu_status_dict[1].power_exceeded_threshold
+        assert daemon_psud.psu_status_dict['PSU 1'].check_psu_power_threshold
+        assert not daemon_psud.psu_status_dict['PSU 1'].power_exceeded_threshold
         assert psu.STATUS_LED_COLOR_GREEN == psu.get_status_led()
 
         # PSU becomes absent
         psu.set_presence(False)
-        daemon_psud._update_single_psu_data(1, psu)
+        daemon_psud._update_single_psu_data(psu)
         daemon_psud._update_led_color()
-        assert not daemon_psud.psu_status_dict[1].check_psu_power_threshold
-        assert not daemon_psud.psu_status_dict[1].power_exceeded_threshold
+        assert not daemon_psud.psu_status_dict['PSU 1'].check_psu_power_threshold
+        assert not daemon_psud.psu_status_dict['PSU 1'].power_exceeded_threshold
         assert psu.STATUS_LED_COLOR_RED == psu.get_status_led()
 
         # PSU becomes present
         psu.set_presence(True)
-        daemon_psud._update_single_psu_data(1, psu)
+        daemon_psud._update_single_psu_data(psu)
         daemon_psud._update_led_color()
-        assert daemon_psud.psu_status_dict[1].check_psu_power_threshold
-        assert not daemon_psud.psu_status_dict[1].power_exceeded_threshold
+        assert daemon_psud.psu_status_dict['PSU 1'].check_psu_power_threshold
+        assert not daemon_psud.psu_status_dict['PSU 1'].power_exceeded_threshold
         assert psu.STATUS_LED_COLOR_GREEN == psu.get_status_led()
 
         # Thresholds become invalid on the fly
         psu.get_psu_power_critical_threshold = mock.MagicMock(side_effect=NotImplementedError(''))
-        daemon_psud._update_single_psu_data(1, psu)
-        assert not daemon_psud.psu_status_dict[1].check_psu_power_threshold
-        assert not daemon_psud.psu_status_dict[1].power_exceeded_threshold
+        daemon_psud._update_single_psu_data(psu)
+        assert not daemon_psud.psu_status_dict['PSU 1'].check_psu_power_threshold
+        assert not daemon_psud.psu_status_dict['PSU 1'].power_exceeded_threshold
         psu.get_psu_power_critical_threshold = mock.MagicMock(return_value=120.0)
-        daemon_psud.psu_status_dict[1].check_psu_power_threshold = True
-        daemon_psud._update_single_psu_data(1, psu)
-        assert daemon_psud.psu_status_dict[1].check_psu_power_threshold
-        assert not daemon_psud.psu_status_dict[1].power_exceeded_threshold
+        daemon_psud.psu_status_dict['PSU 1'].check_psu_power_threshold = True
+        daemon_psud._update_single_psu_data(psu)
+        assert daemon_psud.psu_status_dict['PSU 1'].check_psu_power_threshold
+        assert not daemon_psud.psu_status_dict['PSU 1'].power_exceeded_threshold
         psu.get_psu_power_warning_suppress_threshold = mock.MagicMock(side_effect=NotImplementedError(''))
-        daemon_psud._update_single_psu_data(1, psu)
-        assert not daemon_psud.psu_status_dict[1].check_psu_power_threshold
-        assert not daemon_psud.psu_status_dict[1].power_exceeded_threshold
+        daemon_psud._update_single_psu_data(psu)
+        assert not daemon_psud.psu_status_dict['PSU 1'].check_psu_power_threshold
+        assert not daemon_psud.psu_status_dict['PSU 1'].power_exceeded_threshold
 
     def test_set_psu_led(self):
         mock_logger = mock.MagicMock()
@@ -390,13 +444,13 @@ class TestDaemonPsud(object):
         assert daemon_psud._update_psu_fan_led_status.call_count == 0
 
         psud.platform_chassis = MockChassis()
-        daemon_psud.psu_status_dict[1] = psu_status
+        daemon_psud.psu_status_dict['PSU 1'] = psu_status
         expected_fvp = psud.swsscommon.FieldValuePairs([('led_status', MockPsu.STATUS_LED_COLOR_OFF)])
         daemon_psud._update_led_color()
         assert daemon_psud.psu_tbl.set.call_count == 1
-        daemon_psud.psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+        daemon_psud.psu_tbl.set.assert_called_with('PSU 1', expected_fvp)
         assert daemon_psud._update_psu_fan_led_status.call_count == 1
-        daemon_psud._update_psu_fan_led_status.assert_called_with(mock_psu, 1)
+        daemon_psud._update_psu_fan_led_status.assert_called_with(mock_psu, 'PSU 1')
 
         daemon_psud.psu_tbl.reset_mock()
         daemon_psud._update_psu_fan_led_status.reset_mock()
@@ -405,9 +459,9 @@ class TestDaemonPsud(object):
         expected_fvp = psud.swsscommon.FieldValuePairs([('led_status', MockPsu.STATUS_LED_COLOR_GREEN)])
         daemon_psud._update_led_color()
         assert daemon_psud.psu_tbl.set.call_count == 1
-        daemon_psud.psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+        daemon_psud.psu_tbl.set.assert_called_with('PSU 1', expected_fvp)
         assert daemon_psud._update_psu_fan_led_status.call_count == 1
-        daemon_psud._update_psu_fan_led_status.assert_called_with(mock_psu, 1)
+        daemon_psud._update_psu_fan_led_status.assert_called_with(mock_psu, 'PSU 1')
 
         daemon_psud.psu_tbl.reset_mock()
         daemon_psud._update_psu_fan_led_status.reset_mock()
@@ -416,9 +470,9 @@ class TestDaemonPsud(object):
         expected_fvp = psud.swsscommon.FieldValuePairs([('led_status', MockPsu.STATUS_LED_COLOR_RED)])
         daemon_psud._update_led_color()
         assert daemon_psud.psu_tbl.set.call_count == 1
-        daemon_psud.psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+        daemon_psud.psu_tbl.set.assert_called_with('PSU 1', expected_fvp)
         assert daemon_psud._update_psu_fan_led_status.call_count == 1
-        daemon_psud._update_psu_fan_led_status.assert_called_with(mock_psu, 1)
+        daemon_psud._update_psu_fan_led_status.assert_called_with(mock_psu, 'PSU 1')
 
         daemon_psud.psu_tbl.reset_mock()
         daemon_psud._update_psu_fan_led_status.reset_mock()
@@ -428,9 +482,9 @@ class TestDaemonPsud(object):
         expected_fvp = psud.swsscommon.FieldValuePairs([('led_status', psud.NOT_AVAILABLE)])
         daemon_psud._update_led_color()
         assert daemon_psud.psu_tbl.set.call_count == 1
-        daemon_psud.psu_tbl.set.assert_called_with(psud.PSU_INFO_KEY_TEMPLATE.format(1), expected_fvp)
+        daemon_psud.psu_tbl.set.assert_called_with('PSU 1', expected_fvp)
         assert daemon_psud._update_psu_fan_led_status.call_count == 1
-        daemon_psud._update_psu_fan_led_status.assert_called_with(mock_psu, 1)
+        daemon_psud._update_psu_fan_led_status.assert_called_with(mock_psu, 'PSU 1')
 
     def test_update_psu_fan_led_status(self):
         mock_fan = MockFan("PSU 1 Test Fan 1", MockFan.FAN_DIRECTION_INTAKE)
@@ -444,7 +498,7 @@ class TestDaemonPsud(object):
         daemon_psud.fan_tbl = mock.MagicMock()
 
         expected_fvp = psud.swsscommon.FieldValuePairs([(psud.FAN_INFO_LED_STATUS_FIELD, MockFan.STATUS_LED_COLOR_OFF)])
-        daemon_psud._update_psu_fan_led_status(mock_psu, 1)
+        daemon_psud._update_psu_fan_led_status(mock_psu, 'PSU 1')
         assert daemon_psud.fan_tbl.set.call_count == 1
         daemon_psud.fan_tbl.set.assert_called_with("PSU 1 Test Fan 1", expected_fvp)
 
@@ -453,7 +507,7 @@ class TestDaemonPsud(object):
         # Test Fan.get_status_led not implemented
         mock_fan.get_status_led = mock.Mock(side_effect=NotImplementedError)
         expected_fvp = psud.swsscommon.FieldValuePairs([(psud.FAN_INFO_LED_STATUS_FIELD, psud.NOT_AVAILABLE)])
-        daemon_psud._update_psu_fan_led_status(mock_psu, 1)
+        daemon_psud._update_psu_fan_led_status(mock_psu, 'PSU 1')
         assert daemon_psud.fan_tbl.set.call_count == 1
         daemon_psud.fan_tbl.set.assert_called_with("PSU 1 Test Fan 1", expected_fvp)
 
@@ -461,7 +515,7 @@ class TestDaemonPsud(object):
 
         # Test Fan.get_name not implemented
         mock_fan.get_name = mock.Mock(side_effect=NotImplementedError)
-        daemon_psud._update_psu_fan_led_status(mock_psu, 1)
+        daemon_psud._update_psu_fan_led_status(mock_psu, 'PSU 1')
         assert daemon_psud.fan_tbl.set.call_count == 1
         daemon_psud.fan_tbl.set.assert_called_with("PSU 1 FAN 1", expected_fvp)
 
@@ -497,13 +551,13 @@ class TestDaemonPsud(object):
         psud.platform_chassis._psu_list = [mock_psu1]
         daemon_psud._update_psu_entity_info()
         assert daemon_psud._update_single_psu_entity_info.call_count == 1
-        daemon_psud._update_single_psu_entity_info.assert_called_with(1, mock_psu1)
+        daemon_psud._update_single_psu_entity_info.assert_called_with(mock_psu1)
 
         daemon_psud._update_single_psu_entity_info.reset_mock()
         psud.platform_chassis._psu_list = [mock_psu1, mock_psu2]
         daemon_psud._update_psu_entity_info()
         assert daemon_psud._update_single_psu_entity_info.call_count == 2
-        expected_calls = [mock.call(1, mock_psu1), mock.call(2, mock_psu2)]
+        expected_calls = [mock.call(mock_psu1), mock.call(mock_psu2)]
         assert daemon_psud._update_single_psu_entity_info.mock_calls == expected_calls
 
         # Test behavior if _update_single_psu_entity_info raises an exception
@@ -513,9 +567,9 @@ class TestDaemonPsud(object):
         psud.platform_chassis._psu_list = [mock_psu1]
         daemon_psud._update_psu_entity_info()
         assert daemon_psud._update_single_psu_entity_info.call_count == 1
-        daemon_psud._update_single_psu_entity_info.assert_called_with(1, mock_psu1)
+        daemon_psud._update_single_psu_entity_info.assert_called_with(mock_psu1)
         assert daemon_psud.log_warning.call_count == 1
-        daemon_psud.log_warning.assert_called_with("Failed to update PSU data - Test message")
+        daemon_psud.log_warning.assert_called_with("Failed to update PSU entity data - Test message")
 
     def test_update_single_psu_entity_info(self):
         #creating psu object in slot not used to allow for name specific check
@@ -528,7 +582,7 @@ class TestDaemonPsud(object):
         daemon_psud = psud.DaemonPsud(SYSLOG_IDENTIFIER)
         daemon_psud.phy_entity_tbl = mock.MagicMock()
 
-        daemon_psud._update_single_psu_entity_info(3, mock_psu1)
+        daemon_psud._update_single_psu_entity_info(mock_psu1)
         daemon_psud.phy_entity_tbl.set.assert_called_with('PSU 3', expected_fvp)
 
     def test_deinit(self):
@@ -588,7 +642,7 @@ class TestDaemonPsud(object):
              (psud.FAN_INFO_SPEED_FIELD, str(mock_fan.get_speed())),
              (psud.FAN_INFO_TIMESTAMP_FIELD, fake_time.strftime('%Y%m%d %H:%M:%S'))
              ])
-        daemon_psud._update_psu_fan_data(mock_psu1, 1)
+        daemon_psud._update_psu_fan_data(mock_psu1)
         assert daemon_psud.fan_tbl.set.call_count == 1
         daemon_psud.fan_tbl.set.assert_called_with("PSU 1 Test Fan 1", expected_fvp)
 
@@ -610,12 +664,12 @@ class TestDaemonPsud(object):
         daemon_psud.psu_tbl.set.side_effect = RuntimeError("BUSY Redis is busy running a script")
 
         # Should not raise exception, should log error instead
-        daemon_psud._update_single_psu_data(1, psu1)
+        daemon_psud._update_single_psu_data(psu1)
 
         assert daemon_psud.psu_tbl.set.call_count == 1
         assert daemon_psud.log_error.call_count == 1
         daemon_psud.log_error.assert_called_with(
-            "Failed to update PSU {} info to DB: BUSY Redis is busy running a script".format('PSU 1')
+            "Failed to update {} info to DB: BUSY Redis is busy running a script".format('PSU 1')
         )
 
     def test_update_led_color_db_error(self):
@@ -629,7 +683,7 @@ class TestDaemonPsud(object):
         daemon_psud.psu_tbl = mock.MagicMock()
         daemon_psud._update_psu_fan_led_status = mock.MagicMock()
         daemon_psud.log_error = mock.MagicMock()
-        daemon_psud.psu_status_dict[1] = psu_status
+        daemon_psud.psu_status_dict['PSU 1'] = psu_status
 
         # Simulate Redis BUSY error
         daemon_psud.psu_tbl.set.side_effect = RuntimeError("BUSY Redis is busy running a script")
@@ -663,7 +717,7 @@ class TestDaemonPsud(object):
         daemon_psud.fan_tbl.set.side_effect = RuntimeError("BUSY Redis is busy running a script")
 
         # Should not raise exception, should log error instead
-        daemon_psud._update_psu_fan_data(mock_psu1, 1)
+        daemon_psud._update_psu_fan_data(mock_psu1)
 
         assert daemon_psud.fan_tbl.set.call_count == 1
         assert daemon_psud.log_error.call_count == 1
@@ -687,7 +741,7 @@ class TestDaemonPsud(object):
         daemon_psud.fan_tbl.set.side_effect = RuntimeError("BUSY Redis is busy running a script")
 
         # Should not raise exception, should log error instead
-        daemon_psud._update_psu_fan_led_status(mock_psu, 1)
+        daemon_psud._update_psu_fan_led_status(mock_psu, 'PSU 1')
 
         assert daemon_psud.fan_tbl.set.call_count == 1
         assert daemon_psud.log_error.call_count == 1
@@ -709,12 +763,12 @@ class TestDaemonPsud(object):
         daemon_psud.phy_entity_tbl.set.side_effect = RuntimeError("BUSY Redis is busy running a script")
 
         # Should not raise exception, should log error instead
-        daemon_psud._update_single_psu_entity_info(1, mock_psu1)
+        daemon_psud._update_single_psu_entity_info(mock_psu1)
 
         assert daemon_psud.phy_entity_tbl.set.call_count == 1
         assert daemon_psud.log_error.call_count == 1
         daemon_psud.log_error.assert_called_with(
-            "Failed to update PSU {} entity info to DB: BUSY Redis is busy running a script".format(1)
+            "Failed to update PSU 1 entity info to DB: BUSY Redis is busy running a script"
         )
 
     @mock.patch('psud.swsscommon.Table')
@@ -754,27 +808,160 @@ class TestDaemonPsud(object):
             daemon_psud = psud.DaemonPsud(SYSLOG_IDENTIFIER)
 
             # Verify that the error was logged
-            mock_log_error.assert_called_with("Failed to set PSU number to DB: BUSY Redis is busy running a script")
+            mock_log_error.assert_called_with("Failed to set PSU/PDB number to DB: BUSY Redis is busy running a script")
 
     def test_del_chassis_info_db_error(self):
-        """Test that exception when deleting chassis info from DB in __del__ is handled gracefully"""
+        """Test that exception when deleting chassis info from DB in __del__ is handled gracefully (no raise)."""
         psud.platform_chassis = MockChassis()
 
         daemon_psud = psud.DaemonPsud(SYSLOG_IDENTIFIER)
-        daemon_psud.log_error = mock.MagicMock()
 
-        # Mock the chassis_tbl._del to raise exception
+        # Mock the chassis_tbl._del to raise exception (e.g. KeyError when key missing in test mock)
         daemon_psud.chassis_tbl = mock.MagicMock()
         daemon_psud.chassis_tbl._del.side_effect = Exception("Failed to delete")
 
         # Mock psu_tbl to avoid errors when deleting PSU info
         daemon_psud.psu_tbl = mock.MagicMock()
 
-        # Call __del__ - should not raise exception, should log error instead
+        # __del__ must not raise; it swallows exceptions to avoid issues during interpreter teardown
         daemon_psud.__del__()
 
-        # Should have logged error for chassis info deletion failure
-        assert daemon_psud.log_error.call_count >= 1
-        # Check that the chassis info deletion error was logged
-        calls = [str(call) for call in daemon_psud.log_error.call_args_list]
-        assert any("Failed to delete chassis info from DB" in call for call in calls)
+    def test_update_psu_data_not_implemented(self):
+        daemon_psud = psud.DaemonPsud(SYSLOG_IDENTIFIER)
+        ch = MockChassis()
+        ch.get_all_psus = mock.MagicMock(side_effect=NotImplementedError)
+        psud.platform_chassis = ch
+        daemon_psud._update_single_psu_data = mock.MagicMock()
+        daemon_psud.update_psu_data()
+        daemon_psud._update_single_psu_data.assert_not_called()
+
+    def test_update_pdb_data_not_implemented(self):
+        daemon_psud = psud.DaemonPsud(SYSLOG_IDENTIFIER)
+        ch = MockChassis()
+        ch.get_all_pdbs = mock.MagicMock(side_effect=NotImplementedError)
+        psud.platform_chassis = ch
+        daemon_psud._update_single_pdb_data = mock.MagicMock()
+        daemon_psud.update_pdb_data()
+        daemon_psud._update_single_pdb_data.assert_not_called()
+
+    def test_update_psu_entity_info_pdbs_and_errors(self):
+        mock_pdb = MockPsu("PDB 1", 0, True, True)
+        psud.platform_chassis = MockChassis()
+        psud.platform_chassis._pdb_list = [mock_pdb]
+
+        daemon_psud = psud.DaemonPsud(SYSLOG_IDENTIFIER)
+        daemon_psud._update_single_psu_entity_info = mock.MagicMock()
+        daemon_psud._update_psu_entity_info()
+        daemon_psud._update_single_psu_entity_info.assert_called_with(mock_pdb)
+
+        daemon_psud._update_single_psu_entity_info.reset_mock()
+        daemon_psud._update_single_psu_entity_info = mock.MagicMock()
+        psud.platform_chassis.get_all_pdbs = mock.MagicMock(side_effect=NotImplementedError)
+        daemon_psud._update_psu_entity_info()
+        daemon_psud._update_single_psu_entity_info.assert_not_called()
+
+        psud.platform_chassis = MockChassis()
+        psud.platform_chassis._pdb_list = [mock_pdb]
+        daemon_psud._update_single_psu_entity_info = mock.MagicMock(side_effect=Exception("pdb err"))
+        daemon_psud.log_warning = mock.MagicMock()
+        daemon_psud._update_psu_entity_info()
+        assert daemon_psud.log_warning.call_count == 1
+        daemon_psud.log_warning.assert_called_with("Failed to update PDB entity data - pdb err")
+
+    @mock.patch('psud.swsscommon.Table')
+    @mock.patch('psud.daemon_base.db_connect')
+    def test_init_skips_name_list_when_psu_pdb_enumeration_not_implemented(self, mock_db_connect, mock_table):
+        """Chassis counts succeed but listing PSUs/PDBs raises: STATE_DB counts still posted, names list empty."""
+        ch = mock.MagicMock()
+        ch.get_num_psus.return_value = 2
+        ch.get_all_psus.side_effect = NotImplementedError
+        ch.get_num_pdbs.return_value = 1
+        ch.get_all_pdbs.side_effect = NotImplementedError
+        psud.platform_chassis = ch
+
+        mock_chassis_tbl = mock.MagicMock()
+        mock_psu_tbl = mock.MagicMock()
+        mock_fan_tbl = mock.MagicMock()
+        mock_phy_entity_tbl = mock.MagicMock()
+        mock_table.side_effect = [mock_chassis_tbl, mock_psu_tbl, mock_fan_tbl, mock_phy_entity_tbl]
+
+        daemon_psud = psud.DaemonPsud(SYSLOG_IDENTIFIER)
+        assert daemon_psud.all_power_entity_names == []
+        mock_chassis_tbl.set.assert_called()
+
+    @mock.patch('psud.swsscommon.Table')
+    @mock.patch('psud.daemon_base.db_connect')
+    def test_del_deletes_by_psu_key_when_entity_names_empty(self, mock_db_connect, mock_table):
+        ch = mock.MagicMock()
+        ch.get_num_psus.return_value = 2
+        ch.get_num_pdbs.return_value = 0
+        ch.get_all_psus.side_effect = NotImplementedError
+        ch.get_all_pdbs.side_effect = NotImplementedError
+        psud.platform_chassis = ch
+
+        mock_chassis_tbl = mock.MagicMock()
+        mock_psu_tbl = mock.MagicMock()
+        mock_fan_tbl = mock.MagicMock()
+        mock_phy_entity_tbl = mock.MagicMock()
+        mock_table.side_effect = [mock_chassis_tbl, mock_psu_tbl, mock_fan_tbl, mock_phy_entity_tbl]
+
+        daemon_psud = psud.DaemonPsud(SYSLOG_IDENTIFIER)
+        key_chassis = MockChassis()
+        key_chassis._psu_list = [
+            MockPsu("PSU 1", 0, True, True),
+            MockPsu("PSU 2", 1, True, True),
+        ]
+        psud.platform_chassis = key_chassis
+        daemon_psud.__del__()
+        assert mock_psu_tbl._del.call_count == 2
+        mock_psu_tbl._del.assert_has_calls(
+            [mock.call("PSU 1"), mock.call("PSU 2")], any_order=True)
+
+    @mock.patch('psud.datetime')
+    def test_update_single_pdb_fallback_name_and_first_run_absent(self, mock_datetime):
+        mock_now = mock.MagicMock()
+        mock_now.timestamp.return_value = self._FIXED_PSU_TS
+        mock_datetime.now.return_value = mock_now
+
+        # Use MockPsu so _update_single_power_entity_data has all required APIs
+        # (is_replaceable, STATUS_LED_COLOR_*, get_model, etc.); force fallback name via get_name.
+        pdb_ent = MockPsu('ignored', 2, False, True)
+        pdb_ent.index = 2
+        pdb_ent.get_name = mock.MagicMock(side_effect=RuntimeError('no name'))
+        psud.platform_chassis = MockChassis()
+
+        daemon_psud = psud.DaemonPsud(SYSLOG_IDENTIFIER)
+        daemon_psud.psu_tbl = mock.MagicMock()
+        daemon_psud.log_error = mock.MagicMock()
+        daemon_psud.first_run = True
+        daemon_psud._update_single_pdb_data(pdb_ent)
+        daemon_psud.log_error.assert_called_once_with('PDB 2 is not present.')
+        daemon_psud.psu_tbl.set.assert_called_once()
+        call_name, _fvs = daemon_psud.psu_tbl.set.call_args[0]
+        assert call_name == 'PDB 2'
+
+    @mock.patch('psud.datetime')
+    def test_system_power_threshold_includes_other_pdbs(self, mock_datetime):
+        mock_now = mock.MagicMock()
+        mock_now.timestamp.return_value = self._FIXED_PSU_TS
+        mock_datetime.now.return_value = mock_now
+
+        psu = MockPsu('PSU 1', 0, True, 'Fake Model', '12345678', '1234')
+        psu.set_power(80.0)
+        psu.get_psu_power_critical_threshold = mock.MagicMock(return_value=160.0)
+        psu.get_psu_power_warning_suppress_threshold = mock.MagicMock(return_value=100.0)
+
+        pdb_other = MockPsu('PDB 1', 0, True, 'Fake Model', '12345678', '1234')
+        pdb_other.set_power(90.0)
+
+        psud.platform_chassis = MockChassis()
+        psud.platform_chassis._psu_list = [psu]
+        psud.platform_chassis._pdb_list = [pdb_other]
+
+        daemon_psud = psud.DaemonPsud(SYSLOG_IDENTIFIER)
+        daemon_psud.psu_tbl = mock.MagicMock()
+        # system_power = 80 + 90 (other PDB) exceeds critical threshold 160
+        daemon_psud._update_single_psu_data(psu)
+        status = daemon_psud.psu_status_dict['PSU 1']
+        assert status.check_psu_power_threshold
+        assert status.power_exceeded_threshold

--- a/sonic-psud/tests/test_PsuChassisInfo.py
+++ b/sonic-psud/tests/test_PsuChassisInfo.py
@@ -28,6 +28,17 @@ sys.path.insert(0, mocked_libs_path)
 load_source('swsscommon', os.path.join(mocked_libs_path, 'swsscommon', 'swsscommon.py'))
 import swsscommon as mock_swsscommon
 
+# Patch Table.set so it accepts real swsscommon.FieldValuePairs (no .fv_dict) from production code
+_original_table_set = mock_swsscommon.Table.set
+def _patched_table_set(self, key, fvs):
+    if hasattr(fvs, 'fv_dict'):
+        return _original_table_set(self, key, fvs)
+    try:
+        self.mock_dict[key] = dict(fvs)
+    except (TypeError, ValueError):
+        self.mock_dict[key] = dict(list(fvs))
+mock_swsscommon.Table.set = _patched_table_set
+
 # Add path to the file under test so that we can load it
 modules_path = os.path.dirname(tests_path)
 scripts_path = os.path.join(modules_path, "scripts")
@@ -403,3 +414,54 @@ class TestPsuChassisInfo(object):
         # Should have tried hdel for PSU, fan drawer, and module
         assert chassis_tbl.hdel.call_count == 3
         assert chassis_info.log_error.call_count == 3
+
+    def test_supplied_power_includes_pdbs(self):
+        chassis = MockChassis()
+        pdb1 = MockPsu("PDB 1", 0, True, True)
+        pdb1.set_maximum_supplied_power(150.0)
+        chassis._pdb_list.append(pdb1)
+
+        state_db = daemon_base.db_connect("STATE_DB")
+        chassis_tbl = mock_swsscommon.Table(state_db, CHASSIS_INFO_TABLE)
+        chassis_info = psud.PsuChassisInfo(SYSLOG_IDENTIFIER, chassis)
+        chassis_info.run_power_budget(chassis_tbl)
+        fvs = chassis_tbl.get(CHASSIS_INFO_POWER_KEY_TEMPLATE.format(1))
+        assert float(fvs[CHASSIS_INFO_TOTAL_POWER_SUPPLIED_FIELD]) == 150.0
+
+    def test_run_power_budget_when_get_all_pdbs_raises(self):
+        """
+        If get_all_psus succeeds but get_all_pdbs raises, the outer except re-fetches
+        PSUs only and still records PSU suppliers (no PDBs in that pass).
+        """
+        class ChassisPdbListNotImplemented(MockChassis):
+            def get_all_pdbs(self):
+                raise NotImplementedError
+
+        chassis = ChassisPdbListNotImplemented()
+        psu1 = MockPsu("PSU 1", 0, True, True)
+        psu1.set_maximum_supplied_power(200.0)
+        chassis._psu_list.append(psu1)
+
+        state_db = daemon_base.db_connect("STATE_DB")
+        chassis_tbl = mock_swsscommon.Table(state_db, CHASSIS_INFO_TABLE)
+        chassis_info = psud.PsuChassisInfo(SYSLOG_IDENTIFIER, chassis)
+        chassis_info.run_power_budget(chassis_tbl)
+        fvs = chassis_tbl.get(CHASSIS_INFO_POWER_KEY_TEMPLATE.format(1))
+        assert float(fvs[CHASSIS_INFO_TOTAL_POWER_SUPPLIED_FIELD]) == 200.0
+
+    def test_run_power_budget_when_all_supplier_lists_unavailable(self):
+        """Both get_all_psus and get_all_pdbs raise: no suppliers, totals only."""
+        class ChassisNoSuppliers(MockChassis):
+            def get_all_psus(self):
+                raise NotImplementedError
+
+            def get_all_pdbs(self):
+                raise NotImplementedError
+
+        chassis = ChassisNoSuppliers()
+        state_db = daemon_base.db_connect("STATE_DB")
+        chassis_tbl = mock_swsscommon.Table(state_db, CHASSIS_INFO_TABLE)
+        chassis_info = psud.PsuChassisInfo(SYSLOG_IDENTIFIER, chassis)
+        chassis_info.run_power_budget(chassis_tbl)
+        fvs = chassis_tbl.get(CHASSIS_INFO_POWER_KEY_TEMPLATE.format(1))
+        assert float(fvs[CHASSIS_INFO_TOTAL_POWER_SUPPLIED_FIELD]) == 0.0

--- a/sonic-psud/tests/test_psud.py
+++ b/sonic-psud/tests/test_psud.py
@@ -38,24 +38,67 @@ NOT_AVAILABLE = 'N/A'
 @mock.patch('psud.platform_psuutil', mock.MagicMock())
 def test_wrapper_get_num_psus():
     mock_logger = mock.MagicMock()
+    psud.platform_chassis.get_num_pdbs.return_value = 0
     # Test new platform API is available and implemented
     psud._wrapper_get_num_psus(mock_logger)
     assert psud.platform_chassis.get_num_psus.call_count == 1
+    assert psud.platform_chassis.get_num_pdbs.call_count == 1
     assert psud.platform_psuutil.get_num_psus.call_count == 0
 
-    # Test new platform API is available but not implemented
+    # PDB count is added to PSU count when both are implemented
+    psud.platform_chassis.get_num_psus.reset_mock()
+    psud.platform_chassis.get_num_pdbs.reset_mock()
+    psud.platform_chassis.get_num_psus.return_value = 2
+    psud.platform_chassis.get_num_pdbs.return_value = 1
+    assert psud._wrapper_get_num_psus(mock_logger) == 3
+
+    # get_num_pdbs can raise NotImplementedError while PSUs still count
+    psud.platform_chassis.get_num_psus.reset_mock()
+    psud.platform_chassis.get_num_pdbs.reset_mock()
+    psud.platform_chassis.get_num_psus.return_value = 4
+    psud.platform_chassis.get_num_pdbs.side_effect = NotImplementedError
+    assert psud._wrapper_get_num_psus(mock_logger) == 4
+
+    # get_num_psus can raise NotImplementedError while PDBs still count
+    psud.platform_chassis.get_num_psus.reset_mock()
+    psud.platform_chassis.get_num_pdbs.reset_mock()
     psud.platform_chassis.get_num_psus.side_effect = NotImplementedError
+    psud.platform_chassis.get_num_pdbs.side_effect = None
+    psud.platform_chassis.get_num_pdbs.return_value = 2
+    assert psud._wrapper_get_num_psus(mock_logger) == 2
+
+    # Both counts can be unavailable on chassis API
+    psud.platform_chassis.get_num_psus.reset_mock()
+    psud.platform_chassis.get_num_pdbs.reset_mock()
+    psud.platform_chassis.get_num_psus.side_effect = NotImplementedError
+    psud.platform_chassis.get_num_pdbs.side_effect = NotImplementedError
+    assert psud._wrapper_get_num_psus(mock_logger) == 0
+
+    # Restore sane defaults for the remainder of this test
+    psud.platform_chassis.get_num_psus.side_effect = None
+    psud.platform_chassis.get_num_pdbs.side_effect = None
+    psud.platform_chassis.get_num_psus.return_value = 0
+    psud.platform_chassis.get_num_pdbs.return_value = 0
+
+    # Test new platform API is available but get_num_psus not implemented:
+    # current behavior is to treat PSU count as 0 (no psuutil fallback while chassis exists)
+    psud.platform_chassis.get_num_psus.reset_mock()
+    psud.platform_chassis.get_num_pdbs.reset_mock()
+    psud.platform_chassis.get_num_psus.side_effect = NotImplementedError
+    psud.platform_chassis.get_num_pdbs.return_value = 0
     psud._wrapper_get_num_psus(mock_logger)
-    assert psud.platform_chassis.get_num_psus.call_count == 2
-    assert psud.platform_psuutil.get_num_psus.call_count == 1
+    assert psud.platform_chassis.get_num_psus.call_count == 1
+    assert psud.platform_chassis.get_num_pdbs.call_count == 1
+    assert psud.platform_psuutil.get_num_psus.call_count == 0
 
     # Test new platform API not available
     psud.platform_chassis = None
     psud._wrapper_get_num_psus(mock_logger)
-    assert psud.platform_psuutil.get_num_psus.call_count == 2
+    assert psud.platform_psuutil.get_num_psus.call_count == 1
 
     # Test with None logger - should not crash
     psud.platform_chassis = mock.MagicMock()
+    psud.platform_chassis.get_num_pdbs.return_value = 0
     psud.platform_psuutil = mock.MagicMock()
     psud._wrapper_get_num_psus(None)
     assert psud.platform_chassis.get_num_psus.call_count >= 1
@@ -239,6 +282,83 @@ def test_wrapper_get_psu():
     psud.platform_chassis = None
     result = psud._wrapper_get_psu(mock_logger, 1)
     assert result is None
+
+    # Invalid 1-based index short-circuits without calling into the chassis
+    psud.platform_chassis = mock.MagicMock()
+    assert psud._wrapper_get_psu(mock_logger, 0) is None
+    psud.platform_chassis.get_psu.assert_not_called()
+
+
+@mock.patch('psud.platform_chassis', mock.MagicMock())
+@mock.patch('psud.platform_psuutil', mock.MagicMock())
+def test_wrapper_get_pdb():
+    mock_logger = mock.MagicMock()
+    mock_pdb = mock.MagicMock()
+
+    psud.platform_chassis.get_pdb.return_value = mock_pdb
+    assert psud._wrapper_get_pdb(mock_logger, 1) == mock_pdb
+    psud.platform_chassis.get_pdb.assert_called_with(0)
+
+    psud.platform_chassis.get_pdb.reset_mock()
+    psud.platform_chassis.get_pdb.side_effect = NotImplementedError('Not implemented')
+    assert psud._wrapper_get_pdb(mock_logger, 1) is None
+    mock_logger.log_warning.assert_called_with(
+        "get_pdb() not implemented by platform chassis: Not implemented")
+
+    psud.platform_chassis.get_pdb.reset_mock()
+    mock_logger.log_warning.reset_mock()
+    psud.platform_chassis.get_pdb.side_effect = Exception('boom')
+    assert psud._wrapper_get_pdb(mock_logger, 2) is None
+    mock_logger.log_error.assert_called_with(
+        "Failed to get PDB 2 from platform chassis: boom")
+
+    assert psud._wrapper_get_pdb(None, 1) is None  # no logger
+    psud.platform_chassis = None
+    assert psud._wrapper_get_pdb(mock_logger, 1) is None
+    psud.platform_chassis = mock.MagicMock()
+    assert psud._wrapper_get_pdb(mock_logger, 0) is None
+    psud.platform_chassis.get_pdb.assert_not_called()
+
+
+def test_wrapper_get_pdb_presence_and_status():
+    mock_logger = mock.MagicMock()
+    mock_pdb = mock.MagicMock()
+    psud.platform_chassis = mock.MagicMock()
+    psud.platform_chassis.get_pdb.return_value = mock_pdb
+
+    mock_pdb.get_presence.return_value = True
+    assert psud._wrapper_get_pdb_presence(mock_logger, 1) is True
+
+    mock_pdb.get_presence.side_effect = NotImplementedError
+    assert psud._wrapper_get_pdb_presence(mock_logger, 1) is False
+
+    mock_pdb.get_presence.side_effect = RuntimeError('bad')
+    assert psud._wrapper_get_pdb_presence(mock_logger, 1) is False
+    mock_logger.log_warning.assert_called_with(
+        "Exception in pdb.get_presence() for PDB 1: bad")
+
+    psud.platform_chassis = None
+    assert psud._wrapper_get_pdb_presence(mock_logger, 1) is False
+
+    psud.platform_chassis = mock.MagicMock()
+    psud.platform_chassis.get_pdb.return_value = None
+    assert psud._wrapper_get_pdb_presence(mock_logger, 1) is False
+
+    psud.platform_chassis.get_pdb.return_value = mock_pdb
+    mock_pdb.get_presence.side_effect = None
+    mock_pdb.get_powergood_status.return_value = True
+    assert psud._wrapper_get_pdb_status(mock_logger, 1) is True
+
+    mock_pdb.get_powergood_status.side_effect = NotImplementedError
+    assert psud._wrapper_get_pdb_status(mock_logger, 1) is False
+
+    mock_pdb.get_powergood_status.side_effect = ValueError('x')
+    assert psud._wrapper_get_pdb_status(mock_logger, 1) is False
+    mock_logger.log_warning.assert_called_with(
+        "Exception in pdb.get_powergood_status() for PDB 1: x")
+
+    psud.platform_chassis = None
+    assert psud._wrapper_get_pdb_status(mock_logger, 1) is False
 
 
 @mock.patch('psud.platform_chassis', mock.MagicMock())
@@ -429,9 +549,93 @@ def test_get_psu_key():
 
 
 @mock.patch('psud.platform_chassis', mock.MagicMock())
+def test_get_pdb_key():
+    mock_pdb = mock.MagicMock()
+    mock_pdb.get_name.return_value = 'PDB-A'
+
+    psud.platform_chassis.get_pdb.return_value = mock_pdb
+    assert psud.get_pdb_key(1) == 'PDB-A'
+
+    psud.platform_chassis.get_pdb.reset_mock()
+    mock_pdb.get_name.reset_mock()
+    psud.platform_chassis.get_pdb.side_effect = Exception('fail')
+    assert psud.get_pdb_key(2) == psud.PDB_INFO_KEY_TEMPLATE.format(2)
+
+    psud.platform_chassis.get_pdb.reset_mock()
+    psud.platform_chassis.get_pdb.side_effect = None
+    psud.platform_chassis.get_pdb.return_value = mock_pdb
+    mock_pdb.get_name.side_effect = RuntimeError
+    assert psud.get_pdb_key(3) == psud.PDB_INFO_KEY_TEMPLATE.format(3)
+
+    psud.platform_chassis = None
+    assert psud.get_pdb_key(4) == psud.PDB_INFO_KEY_TEMPLATE.format(4)
+
+
+def test_sum_system_power_from_other_psus_and_pdbs():
+    chassis = MockChassis()
+    psu0 = MockPsu('PSU 1', 0, True, True)
+    psu1 = MockPsu('PSU 2', 1, True, True)
+    psu0.set_power(10.0)
+    psu1.set_power(25.0)
+    pdb0 = MockPsu('PDB 1', 0, True, True)
+    pdb0.set_power(7.0)
+    chassis._psu_list = [psu0, psu1]
+    chassis._pdb_list = [pdb0]
+
+    # Sum others while measuring for psu0: psu1 + pdb0
+    assert psud._sum_system_power_from_other_psus_and_pdbs(chassis, psu0, 100.0) == 132.0
+
+    # Measuring for pdb0: psu0 + psu1
+    assert psud._sum_system_power_from_other_psus_and_pdbs(chassis, pdb0, 50.0) == 85.0
+
+    ch2 = mock.MagicMock()
+    ch2.get_all_psus.side_effect = NotImplementedError
+    ch2.get_all_pdbs.return_value = [pdb0]
+    assert psud._sum_system_power_from_other_psus_and_pdbs(ch2, pdb0, 1.0) == 1.0
+
+    ch3 = mock.MagicMock()
+    ch3.get_all_psus.return_value = [psu0]
+    ch3.get_all_pdbs.side_effect = NotImplementedError
+    assert psud._sum_system_power_from_other_psus_and_pdbs(ch3, psu0, 2.0) == 2.0
+
+
+def _make_mock_swsscommon_for_main():
+    """Build a minimal swsscommon module so DaemonPsud can connect to STATE_DB without real Redis."""
+    import types
+    mod = types.ModuleType('swsscommon')
+    mod.STATE_DB = ''
+
+    class Table:
+        def __init__(self, db, table_name):
+            self.table_name = table_name
+            self.mock_dict = {}
+
+        def _del(self, key):
+            self.mock_dict.pop(key, None)
+
+        def set(self, key, fvs):
+            self.mock_dict[key] = getattr(fvs, 'fv_dict', fvs) if hasattr(fvs, 'fv_dict') else fvs
+
+        def get(self, key):
+            return self.mock_dict.get(key)
+
+    class FieldValuePairs:
+        def __init__(self, tuple_list):
+            if isinstance(tuple_list, list) and tuple_list and isinstance(tuple_list[0], (tuple, list)):
+                self.fv_dict = dict(tuple_list)
+            else:
+                self.fv_dict = {}
+
+    mod.Table = Table
+    mod.FieldValuePairs = FieldValuePairs
+    return mod
+
+
+@mock.patch('psud.platform_chassis', mock.MagicMock())
 @mock.patch('psud.DaemonPsud.run')
 def test_main(mock_run):
     mock_run.return_value = False
-
-    psud.main()
+    mock_swsscommon = _make_mock_swsscommon_for_main()
+    with mock.patch('psud.swsscommon', mock_swsscommon):
+        psud.main()
     assert mock_run.call_count == 1

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -271,20 +271,40 @@ class FanUpdater(logger.Logger):
         self.phy_entity_table = swsscommon.Table(state_db, PHYSICAL_ENTITY_INFO_TABLE)
 
     def __del__(self):
-        if self.table:
-            table_keys = self.table.getKeys()
-            for tk in table_keys:
-                self.table._del(tk)
-                if self.phy_entity_table:
-                    if self.phy_entity_table.get(tk) is not None:
-                        self.phy_entity_table._del(tk)
-        if self.drawer_table:
-            drawer_keys = self.drawer_table.getKeys()
-            for dtk in drawer_keys:
-                self.drawer_table._del(dtk)
-                if self.phy_entity_table:
-                    if self.phy_entity_table.get(dtk) is not None:
-                        self.phy_entity_table._del(dtk)
+        try:
+            table = getattr(self, 'table', None)
+            drawer_table = getattr(self, 'drawer_table', None)
+            phy_entity_table = getattr(self, 'phy_entity_table', None)
+            if table is not None:
+                get_keys = getattr(table, 'getKeys', None)
+                table_keys = list(get_keys()) if get_keys else []
+                for tk in table_keys:
+                    try:
+                        table._del(tk)
+                    except Exception:
+                        pass
+                    if phy_entity_table is not None:
+                        try:
+                            if phy_entity_table.get(tk) is not None:
+                                phy_entity_table._del(tk)
+                        except Exception:
+                            pass
+            if drawer_table is not None:
+                get_drawer_keys = getattr(drawer_table, 'getKeys', None)
+                drawer_keys = list(get_drawer_keys()) if get_drawer_keys else []
+                for dtk in drawer_keys:
+                    try:
+                        drawer_table._del(dtk)
+                    except Exception:
+                        pass
+                    if phy_entity_table is not None:
+                        try:
+                            if phy_entity_table.get(dtk) is not None:
+                                phy_entity_table._del(dtk)
+                        except Exception:
+                            pass
+        except Exception:
+            pass
 
     def _log_on_status_changed(self, normal_status, normal_log, abnormal_log):
         """
@@ -557,18 +577,20 @@ class LiquidCoolingUpdater(threading.Thread, logger.Logger):
             self.profile_table.set(profile.get_type(), fvs)
 
     def __del__(self):
-        if self.system_table:
-            table_keys = self.system_table.getKeys()
-            for tk in table_keys:
-                self.system_table._del(tk)
-        if self.sensor_table:
-            table_keys = self.sensor_table.getKeys()
-            for tk in table_keys:
-                self.sensor_table._del(tk)
-        if self.profile_table:
-            table_keys = self.profile_table.getKeys()
-            for tk in table_keys:
-                self.profile_table._del(tk)
+        try:
+            for attr in ('system_table', 'sensor_table', 'profile_table'):
+                tbl = getattr(self, attr, None)
+                if tbl is None:
+                    continue
+                get_keys = getattr(tbl, 'getKeys', None)
+                table_keys = list(get_keys()) if get_keys else []
+                for tk in table_keys:
+                    try:
+                        tbl._del(tk)
+                    except Exception:
+                        pass
+        except Exception:
+            pass
 
     def _refresh_leak_status(self):
         status = None
@@ -812,21 +834,32 @@ class TemperatureUpdater(logger.Logger):
                     self.chassis_table = None
 
     def __del__(self):
-        if self.table:
-            table_keys = self.table.getKeys()
-            for tk in table_keys:
-                self.table._del(tk)
-                try:
-                    if self.is_chassis_upd_required and self.chassis_table is not None:
-                        self.chassis_table._del(tk)
-                except Exception as e:
-                    # On a chassis system it is possible we may lose connection
-                    # to the supervisor and chassisdb. If this happens then we
-                    # should simply remove our handle to chassisdb.
-                    self.chassis_table = None
-                if self.phy_entity_table:
-                    if self.phy_entity_table.get(tk) is not None:
-                        self.phy_entity_table._del(tk)
+        try:
+            table = getattr(self, 'table', None)
+            if table is not None:
+                get_keys = getattr(table, 'getKeys', None)
+                table_keys = list(get_keys()) if get_keys else []
+                phy_entity_table = getattr(self, 'phy_entity_table', None)
+                for tk in table_keys:
+                    try:
+                        table._del(tk)
+                    except Exception:
+                        pass
+                    try:
+                        if getattr(self, 'is_chassis_upd_required', False) and getattr(self, 'chassis_table', None) is not None:
+                            self.chassis_table._del(tk)
+                    except Exception:
+                        # On a chassis system we may lose connection to the supervisor
+                        # and chassisdb; drop the handle.
+                        self.chassis_table = None
+                    if phy_entity_table is not None:
+                        try:
+                            if phy_entity_table.get(tk) is not None:
+                                phy_entity_table._del(tk)
+                        except Exception:
+                            pass
+        except Exception:
+            pass
 
     def _init_sfp_util_helper(self):
         """
@@ -972,6 +1005,17 @@ class TemperatureUpdater(logger.Logger):
                 if not self._collect_thermals(available_thermals, parent_name, psu.get_all_thermals(),
                                               refresh=should_update_psu, now=now):
                     return
+
+        # PDB thermals (get_all_pdbs() returns [] on PSU-based platforms, no overhead)
+        try:
+            for pdb_index, pdb in enumerate(self.chassis.get_all_pdbs()):
+                if try_get(pdb.get_presence):
+                    parent_name = try_get(pdb.get_name, default='PDB {}'.format(pdb_index + 1))
+                    if not self._collect_thermals(available_thermals, parent_name, pdb.get_all_thermals(),
+                                                  refresh=should_update_psu, now=now):
+                        return
+        except NotImplementedError:
+            pass
 
         if should_update_psu:
             self._last_psu_thermal_update = now

--- a/sonic-thermalctld/tests/mock_platform.py
+++ b/sonic-thermalctld/tests/mock_platform.py
@@ -529,6 +529,9 @@ class MockChassis(chassis_base.ChassisBase):
             raise NotImplementedError
         return self._dpu_id
 
+    def get_all_pdbs(self):
+        return getattr(self, '_pdb_list', [])
+
 class MockModule(module_base.ModuleBase):
     def __init__(self, index=1):
         super(MockModule, self).__init__()
@@ -544,3 +547,6 @@ class MockModule(module_base.ModuleBase):
 
     def get_all_psus(self):
         return self._psu_list
+
+    def get_all_pdbs(self):
+        return getattr(self, '_pdb_list', [])


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

This pr is part of the design [Support PDB flows](https://github.com/sonic-net/SONiC/pull/2219)
- Extended psud to treat PDBs as power entities alongside PSUs: added PDB wrappers/accessors, included pdb_num in CHASSIS_INFO, and updated DB key handling to support both PSU n and PDB n names.
- Refactored PSU update paths into shared PSU/PDB entity logic (presence/status/power/LED/entity/fan updates), including combined system-power calculation across all suppliers and adding a timestamp field in PSU_INFO.
- Updated thermalctld to collect and publish thermals from present PDBs, and hardened daemon cleanup paths (__del__) to avoid teardown exceptions.
- Expanded mocks/tests to cover PDB flows and the refactored entity-based behavior in sonic-psud and sonic-thermalctld.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

to maintain a consistent user experience for power, the psud had been extended to cover the new type hardware, power distribute board. The legacy method had been abstracted to general functions to make both psu and pdb can re-use it. 

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
it has been tested both on pdb installed hardware and unit test

#### Additional Information (Optional)
