### PR TITLE
Enable option to hold xcvrs in lpmode until host_tx is stable/ready

### DIFF
--- a/sonic-xcvrd/xcvrd/sff_mgr.py
+++ b/sonic-xcvrd/xcvrd/sff_mgr.py
@@ -1,3 +1,4 @@
+
 """
     SFF task manager
     Deterministic link bring-up task manager for SFF compliant modules, running
@@ -7,6 +8,7 @@
 try:
     import copy
     import sys
+    import time
     import threading
     import traceback
 
@@ -86,7 +88,8 @@ class SffManagerTask(threading.Thread):
 
     SFF_LOGGER_PREFIX = "SFF-MAIN: "
 
-    def __init__(self, namespaces, main_thread_stop_event, platform_chassis, helper_logger):
+    def __init__(self, namespaces, main_thread_stop_event, platform_chassis, helper_logger,
+                 hold_lpmode_tx_ready_time=None):
         threading.Thread.__init__(self)
         self.name = "SffManagerTask"
         self.exc = None
@@ -103,6 +106,11 @@ class SffManagerTask(threading.Thread):
         self.port_dict_prev = {}
         self.xcvr_table_helper = XcvrTableHelper(namespaces)
         self.namespaces = namespaces
+        # extended time to hold transceiver in lpmode after host_tx_ready
+        # before bringing to high power
+        self.hold_lpmode_tx_ready_time = hold_lpmode_tx_ready_time
+        # Dictionary storing lport -> timestamp
+        self.pending_high_power_mode = {}
 
     def log_notice(self, message):
         self.helper_logger.log_notice("{}{}".format(self.SFF_LOGGER_PREFIX, message))
@@ -325,6 +333,21 @@ class SffManagerTask(threading.Thread):
         except (AttributeError, NotImplementedError):
             pass
 
+    def xcvr_power_up(self, sfp, api, lport):
+        self.enable_high_power_class(api, lport)
+
+        if api.get_lpmode_support():
+            set_lp_success = (
+                sfp.set_lpmode(False)
+                if isinstance(api, Sff8472Api)
+                else api.set_lpmode(False)
+            )
+            if not set_lp_success:
+                self.log_error(
+                    "{}: Failed to take module out of low power mode.".format(
+                        lport)
+                )
+
     def task_worker(self):
         '''
         The main goal of sff_mgr is to make sure SFF compliant modules are
@@ -360,7 +383,7 @@ class SffManagerTask(threading.Thread):
             # operation in the DB tables. Upon process restart, messages will be
             # replayed for all fields, no need to explictly query the DB tables
             # here.
-            if not port_change_observer.handle_port_update_event():
+            if not port_change_observer.handle_port_update_event() and not self.pending_high_power_mode:
                 # In the case of no real update, go back to the beginning of the loop
                 continue
 
@@ -378,6 +401,7 @@ class SffManagerTask(threading.Thread):
                 xcvr_inserted = False
                 host_tx_ready_changed = False
                 admin_status_changed = False
+                lpmode_deassert_pending = lport in self.pending_high_power_mode
                 if pport < 0 or lanes_list is None:
                     continue
 
@@ -447,6 +471,7 @@ class SffManagerTask(threading.Thread):
                 # event, such as CONFIG_DB change other than admin_status field.
                 if ((not xcvr_inserted) and
                     (not host_tx_ready_changed) and
+                    (not lpmode_deassert_pending) and
                     (not admin_status_changed)):
                     continue
                 self.log_notice(("{}: xcvr=present(inserted={}), "
@@ -474,20 +499,26 @@ class SffManagerTask(threading.Thread):
                     # Skip if these essential routines are not available
                     continue
 
-                if xcvr_inserted or (admin_status_changed and data[self.ADMIN_STATUS] == "up"):
-                    self.enable_high_power_class(api, lport)
+                admin_changed_up = admin_status_changed and data[self.ADMIN_STATUS] == "up"
+                if self.hold_lpmode_tx_ready_time:
+                    # When this flag is asserted, the SFF-MGR will hold the module in lpmode
+                    # for DEASSERT_LPMODE_WAIT_TIME after the host tx signal is ready.
+                    xcvr_queue_power_up = (xcvr_inserted or
+                                               host_tx_ready_changed or
+                                               admin_changed_up)
 
-                    if api.get_lpmode_support():
-                        set_lp_success = (
-                            sfp.set_lpmode(False)
-                            if isinstance(api, Sff8472Api)
-                            else api.set_lpmode(False)
-                        )
-                        if not set_lp_success:
-                            self.log_error(
-                                "{}: Failed to take module out of low power mode.".format(
-                                    lport)
-                            )
+                    if (xcvr_queue_power_up and data[self.HOST_TX_READY] == "true" and
+                            not lpmode_deassert_pending):
+                        self.pending_high_power_mode[lport] = time.monotonic()
+
+                    if (lpmode_deassert_pending and time.monotonic() -
+                           self.pending_high_power_mode[lport] > self.hold_lpmode_tx_ready_time):
+                        del self.pending_high_power_mode[lport]
+                        self.xcvr_power_up(sfp, api, lport)
+                    else:
+                        continue
+                elif xcvr_inserted or admin_changed_up:
+                    self.xcvr_power_up(sfp, api, lport)
 
                 if active_lanes is None:
                     active_lanes = self.get_active_lanes_for_lport(lport, subport_idx,

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -874,7 +874,9 @@ class SfpStateUpdateTask(threading.Thread):
 
 
 class DaemonXcvrd(daemon_base.DaemonBase):
-    def __init__(self, log_identifier, skip_cmis_mgr=False, enable_sff_mgr=False, dom_temperature_poll_interval=None, dom_update_interval=None):
+    def __init__(self, log_identifier, skip_cmis_mgr=False, enable_sff_mgr=False,
+                 dom_temperature_poll_interval=None, dom_update_interval=None,
+                 hold_lpmode_tx_ready_time=None):
         super(DaemonXcvrd, self).__init__(log_identifier, enable_runtime_log_config=True)
         self.stop_event = threading.Event()
         self.sfp_error_event = threading.Event()
@@ -882,6 +884,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         self.enable_sff_mgr = enable_sff_mgr
         self.dom_temperature_poll_interval = dom_temperature_poll_interval
         self.dom_update_interval = dom_update_interval
+        self.hold_lpmode_tx_ready_time = hold_lpmode_tx_ready_time
         self.namespaces = ['']
         self.threads = []
         self.sfp_obj_dict = {}
@@ -1147,7 +1150,9 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         # Start the SFF manager
         sff_manager = None
         if self.enable_sff_mgr:
-            sff_manager = SffManagerTask(self.namespaces, self.stop_event, platform_chassis, helper_logger)
+            sff_manager = SffManagerTask(self.namespaces, self.stop_event, platform_chassis,
+                                         helper_logger,
+                                         hold_lpmode_tx_ready_time=self.hold_lpmode_tx_ready_time)
             sff_manager.start()
             self.threads.append(sff_manager)
         else:
@@ -1247,10 +1252,12 @@ def main():
     parser.add_argument('--enable_sff_mgr', action='store_true')
     parser.add_argument('--dom_temperature_poll_interval', default=None, type=int)
     parser.add_argument('--dom_update_interval', default=None, type=int)
+    parser.add_argument('--hold_lpmode_tx_ready_time', default=None, type=int)
 
     args = parser.parse_args()
     xcvrd = DaemonXcvrd(SYSLOG_IDENTIFIER, args.skip_cmis_mgr, args.enable_sff_mgr,
-                        args.dom_temperature_poll_interval, args.dom_update_interval)
+                        args.dom_temperature_poll_interval, args.dom_update_interval,
+                        args.hold_lpmode_tx_ready_time)
     xcvrd.run()
 
 


### PR DESCRIPTION
In this PR, a extra argument is added to sff_mgr/ xcvrd. When xcvrd is run with `--hold_lpmode_tx_ready_time=<time (s)>`, we hold QSFP transceivers in low power mode for that duration before bringing it up to high power. 

#### Description
For example, if `--hold_lpmode_tx_ready_time=5`, this will be the xcvr bringup process.

1. Transceiver inserted
2. Host Tx Becomes Ready
3. Wait 5s      <--- New 
4. Bring to high power mode using software lpmode register
5. Enable module tx

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

Transceivers may require a good/ stable host_tx signal when it is first brought out of low power mode in order to ensure the CDR locks properly. Otherwise the link may be down or suboptimal.

However, we can not just use the host_tx_ready flag from redis to know when to bring the module up as host_tx_ready may flap during module initialization. To ensure the signal is good, we set a timer when host_tx_ready is first reported good. Then after that timer expires, we bring the module to high power and enable tx.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

This has been tested by stressing reboot, physical removal, and admin shut/no shut. A subsequent unit test will be added to this PR once ready

#### Additional Information (Optional)
