### PR TITLE
[LEDD] Subscribe to PORT_TABLE in APPL_DB for port oper status

### DIFF
--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -40,7 +40,7 @@ MAX_FRONT_PANEL_PORTS = 256
 class Port():
     PORT_UP = "up" # All subports are up
     PORT_DOWN = "down" # All subports are down
-    PORT_OP_FIELD = "netdev_oper_status"
+    PORT_OP_FIELD = "oper_status"
 
     def __init__(self, name, index, state, subport, role):
         self._name = name
@@ -132,12 +132,12 @@ class PortStateObserver:
 
     def subscribePortTable(self, namespaces):
         for namespace in namespaces:
-            self.subscribeDbTable("STATE_DB", swsscommon.STATE_PORT_TABLE_NAME, namespace)
- 
+            self.subscribeDbTable("APPL_DB", swsscommon.APP_PORT_TABLE_NAME, namespace)
+
     def connectDB(self, dbname, namespace):
         db = daemon_base.db_connect(dbname, namespace=namespace)
         return db
-    
+
     def getDatabaseTable(self, dbname, tblname, namespace):
         db = self.connectDB(dbname, namespace)
         table = swsscommon.Table(db, tblname)
@@ -205,7 +205,7 @@ class DaemonLedd(daemon_base.DaemonBase):
         # {port-index, total subports oper UP}
         fp_port_up_subports = [0] * MAX_FRONT_PANEL_PORTS
         logical_port_mapping = {}
-        
+
         for namespace in namespaces:
             port_cfg_table = self.portObserver.getDatabaseTable("CONFIG_DB", swsscommon.CFG_PORT_TABLE_NAME, namespace)
             port_st_table = self.portObserver.getDatabaseTable("STATE_DB", swsscommon.STATE_PORT_TABLE_NAME, namespace)

--- a/sonic-ledd/scripts/ledd
+++ b/sonic-ledd/scripts/ledd
@@ -126,7 +126,7 @@ class FrontPanelPorts:
 
 class PortStateObserver:
     def __init__(self):
-       # Subscribe to PORT table notifications in the STATE DB
+       # Subscribe to PORT table notifications in the APPL DB
         self.tables = {}
         self.sel = swsscommon.Select()
 

--- a/sonic-ledd/tests/test_ledd.py
+++ b/sonic-ledd/tests/test_ledd.py
@@ -192,7 +192,7 @@ def test_find_front_panel_ports(mock_get_database_table, mock_load_platform_util
     )
     mock_state_table.get.side_effect = lambda key: (
         key,
-        [("netdev_oper_status", "up" if key == "Ethernet0" else "down")],
+        [("oper_status", "up" if key == "Ethernet0" else "down")],
     )
 
     # Create an instance of DaemonLedd
@@ -229,7 +229,7 @@ def test_get_port_table_event(mock_cast_selectable, mock_subscriber_table):
     # Mock the SubscriberStateTable behavior
     mock_table = mock.Mock()
     mock_subscriber_table.return_value = mock_table
-    mock_table.pop.return_value = ("Ethernet0", "SET", [("netdev_oper_status", ledd.Port.PORT_UP)])
+    mock_table.pop.return_value = ("Ethernet0", "SET", [("oper_status", ledd.Port.PORT_UP)])
 
     # Create an instance of PortStateObserver
     observer = ledd.PortStateObserver()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Subscribe to PORT_TABLE in APPL_DB for port oper status

#### Motivation and Context
Continuous log flooding from ledd daemon even if there is change in port operational status
```
2026 Apr 17 15:15:31.558551 SW1 NOTICE pmon#ledd[2219]: Setting Port Ethernet428 LED state change for down
2026 Apr 17 15:15:31.558737  SW1 NOTICE pmon#ledd[2219]: Received PORT table event: key=Ethernet428, state=up
2026 Apr 17 15:15:31.564639  SW1 NOTICE pmon#ledd[2219]: Received PORT table event: key=Ethernet424, state=up
```

This is because previously the ledd daemon had subscribed to PORT_TABLE of STATE_DB which can get updated by Orchagent which can unnecessarily trigger processing of port oper status by ledd

#### How Has This Been Tested?
Validated this in lab switch where the logs were getting flooded

#### Additional Information (Optional)
