### PR TITLE
[xcvrd] Process host_tx_ready true->true transitions with count changes

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -2022,6 +2022,29 @@ class TestXcvrdScript(object):
         }
         assert observer.port_event_cache == expected_cache
 
+        # Test host_tx_ready true->true with count change (create new observer with host_tx_ready in filter):
+        observer = PortChangeObserver(DEFAULT_NAMESPACE, logger, stop_event,
+                                     port_change_event_handler.handle_port_change_event,
+                                     [{CONFIG_DB: PORT_TABLE, 'FILTER': ['host_tx_ready', 'host_tx_ready_count']}])
+        mock_selectable.pop.side_effect = iter([
+            ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), ('host_tx_ready', 'true'), ('host_tx_ready_count', '1'))),
+            (None, None, None)])
+        assert observer.handle_port_update_event()
+        expected_processed_event_count += 1
+
+        # Same count - should not process (duplicate):
+        mock_selectable.pop.side_effect = iter([
+            ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), ('host_tx_ready', 'true'), ('host_tx_ready_count', '1'))),
+            (None, None, None)])
+        assert not observer.handle_port_update_event()
+
+        # Count incremented - should process:
+        mock_selectable.pop.side_effect = iter([
+            ('Ethernet0', swsscommon.SET_COMMAND, (('index', '1'), ('host_tx_ready', 'true'), ('host_tx_ready_count', '2'))),
+            (None, None, None)])
+        assert observer.handle_port_update_event()
+        expected_processed_event_count += 1
+
     @patch('swsscommon.swsscommon.Select.addSelectable', MagicMock())
     @patch('swsscommon.swsscommon.SubscriberStateTable')
     @patch('swsscommon.swsscommon.Select.select')

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/port_event_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/port_event_helper.py
@@ -7,7 +7,7 @@ SELECT_TIMEOUT_MSECS = 1000
 DEFAULT_PORT_TBL_MAP = [
     {'CONFIG_DB': swsscommon.CFG_PORT_TABLE_NAME},
     {'STATE_DB': 'TRANSCEIVER_INFO'},
-    {'STATE_DB': 'PORT_TABLE', 'FILTER': ['host_tx_ready']},
+    {'STATE_DB': 'PORT_TABLE', 'FILTER': ['host_tx_ready', 'host_tx_ready_count']},
 ]
 
 class PortChangeEvent:
@@ -176,10 +176,26 @@ class PortChangeObserver:
                     # Compare current event with last event on this key, to see if
                     # there's really a need to update.
                     diff = set(fvp.items()) - set(self.port_event_cache[key].items())
-                    # Ignore duplicate events
-                    if not diff:
-                       self.port_event_cache[key] = fvp
-                       continue
+
+                    # Special handling for host_tx_ready true->true transition with count change
+                    # Even if host_tx_ready value is the same, if the count changed, we need to process it
+                    old_host_tx_ready = self.port_event_cache[key].get('host_tx_ready', None)
+                    new_host_tx_ready = fvp.get('host_tx_ready', None)
+                    old_count = self.port_event_cache[key].get('host_tx_ready_count', None)
+                    new_count = fvp.get('host_tx_ready_count', None)
+
+                    # If both host_tx_ready are 'true' but count changed, treat it as a real event
+                    if (old_host_tx_ready == 'true' and new_host_tx_ready == 'true' and
+                        old_count is not None and new_count is not None and old_count != new_count):
+                        self.logger.log_notice("$$$ {} Detected host_tx_ready true->true transition with count change ({} -> {})".format(
+                            key[0], old_count, new_count))
+                        # Don't skip this event - let it proceed
+                    elif not diff:
+                        # Ignore duplicate events only if there's no real change
+                        self.port_event_cache[key] = fvp
+                        continue
+                    # else: First event for this key - always process it and populate the cache
+
                 # Update the latest event to the cache
                 self.port_event_cache[key] = fvp
 


### PR DESCRIPTION
### Summary

Safer fix for 202511 instead of https://github.com/sonic-net/sonic-platform-daemons/pull/799

#### Description
Add special handling in xcvrd's `handle_port_update_event()` to process `host_tx_ready` true->true transitions when the `host_tx_ready_count` changes. Previously, these events were filtered out as duplicates because the `host_tx_ready` value remained 'true', but the count increment indicates a real state transition that needs to be processed.

The change adds logic to detect when:
- Both old and new `host_tx_ready` values are 'true'
- Both `host_tx_ready_count` values exist
- The count values are different

When this condition is met, the event bypasses the duplicate filter and gets processed normally.

#### Motivation and Context
In certain scenarios, the `host_tx_ready` signal can transition from true->true with an incremented count, indicating a genuine state change (e.g., a retry or re-initialization). The existing duplicate event filtering logic was treating these as duplicates and skipping them, causing important state transitions to be missed.

This change ensures that even when `host_tx_ready` remains 'true', if the associated count changes, the event is recognized as a real update and processed accordingly. This is critical for proper transceiver state management as we need valid host signal before processing the state machine and signal should not flap during the state machine transition

#### How Has This Been Tested?

After a reload, port comes up in admin state up, then we program serdes that changes the host_tx_ready again to false and then true.
Before the change the second true was not getting processed by CmisManagerTask as it didn't receive the event. It was doing work on other port at that point.

After the fix
```
2026 Mar 27 21:33:21.634547 humm212 NOTICE swss#orchagent: :- initHostTxReadyState: initialize host_tx_ready as false for port Ethernet0
2026 Mar 27 21:33:21.673139 humm212 NOTICE swss#orchagent: :- setHostTxReady: Setting host_tx_ready status = true, count = 1, alias = Ethernet0, port_id = 0x1000000000001
2026 Mar 27 21:33:21.673259 humm212 NOTICE swss#orchagent: :- setPortAdminStatus: Set admin status UP host_tx_ready to true for port Ethernet0
2026 Mar 27 21:33:21.679035 humm212 NOTICE pmon#CmisManagerTask[30]: *** ('Ethernet0', 'STATE_DB', 'PORT_TABLE') handle_port_update_event() fvp {'host_tx_ready': 'false', 'host_tx_ready_count': '0', 'index': '-1', 'port_name': 'Ethernet0', 'asic_id': 0, 'op': 'SET'}
2026 Mar 27 21:33:22.905734 humm212 NOTICE pmon#CmisManagerTask[30]: *** ('Ethernet0', 'STATE_DB', 'PORT_TABLE') handle_port_update_event() fvp {'host_tx_ready': 'true', 'host_tx_ready_count': '1', 'index': '-1', 'port_name': 'Ethernet0', 'asic_id': 0, 'op': 'SET'}
2026 Mar 27 21:33:23.248422 humm212 NOTICE swss#orchagent: :- setHostTxReady: Setting host_tx_ready status = false, count = 2, alias = Ethernet0, port_id = 0x1000000000001
2026 Mar 27 21:33:23.248495 humm212 NOTICE swss#orchagent: :- setPortAdminStatus: Set admin status DOWN host_tx_ready to false for port Ethernet0
2026 Mar 27 21:33:23.358714 humm212 NOTICE swss#orchagent: :- setHostTxReady: Setting host_tx_ready status = true, count = 3, alias = Ethernet0, port_id = 0x1000000000001
2026 Mar 27 21:33:23.358826 humm212 NOTICE swss#orchagent: :- setPortAdminStatus: Set admin status UP host_tx_ready to true for port Ethernet0
2026 Mar 27 21:33:23.564838 humm212 NOTICE pmon#CmisManagerTask[30]: *** Ethernet0 Detected host_tx_ready true->true transition with count change (1 -> 3)
2026 Mar 27 21:33:23.564853 humm212 NOTICE pmon#CmisManagerTask[30]: *** ('Ethernet0', 'STATE_DB', 'PORT_TABLE') handle_port_update_event() fvp {'host_tx_ready': 'true', 'host_tx_ready_count': '3', 'index': '-1', 'port_name': 'Ethernet0', 'asic_id': 0, 'op': 'SET'}
