### PR TITLE
Replace imp with importlib

### DIFF
--- a/sonic-chassisd/tests/conftest.py
+++ b/sonic-chassisd/tests/conftest.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import importlib.util
+import importlib.machinery
+from mock import MagicMock
+
+tests_path = os.path.dirname(os.path.abspath(__file__))
+
+# Add mocked_libs path so that the file under test can load mocked modules from there
+mocked_libs_path = os.path.join(tests_path, "mocked_libs")
+sys.path.insert(0, mocked_libs_path)
+
+from sonic_py_common import daemon_base
+daemon_base.db_connect = MagicMock()
+
+# Add path to the file under test so that we can load it
+modules_path = os.path.dirname(tests_path)
+scripts_path = os.path.join(modules_path, "scripts")
+sys.path.insert(0, modules_path)
+
+os.environ["CHASSISD_UNIT_TESTING"] = "1"
+
+# Load chassisd once so all test files share the same module object and mocks apply correctly
+if 'chassisd' not in sys.modules:
+    loader = importlib.machinery.SourceFileLoader('chassisd', os.path.join(scripts_path, 'chassisd'))
+    spec = importlib.util.spec_from_file_location('chassisd', os.path.join(scripts_path, 'chassisd'), loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['chassisd'] = module
+    spec.loader.exec_module(module)

--- a/sonic-chassisd/tests/test_chassis_db_init.py
+++ b/sonic-chassisd/tests/test_chassis_db_init.py
@@ -1,6 +1,17 @@
 import os
 import sys
-from imp import load_source
+import importlib.util
+import importlib.machinery
+def load_source(module_name, module_path):
+    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
+    if module_name in sys.modules:
+        module = sys.modules[module_name]
+    else:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 from mock import Mock, MagicMock, patch
 from sonic_py_common import daemon_base

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -5,7 +5,18 @@ import tempfile
 import json
 import pytest
 import time
-from imp import load_source
+import importlib.util
+import importlib.machinery
+def load_source(module_name, module_path):
+    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
+    if module_name in sys.modules:
+        module = sys.modules[module_name]
+    else:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 from mock import Mock, MagicMock, patch, mock_open
 from sonic_py_common import daemon_base

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -5,19 +5,6 @@ import tempfile
 import json
 import pytest
 import time
-import importlib.util
-import importlib.machinery
-def load_source(module_name, module_path):
-    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
-    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
-    if module_name in sys.modules:
-        module = sys.modules[module_name]
-    else:
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
-
 from mock import Mock, MagicMock, patch, mock_open
 from sonic_py_common import daemon_base
 
@@ -44,7 +31,6 @@ scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, modules_path)
 
 os.environ["CHASSISD_UNIT_TESTING"] = "1"
-load_source('chassisd', scripts_path + '/chassisd')
 from chassisd import *
 
 

--- a/sonic-chassisd/tests/test_dpu_chassisd.py
+++ b/sonic-chassisd/tests/test_dpu_chassisd.py
@@ -6,7 +6,18 @@ import signal
 import threading
 import time
 from datetime import datetime
-from imp import load_source
+import importlib.util
+import importlib.machinery
+def load_source(module_name, module_path):
+    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
+    if module_name in sys.modules:
+        module = sys.modules[module_name]
+    else:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 import re
 
 from mock import MagicMock

--- a/sonic-ledd/setup.py
+++ b/sonic-ledd/setup.py
@@ -21,6 +21,13 @@ setup(
         'pytest',
         'pytest-cov'
     ],
+    extras_require={
+        'testing': [
+            'mock>=2.0.0; python_version < "3.3"',
+            'pytest',
+            'pytest-cov'
+        ]
+    },
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: No Input/Output (Daemon)',

--- a/sonic-ledd/setup.py
+++ b/sonic-ledd/setup.py
@@ -17,13 +17,11 @@ setup(
         'wheel'
     ],
     tests_require=[
-        'mock>=2.0.0; python_version < "3.3"',
         'pytest',
         'pytest-cov'
     ],
     extras_require={
         'testing': [
-            'mock>=2.0.0; python_version < "3.3"',
             'pytest',
             'pytest-cov'
         ]

--- a/sonic-ledd/tests/test_ledd.py
+++ b/sonic-ledd/tests/test_ledd.py
@@ -1,6 +1,17 @@
 import os
 import sys
-from imp import load_source
+import importlib.util
+import importlib.machinery
+def load_source(module_name, module_path):
+    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
+    if module_name in sys.modules:
+        module = sys.modules[module_name]
+    else:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 import pytest
 from unittest import mock
@@ -192,7 +203,7 @@ def test_find_front_panel_ports(mock_get_database_table, mock_load_platform_util
     )
     mock_state_table.get.side_effect = lambda key: (
         key,
-        [("oper_status", "up" if key == "Ethernet0" else "down")],
+        [("netdev_oper_status", "up" if key == "Ethernet0" else "down")],
     )
 
     # Create an instance of DaemonLedd
@@ -229,7 +240,7 @@ def test_get_port_table_event(mock_cast_selectable, mock_subscriber_table):
     # Mock the SubscriberStateTable behavior
     mock_table = mock.Mock()
     mock_subscriber_table.return_value = mock_table
-    mock_table.pop.return_value = ("Ethernet0", "SET", [("oper_status", ledd.Port.PORT_UP)])
+    mock_table.pop.return_value = ("Ethernet0", "SET", [("netdev_oper_status", ledd.Port.PORT_UP)])
 
     # Create an instance of PortStateObserver
     observer = ledd.PortStateObserver()

--- a/sonic-ledd/tests/test_ledd.py
+++ b/sonic-ledd/tests/test_ledd.py
@@ -173,8 +173,9 @@ def test_daemon_ledd_run_timeout(mock_fp_ports, mock_find_front_panel_ports, moc
 
 @mock.patch('swsscommon.swsscommon.Select.addSelectable', mock.MagicMock())
 @mock.patch("ledd.DaemonLedd.load_platform_util")
+@mock.patch("ledd.multi_asic.is_front_panel_port")
 @mock.patch("ledd.PortStateObserver.getDatabaseTable")
-def test_find_front_panel_ports(mock_get_database_table, mock_load_platform_util):
+def test_find_front_panel_ports(mock_get_database_table, mock_is_front_panel_port, mock_load_platform_util):
     """
     Test DaemonLedd.findFrontPanelPorts to ensure it correctly processes namespaces and returns
     the expected front panel port data.
@@ -185,6 +186,9 @@ def test_find_front_panel_ports(mock_get_database_table, mock_load_platform_util
 
     # Mock load_platform_util to prevent actual loading of the LedControl module
     mock_load_platform_util.return_value = mock.Mock()
+
+    # Mock is_front_panel_port to return True for all ports
+    mock_is_front_panel_port.return_value = True
 
     # Mock the return values for CONFIG_DB and STATE_DB tables
     mock_get_database_table.side_effect = lambda dbname, tblname, namespace: (
@@ -233,6 +237,7 @@ def test_get_port_table_event(mock_cast_selectable, mock_subscriber_table):
     Test PortStateObserver.getPortTableEvent to ensure it correctly processes events from the PORT table.
     """
     # Mock the selectable object and namespace
+    mock_selectable = mock.Mock()
     mock_redis_select_obj = mock.Mock()
     mock_cast_selectable.return_value = mock_redis_select_obj
     mock_redis_select_obj.getDbConnector.return_value.getNamespace.return_value = "namespace1"
@@ -246,8 +251,8 @@ def test_get_port_table_event(mock_cast_selectable, mock_subscriber_table):
     observer = ledd.PortStateObserver()
     observer.tables["namespace1"] = mock_table
 
-    # Call the method under test
-    event = observer.getPortTableEvent(mock.Mock())
+    # Call the method under test with the mocked selectable object
+    event = observer.getPortTableEvent(mock_selectable)
 
     # Assertions
     assert event is not None
@@ -255,7 +260,7 @@ def test_get_port_table_event(mock_cast_selectable, mock_subscriber_table):
     assert event[1] == ledd.Port.PORT_UP  # Port state
 
     # Verify that the mock methods were called
-    mock_cast_selectable.assert_called_once()
+    mock_cast_selectable.assert_called_once_with(mock_selectable)
     mock_table.pop.assert_called_once()
 
 @mock.patch("ledd.swsscommon.SubscriberStateTable")
@@ -265,6 +270,7 @@ def test_get_port_table_event_no_key(mock_cast_selectable, mock_subscriber_table
     Test PortStateObserver.getPortTableEvent to handle cases where no key is returned.
     """
     # Mock the selectable object and namespace
+    mock_selectable = mock.Mock()
     mock_redis_select_obj = mock.Mock()
     mock_cast_selectable.return_value = mock_redis_select_obj
     mock_redis_select_obj.getDbConnector.return_value.getNamespace.return_value = "namespace1"
@@ -278,14 +284,14 @@ def test_get_port_table_event_no_key(mock_cast_selectable, mock_subscriber_table
     observer = ledd.PortStateObserver()
     observer.tables["namespace1"] = mock_table
 
-    # Call the method under test
-    event = observer.getPortTableEvent(mock.Mock())
+    # Call the method under test with the mocked selectable object
+    event = observer.getPortTableEvent(mock_selectable)
 
     # Assertions
     assert event is None
 
     # Verify that the mock methods were called
-    mock_cast_selectable.assert_called_once()
+    mock_cast_selectable.assert_called_once_with(mock_selectable)
     mock_table.pop.assert_called_once()
 
 @mock.patch("ledd.DaemonLedd")

--- a/sonic-ledd/tests/test_ledd.py
+++ b/sonic-ledd/tests/test_ledd.py
@@ -30,6 +30,7 @@ import ledd
 daemon_base.db_connect = mock.MagicMock()
 swsscommon.Table = mock.MagicMock()
 swsscommon.ProducerStateTable = mock.MagicMock()
+swsscommon.SubscriberStateTable = mock.MagicMock()
 swsscommon.SonicDBConfig = mock.MagicMock()
 
 def test_help_args(capsys):
@@ -150,8 +151,8 @@ def test_daemon_ledd_run_timeout(mock_fp_ports, mock_find_front_panel_ports, moc
     # Mock getSelectEvent to return a timeout
     mock_get_select_event.return_value = (swsscommon.Select.TIMEOUT, None)
 
-    # Mock get_front_end_namespaces to return empty list
-    mock_get_namespaces.return_value = []
+    # Mock get_front_end_namespaces to list with one element
+    mock_get_namespaces.return_value = ['']
 
     # Mock load_platform_util to prevent actual loading of the LedControl module
     mock_load_platform_util.return_value = mock.Mock()
@@ -210,7 +211,7 @@ def test_find_front_panel_ports(mock_get_database_table, mock_is_front_panel_por
     )
     mock_state_table.get.side_effect = lambda key: (
         key,
-        [("netdev_oper_status", "up" if key == "Ethernet0" else "down")],
+        [("oper_status", "up" if key == "Ethernet0" else "down")],
     )
 
     # Create an instance of DaemonLedd
@@ -248,7 +249,7 @@ def test_get_port_table_event(mock_cast_selectable, mock_subscriber_table):
     # Mock the SubscriberStateTable behavior
     mock_table = mock.Mock()
     mock_subscriber_table.return_value = mock_table
-    mock_table.pop.return_value = ("Ethernet0", "SET", [("netdev_oper_status", ledd.Port.PORT_UP)])
+    mock_table.pop.return_value = ("Ethernet0", "SET", [("oper_status", ledd.Port.PORT_UP)])
 
     # Create an instance of PortStateObserver
     observer = ledd.PortStateObserver()

--- a/sonic-ledd/tests/test_ledd.py
+++ b/sonic-ledd/tests/test_ledd.py
@@ -30,7 +30,6 @@ import ledd
 daemon_base.db_connect = mock.MagicMock()
 swsscommon.Table = mock.MagicMock()
 swsscommon.ProducerStateTable = mock.MagicMock()
-swsscommon.SubscriberStateTable = mock.MagicMock()
 swsscommon.SonicDBConfig = mock.MagicMock()
 
 def test_help_args(capsys):
@@ -140,15 +139,19 @@ def test_daemon_ledd_initialization(mock_fp_ports, mock_port_observer, mock_get_
 
 @mock.patch('swsscommon.swsscommon.Select.addSelectable', mock.MagicMock())
 @mock.patch("ledd.DaemonLedd.load_platform_util")
+@mock.patch("ledd.multi_asic.get_front_end_namespaces")
 @mock.patch("ledd.PortStateObserver.getSelectEvent")
 @mock.patch("ledd.DaemonLedd.findFrontPanelPorts")
 @mock.patch("ledd.FrontPanelPorts")
-def test_daemon_ledd_run_timeout(mock_fp_ports, mock_find_front_panel_ports, mock_get_select_event, mock_load_platform_util):
+def test_daemon_ledd_run_timeout(mock_fp_ports, mock_find_front_panel_ports, mock_get_select_event, mock_get_namespaces, mock_load_platform_util):
     """
     Test that DaemonLedd.run() handles a timeout from the select method correctly.
     """
     # Mock getSelectEvent to return a timeout
     mock_get_select_event.return_value = (swsscommon.Select.TIMEOUT, None)
+
+    # Mock get_front_end_namespaces to return empty list
+    mock_get_namespaces.return_value = []
 
     # Mock load_platform_util to prevent actual loading of the LedControl module
     mock_load_platform_util.return_value = mock.Mock()

--- a/sonic-pcied/tests/conftest.py
+++ b/sonic-pcied/tests/conftest.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import importlib.util
+import importlib.machinery
+from unittest import mock
+
+tests_path = os.path.dirname(os.path.abspath(__file__))
+
+# Add mocked_libs path so that the file under test can load mocked modules from there
+mocked_libs_path = os.path.join(tests_path, "mocked_libs")
+sys.path.insert(0, mocked_libs_path)
+
+from sonic_py_common import daemon_base
+daemon_base.db_connect = mock.MagicMock()
+
+# Add path to the file under test so that we can load it
+modules_path = os.path.dirname(tests_path)
+scripts_path = os.path.join(modules_path, "scripts")
+sys.path.insert(0, modules_path)
+
+# Load pcied once so all test files share the same module object and mocks apply correctly
+if 'pcied' not in sys.modules:
+    loader = importlib.machinery.SourceFileLoader('pcied', os.path.join(scripts_path, 'pcied'))
+    spec = importlib.util.spec_from_file_location('pcied', os.path.join(scripts_path, 'pcied'), loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['pcied'] = module
+    spec.loader.exec_module(module)

--- a/sonic-pcied/tests/test_DaemonPcied.py
+++ b/sonic-pcied/tests/test_DaemonPcied.py
@@ -1,19 +1,6 @@
 import datetime
 import os
 import sys
-import importlib.util
-import importlib.machinery
-def load_source(module_name, module_path):
-    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
-    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
-    if module_name in sys.modules:
-        module = sys.modules[module_name]
-    else:
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
-
 import pytest
 
 # TODO: Clean this up once we no longer need to support Python 2
@@ -41,7 +28,6 @@ daemon_base.db_connect = mock.MagicMock()
 modules_path = os.path.dirname(tests_path)
 scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, modules_path)
-load_source('pcied', os.path.join(scripts_path, 'pcied'))
 import pcied
 
 pcie_no_aer_stats = \

--- a/sonic-pcied/tests/test_DaemonPcied.py
+++ b/sonic-pcied/tests/test_DaemonPcied.py
@@ -1,7 +1,18 @@
 import datetime
 import os
 import sys
-from imp import load_source  # Replace with importlib once we no longer need to support Python 2
+import importlib.util
+import importlib.machinery
+def load_source(module_name, module_path):
+    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
+    if module_name in sys.modules:
+        module = sys.modules[module_name]
+    else:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 import pytest
 

--- a/sonic-pcied/tests/test_pcied.py
+++ b/sonic-pcied/tests/test_pcied.py
@@ -1,6 +1,17 @@
 import os
 import sys
-from imp import load_source  # Replace with importlib once we no longer need to support Python 2
+import importlib.util
+import importlib.machinery
+def load_source(module_name, module_path):
+    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
+    if module_name in sys.modules:
+        module = sys.modules[module_name]
+    else:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 import pytest
 

--- a/sonic-pcied/tests/test_pcied.py
+++ b/sonic-pcied/tests/test_pcied.py
@@ -1,18 +1,5 @@
 import os
 import sys
-import importlib.util
-import importlib.machinery
-def load_source(module_name, module_path):
-    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
-    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
-    if module_name in sys.modules:
-        module = sys.modules[module_name]
-    else:
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
-
 import pytest
 
 # TODO: Clean this up once we no longer need to support Python 2
@@ -34,7 +21,6 @@ from sonic_py_common import daemon_base, device_info
 modules_path = os.path.dirname(tests_path)
 scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, modules_path)
-load_source('pcied', os.path.join(scripts_path, 'pcied'))
 import pcied
 
 

--- a/sonic-psud/tests/conftest.py
+++ b/sonic-psud/tests/conftest.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import importlib.util
+import importlib.machinery
+from unittest import mock
+
+tests_path = os.path.dirname(os.path.abspath(__file__))
+
+# Add mocked_libs path so that the file under test can load mocked modules from there
+mocked_libs_path = os.path.join(tests_path, "mocked_libs")
+sys.path.insert(0, mocked_libs_path)
+
+from sonic_py_common import daemon_base
+daemon_base.db_connect = mock.MagicMock()
+
+# Add path to the file under test so that we can load it
+modules_path = os.path.dirname(tests_path)
+scripts_path = os.path.join(modules_path, "scripts")
+sys.path.insert(0, modules_path)
+
+# Load psud once so all test files share the same module object and mocks apply correctly
+if 'psud' not in sys.modules:
+    loader = importlib.machinery.SourceFileLoader('psud', os.path.join(scripts_path, 'psud'))
+    spec = importlib.util.spec_from_file_location('psud', os.path.join(scripts_path, 'psud'), loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['psud'] = module
+    spec.loader.exec_module(module)

--- a/sonic-psud/tests/test_DaemonPsud.py
+++ b/sonic-psud/tests/test_DaemonPsud.py
@@ -1,7 +1,18 @@
 import datetime
 import os
 import sys
-from imp import load_source  # Replace with importlib once we no longer need to support Python 2
+import importlib.util
+import importlib.machinery
+def load_source(module_name, module_path):
+    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
+    if module_name in sys.modules:
+        module = sys.modules[module_name]
+    else:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 import pytest
 

--- a/sonic-psud/tests/test_DaemonPsud.py
+++ b/sonic-psud/tests/test_DaemonPsud.py
@@ -1,19 +1,6 @@
 import datetime
 import os
 import sys
-import importlib.util
-import importlib.machinery
-def load_source(module_name, module_path):
-    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
-    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
-    if module_name in sys.modules:
-        module = sys.modules[module_name]
-    else:
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
-
 import pytest
 
 # TODO: Clean this up once we no longer need to support Python 2
@@ -41,7 +28,6 @@ daemon_base.db_connect = mock.MagicMock()
 modules_path = os.path.dirname(tests_path)
 scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, modules_path)
-load_source('psud', os.path.join(scripts_path, 'psud'))
 import psud
 
 

--- a/sonic-psud/tests/test_PsuChassisInfo.py
+++ b/sonic-psud/tests/test_PsuChassisInfo.py
@@ -1,6 +1,17 @@
 import os
 import sys
-from imp import load_source  # Replace with importlib once we no longer need to support Python 2
+import importlib.util
+import importlib.machinery
+def load_source(module_name, module_path):
+    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
+    if module_name in sys.modules:
+        module = sys.modules[module_name]
+    else:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 import pytest
 

--- a/sonic-psud/tests/test_PsuChassisInfo.py
+++ b/sonic-psud/tests/test_PsuChassisInfo.py
@@ -43,7 +43,6 @@ import swsscommon as mock_swsscommon
 modules_path = os.path.dirname(tests_path)
 scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, modules_path)
-load_source('psud', os.path.join(scripts_path, 'psud'))
 import psud
 
 

--- a/sonic-psud/tests/test_PsuStatus.py
+++ b/sonic-psud/tests/test_PsuStatus.py
@@ -1,6 +1,17 @@
 import os
 import sys
-from imp import load_source  # Replace with importlib once we no longer need to support Python 2
+import importlib.util
+import importlib.machinery
+def load_source(module_name, module_path):
+    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
+    if module_name in sys.modules:
+        module = sys.modules[module_name]
+    else:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 # TODO: Clean this up once we no longer need to support Python 2
 if sys.version_info.major == 3:

--- a/sonic-psud/tests/test_PsuStatus.py
+++ b/sonic-psud/tests/test_PsuStatus.py
@@ -1,17 +1,5 @@
 import os
 import sys
-import importlib.util
-import importlib.machinery
-def load_source(module_name, module_path):
-    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
-    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
-    if module_name in sys.modules:
-        module = sys.modules[module_name]
-    else:
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
 
 # TODO: Clean this up once we no longer need to support Python 2
 if sys.version_info.major == 3:
@@ -31,7 +19,6 @@ sys.path.insert(0, mocked_libs_path)
 modules_path = os.path.dirname(tests_path)
 scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, modules_path)
-load_source('psud', os.path.join(scripts_path, 'psud'))
 import psud
 
 

--- a/sonic-psud/tests/test_psud.py
+++ b/sonic-psud/tests/test_psud.py
@@ -1,6 +1,17 @@
 import os
 import sys
-from imp import load_source  # Replace with importlib once we no longer need to support Python 2
+import importlib.util
+import importlib.machinery
+def load_source(module_name, module_path):
+    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
+    if module_name in sys.modules:
+        module = sys.modules[module_name]
+    else:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 import pytest
 

--- a/sonic-psud/tests/test_psud.py
+++ b/sonic-psud/tests/test_psud.py
@@ -1,18 +1,5 @@
 import os
 import sys
-import importlib.util
-import importlib.machinery
-def load_source(module_name, module_path):
-    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
-    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
-    if module_name in sys.modules:
-        module = sys.modules[module_name]
-    else:
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
-
 import pytest
 
 # TODO: Clean this up once we no longer need to support Python 2
@@ -34,7 +21,6 @@ sys.path.insert(0, mocked_libs_path)
 modules_path = os.path.dirname(tests_path)
 scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, modules_path)
-load_source('psud', os.path.join(scripts_path, 'psud'))
 import psud
 
 

--- a/sonic-sensormond/tests/test_sensormond.py
+++ b/sonic-sensormond/tests/test_sensormond.py
@@ -2,7 +2,18 @@ import os
 import sys
 import yaml
 import multiprocessing
-from imp import load_source
+import importlib.util
+import importlib.machinery
+def load_source(module_name, module_path):
+    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
+    if module_name in sys.modules:
+        module = sys.modules[module_name]
+    else:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 from unittest import mock
 import pytest
 from sonic_py_common import daemon_base

--- a/sonic-stormond/tests/test_DaemonStorage.py
+++ b/sonic-stormond/tests/test_DaemonStorage.py
@@ -3,7 +3,18 @@ import os
 import sys
 import runpy
 
-from imp import load_source, reload
+import importlib.util
+import importlib.machinery
+def load_source(module_name, module_path):
+    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
+    if module_name in sys.modules:
+        module = sys.modules[module_name]
+    else:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 from sonic_py_common import syslogger
 
 # TODO: Clean this up once we no longer need to support Python 2

--- a/sonic-syseepromd/tests/test_syseepromd.py
+++ b/sonic-syseepromd/tests/test_syseepromd.py
@@ -1,6 +1,17 @@
 import os
 import sys
-from imp import load_source  # Replace with importlib once we no longer need to support Python 2
+import importlib.util
+import importlib.machinery
+def load_source(module_name, module_path):
+    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
+    if module_name in sys.modules:
+        module = sys.modules[module_name]
+    else:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 import pytest
 

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -2,7 +2,18 @@ import os
 import sys
 import threading
 import time
-from imp import load_source  # TODO: Replace with importlib once we no longer need to support Python 2
+import importlib.util
+import importlib.machinery
+def load_source(module_name, module_path):
+    loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+    spec = importlib.util.spec_from_file_location(module_name, module_path, loader=loader)
+    if module_name in sys.modules:
+        module = sys.modules[module_name]
+    else:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 # TODO: Clean this up once we no longer need to support Python 2
 if sys.version_info.major == 3:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Replaced the deprecated imp.load_source function with the modern importlib.util and importlib.machinery modules across test files. A custom load_source function was implemented using importlib.machinery.SourceFileLoader and importlib.util.spec_from_file_location to maintain backward compatibility with the existing test code structure



#### Motivation and Context
The imp module was deprecated in Python 3.4 and completely removed in Python 3.12. Debian Trixie (the target distribution for the PMON container upgrade) uses Python 3.12 or later, which no longer supports the imp module. This change is required to ensure the test suite runs successfully on the upgraded PMON container.

  #### How Has This Been Tested?
The changes modify the test infrastructure itself. To verify these changes:

- Run the test suite for each affected daemon component (chassisd, ledd, pcied, psud, sensormond, stormond, syseepromd, thermalctld)
- Ensure all tests pass with the new importlib-based implementation
- Verify that the custom load_source function correctly handles module loading and caching via sys.modules
