### PR TITLE
[thermalctld] Remove SFP temperature polling

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -16,14 +16,9 @@ import time
 from datetime import datetime
 
 import sonic_platform
-from sonic_py_common import daemon_base, logger, device_info, multi_asic
+from sonic_py_common import daemon_base, logger
 from sonic_py_common.task_base import ThreadTaskBase
 from swsscommon import swsscommon
-
-try:
-    from sonic_platform_base.sonic_sfp.sfputilhelper import SfpUtilHelper
-except ImportError:
-    SfpUtilHelper = None
 
 
 # TODO: Once we no longer support Python 2, we can eliminate this and get the
@@ -35,9 +30,6 @@ SYSLOG_IDENTIFIER = 'thermalctld'
 NOT_AVAILABLE = 'N/A'
 CHASSIS_INFO_KEY = 'chassis 1'
 PHYSICAL_ENTITY_INFO_TABLE = 'PHYSICAL_ENTITY_INFO'
-TRANSCEIVER_DOM_TEMPERATURE_TABLE = 'TRANSCEIVER_DOM_TEMPERATURE'
-TRANSCEIVER_DOM_THRESHOLD_TABLE = 'TRANSCEIVER_DOM_THRESHOLD'
-TRANSCEIVER_DOM_SENSOR_TABLE = 'TRANSCEIVER_DOM_SENSOR'
 INVALID_SLOT_OR_DPU = -1
 PLATFORM_JSON_FILE = "/usr/share/sonic/platform/platform.json"
 
@@ -708,9 +700,6 @@ class TemperatureUpdater(logger.Logger):
         state_db = daemon_base.db_connect("STATE_DB")
         self.table = swsscommon.Table(state_db, TemperatureUpdater.TEMPER_INFO_TABLE_NAME)
         self.phy_entity_table = swsscommon.Table(state_db, PHYSICAL_ENTITY_INFO_TABLE)
-        self.xcvr_dom_temp_tbl = swsscommon.Table(state_db, TRANSCEIVER_DOM_TEMPERATURE_TABLE)
-        self.xcvr_dom_threshold_tbl = swsscommon.Table(state_db, TRANSCEIVER_DOM_THRESHOLD_TABLE)
-        self.xcvr_dom_sensor_tbl = swsscommon.Table(state_db, TRANSCEIVER_DOM_SENSOR_TABLE)
         self.chassis_table = None
         self.all_thermals = set()
 
@@ -720,9 +709,6 @@ class TemperatureUpdater(logger.Logger):
         self._default_interval = default_interval
         self._last_psu_thermal_update = 0
         self._last_thermal_update_times = {}
-
-        # Initialize SfpUtilHelper for port index to logical port name mapping
-        self.sfp_util = self._init_sfp_util_helper()
 
         self.is_chassis_system = chassis.is_modular_chassis()
         self.is_smartswitch_dpu = chassis.is_smartswitch() and chassis.is_dpu()
@@ -755,52 +741,6 @@ class TemperatureUpdater(logger.Logger):
                 if self.phy_entity_table:
                     if self.phy_entity_table.get(tk) is not None:
                         self.phy_entity_table._del(tk)
-
-    def _init_sfp_util_helper(self):
-        """
-        Initialize SfpUtilHelper and read port table mappings.
-        This provides the physical_to_logical mapping for SFP temperature lookup.
-
-        :return: SfpUtilHelper instance or None if initialization fails
-        """
-        if SfpUtilHelper is None:
-            self.log_warning("SfpUtilHelper not available, SFP temperature from Redis disabled")
-            return None
-
-        try:
-            sfp_util = SfpUtilHelper()
-            if multi_asic.is_multi_asic():
-                (_, hwsku_path) = device_info.get_paths_to_platform_and_hwsku_dirs()
-                sfp_util.read_all_porttab_mappings(hwsku_path, multi_asic.get_num_asics())
-            else:
-                port_config_file_path = device_info.get_path_to_port_config_file()
-                sfp_util.read_porttab_mappings(port_config_file_path, 0)
-            return sfp_util
-        except SystemExit:
-            self.log_warning("Failed to initialize SfpUtilHelper: port config not available")
-            return None
-        except Exception as e:
-            self.log_warning("Failed to initialize SfpUtilHelper: {}".format(e))
-            return None
-
-    def _get_port_name_by_index(self, sfp_index):
-        """
-        Get logical port name for a given SFP index (0-based).
-        Uses SfpUtilHelper.get_physical_to_logical() API.
-
-        :param sfp_index: SFP index (0-based)
-        :return: Logical port name or None if not found
-        """
-        if self.sfp_util is None:
-            return None
-
-        # SFP index is 0-based, but physical port index is 1-based
-        physical_index = sfp_index + 1
-        logical_ports = self.sfp_util.get_physical_to_logical(physical_index)
-        if logical_ports and len(logical_ports) > 0:
-            # Return the first logical port (for breakout, this is the primary port with DOM data)
-            return logical_ports[0]
-        return None
 
     def _log_on_status_changed(self, normal_status, normal_log, abnormal_log):
         """
@@ -846,35 +786,9 @@ class TemperatureUpdater(logger.Logger):
                 return False
             available_thermals.add((thermal, parent_name, thermal_index))
             name = try_get(thermal.get_name, '{} Thermal {}'.format(parent_name, thermal_index + 1))
-            # Always update entity info so PHYSICAL_ENTITY_INFO is populated
-            if 'SFP' not in parent_name:
-                update_entity_info(self.phy_entity_table, parent_name, name, thermal, thermal_index + 1)
+            update_entity_info(self.phy_entity_table, parent_name, name, thermal, thermal_index + 1)
             if refresh and self._should_update_thermal(name, now=now):
                 self._refresh_temperature_status(parent_name, thermal, thermal_index)
-        return True
-
-    def _collect_sfp_thermals(self, available_thermals, parent_name, sfp_index, thermals, now=None):
-        """
-        Process SFP thermals, reading temperature from Redis.
-        :param available_thermals: Set to track available thermals
-        :param parent_name: Name of the parent SFP
-        :param sfp_index: SFP index for port name lookup
-        :param thermals: Iterable of thermal objects from get_all_thermals()
-        :param now: Reference timestamp for this cycle
-        :return: False if task_stopping_event is set, True otherwise
-        """
-        # TODO: This Redis-based approach for reading SFP temperature is temporary.
-        # It will be removed once all platforms migrate to handling optics temperature
-        # outside of thermalctld (e.g., via xcvrd or platform-specific daemons).
-        port_name = self._get_port_name_by_index(sfp_index)
-        for thermal_index, thermal in enumerate(thermals):
-            if self.task_stopping_event.is_set():
-                return False
-            available_thermals.add((thermal, parent_name, thermal_index))
-            if port_name:
-                name = try_get(thermal.get_name, '{} Thermal {}'.format(parent_name, thermal_index + 1))
-                if self._should_update_thermal(name, now=now):
-                    self._refresh_temperature_status(parent_name, thermal, thermal_index, is_sfp=True, port_name=port_name)
         return True
 
     def update(self, now=None):
@@ -904,11 +818,6 @@ class TemperatureUpdater(logger.Logger):
         if should_update_psu:
             self._last_psu_thermal_update = now
 
-        for sfp_index, sfp in enumerate(self.chassis.get_all_sfps()):
-            if not self._collect_sfp_thermals(available_thermals, 'SFP {}'.format(sfp_index + 1),
-                                              sfp_index, sfp.get_all_thermals(), now=now):
-                return
-
         # As there are no modules present in DPU, this IF condition is not updated to consider DPU chassis
         if self.is_chassis_system:
             for module_index, module in enumerate(self.chassis.get_all_modules()):
@@ -916,11 +825,6 @@ class TemperatureUpdater(logger.Logger):
 
                 if not self._collect_thermals(available_thermals, module_name, module.get_all_thermals()):
                     return
-
-                for sfp_index, sfp in enumerate(module.get_all_sfps()):
-                    if not self._collect_sfp_thermals(available_thermals, '{} SFP {}'.format(module_name, sfp_index + 1),
-                                                      sfp_index, sfp.get_all_thermals(), now=now):
-                        return
 
                 for psu_index, psu in enumerate(module.get_all_psus()):
                     if psu.get_presence():
@@ -935,17 +839,13 @@ class TemperatureUpdater(logger.Logger):
 
         self.log_debug("End temperature updating")
 
-    def _refresh_temperature_status(self, parent_name, thermal, thermal_index, is_sfp=False, port_name=None):
+    def _refresh_temperature_status(self, parent_name, thermal, thermal_index):
         """
-        Get temperature status and write to database.
-        For regular thermals, reads from platform API.
-        For SFP thermals (is_sfp=True), reads from Redis tables populated by xcvrd.
+        Get temperature status from platform API and write to database.
 
         :param parent_name: Name of parent device of the thermal object
         :param thermal: Object representing a platform thermal zone
         :param thermal_index: Index of the thermal object in platform chassis
-        :param is_sfp: True if this is an SFP thermal reading from Redis
-        :param port_name: Port name for Redis lookup (required if is_sfp=True)
         :return:
         """
         try:
@@ -963,23 +863,15 @@ class TemperatureUpdater(logger.Logger):
             maximum_temperature = NOT_AVAILABLE
             minimum_temperature = NOT_AVAILABLE
 
-            if is_sfp:
-                # Read SFP temperature and thresholds from Redis
-                temperature = self._get_sfp_temperature_from_db(port_name)
-                is_replaceable = try_get(thermal.is_replaceable, True)
-                high_threshold, low_threshold, high_critical_threshold, low_critical_threshold = \
-                    self._get_sfp_thresholds_from_db(port_name)
-            else:
-                # Read from platform API
-                temperature = try_get(thermal.get_temperature)
-                is_replaceable = try_get(thermal.is_replaceable, False)
-                if temperature != NOT_AVAILABLE:
-                    minimum_temperature = try_get(thermal.get_minimum_recorded)
-                    maximum_temperature = try_get(thermal.get_maximum_recorded)
-                    high_threshold = try_get(thermal.get_high_threshold)
-                    low_threshold = try_get(thermal.get_low_threshold)
-                    high_critical_threshold = try_get(thermal.get_high_critical_threshold)
-                    low_critical_threshold = try_get(thermal.get_low_critical_threshold)
+            temperature = try_get(thermal.get_temperature)
+            is_replaceable = try_get(thermal.is_replaceable, False)
+            if temperature != NOT_AVAILABLE:
+                minimum_temperature = try_get(thermal.get_minimum_recorded)
+                maximum_temperature = try_get(thermal.get_maximum_recorded)
+                high_threshold = try_get(thermal.get_high_threshold)
+                low_threshold = try_get(thermal.get_low_threshold)
+                high_critical_threshold = try_get(thermal.get_high_critical_threshold)
+                low_critical_threshold = try_get(thermal.get_low_critical_threshold)
 
             warning = False
             if temperature != NOT_AVAILABLE:
@@ -1033,81 +925,6 @@ class TemperatureUpdater(logger.Logger):
                 self.chassis_table._del(name)
             except Exception:
                 pass
-
-    def _get_sfp_temperature_from_db(self, port_name):
-        """
-        Get SFP temperature from Redis. First tries TRANSCEIVER_DOM_TEMPERATURE table,
-        then falls back to TRANSCEIVER_DOM_SENSOR table. Both are populated by xcvrd daemon.
-
-        :param port_name: Port name (e.g., 'Ethernet0')
-        :return: Temperature value as float, or NOT_AVAILABLE if not found
-        """
-        # First try TRANSCEIVER_DOM_TEMPERATURE table
-        try:
-            status, fvs = self.xcvr_dom_temp_tbl.get(port_name)
-            if status:
-                for field, value in fvs:
-                    if field == 'temperature':
-                        if value and value != 'N/A' and value != 'N/A C':
-                            temp_str = value.split()[0] if ' ' in value else value
-                            return float(temp_str)
-        except Exception as e:
-            self.log_debug("Failed to get SFP temperature for {} from DOM_TEMPERATURE: {}".format(port_name, e))
-
-        # Fallback to TRANSCEIVER_DOM_SENSOR table
-        try:
-            status, fvs = self.xcvr_dom_sensor_tbl.get(port_name)
-            if status:
-                for field, value in fvs:
-                    if field == 'temperature':
-                        if value and value != 'N/A' and value != 'N/A C':
-                            temp_str = value.split()[0] if ' ' in value else value
-                            return float(temp_str)
-                        return NOT_AVAILABLE
-        except Exception as e:
-            self.log_debug("Failed to get SFP temperature for {} from DOM_SENSOR: {}".format(port_name, e))
-        return NOT_AVAILABLE
-
-    def _get_sfp_thresholds_from_db(self, port_name):
-        """
-        Get SFP temperature thresholds from Redis. First tries TRANSCEIVER_DOM_THRESHOLD table,
-        then falls back to TRANSCEIVER_DOM_SENSOR table.
-
-        :param port_name: Port name (e.g., 'Ethernet0')
-        :return: Tuple of (high_threshold, low_threshold, high_critical_threshold, low_critical_threshold)
-        """
-        high_threshold = NOT_AVAILABLE
-        low_threshold = NOT_AVAILABLE
-        high_critical_threshold = NOT_AVAILABLE
-        low_critical_threshold = NOT_AVAILABLE
-
-        fvs_dict = {}
-        try:
-            # First try TRANSCEIVER_DOM_THRESHOLD table
-            status, fvs = self.xcvr_dom_threshold_tbl.get(port_name)
-            if status:
-                fvs_dict = dict(fvs)
-            # Fallback to TRANSCEIVER_DOM_SENSOR table if no thresholds found
-            if not fvs_dict or 'temphighwarning' not in fvs_dict:
-                status, fvs = self.xcvr_dom_sensor_tbl.get(port_name)
-                if status:
-                    fvs_dict = dict(fvs)
-        except Exception as e:
-            self.log_debug("Failed to get SFP thresholds for {} from DB: {}".format(port_name, e))
-
-        try:
-            if 'temphighwarning' in fvs_dict and fvs_dict['temphighwarning'] not in ('N/A', ''):
-                high_threshold = float(fvs_dict['temphighwarning'].split()[0]) if ' ' in fvs_dict['temphighwarning'] else float(fvs_dict['temphighwarning'])
-            if 'templowwarning' in fvs_dict and fvs_dict['templowwarning'] not in ('N/A', ''):
-                low_threshold = float(fvs_dict['templowwarning'].split()[0]) if ' ' in fvs_dict['templowwarning'] else float(fvs_dict['templowwarning'])
-            if 'temphighalarm' in fvs_dict and fvs_dict['temphighalarm'] not in ('N/A', ''):
-                high_critical_threshold = float(fvs_dict['temphighalarm'].split()[0]) if ' ' in fvs_dict['temphighalarm'] else float(fvs_dict['temphighalarm'])
-            if 'templowalarm' in fvs_dict and fvs_dict['templowalarm'] not in ('N/A', ''):
-                low_critical_threshold = float(fvs_dict['templowalarm'].split()[0]) if ' ' in fvs_dict['templowalarm'] else float(fvs_dict['templowalarm'])
-        except Exception as e:
-            self.log_debug("Failed to parse SFP thresholds for {}: {}".format(port_name, e))
-
-        return high_threshold, low_threshold, high_critical_threshold, low_critical_threshold
 
 
 class ThermalMonitor(ThreadTaskBase):

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -23,13 +23,12 @@ import swsscommon
 assert len(swsscommon.__path__) == 1
 assert(os.path.samefile(swsscommon.__path__[0], os.path.join(mocked_libs_path, 'swsscommon')))
 
-from sonic_py_common import daemon_base, device_info
+from sonic_py_common import daemon_base
 
-from .mock_platform import MockChassis, MockFan, MockFanDrawer, MockModule, MockPsu, MockSfp, MockThermal
+from .mock_platform import MockChassis, MockFan, MockFanDrawer, MockModule, MockPsu, MockThermal
 from .mock_swsscommon import Table
 
 daemon_base.db_connect = mock.MagicMock()
-device_info.get_path_to_port_config_file = mock.MagicMock(return_value=None)
 
 # Add path to the file under test so that we can load it
 modules_path = os.path.dirname(tests_path)
@@ -824,35 +823,6 @@ class TestTemperatureUpdater(object):
         else:
             temperature_updater.log_warning.assert_called_with("Failed to update thermal status for PSU 1 Thermal 1 - Exception('Test message',)")
 
-    def test_update_sfp_thermals(self):
-        """Test SFP thermal processing with Redis-based temperature reading"""
-        chassis = MockChassis()
-        sfp = MockSfp()
-        mock_thermal = MockThermal()
-        sfp._thermal_list.append(mock_thermal)
-        chassis._sfp_list.append(sfp)
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-
-        # Reset warning count after init (init may log SfpUtilHelper warning)
-        temperature_updater.log_warning.reset_mock()
-
-        # With sfp_util as None (default), no Redis reading happens, no warnings
-        temperature_updater.update()
-        assert temperature_updater.log_warning.call_count == 0
-
-        # With sfp_util mocked and port_name available, Redis reading is attempted
-        temperature_updater.sfp_util = mock.MagicMock()
-        temperature_updater.sfp_util.get_physical_to_logical.return_value = ['Ethernet0']
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (True, [('temperature', '55.5')])
-        temperature_updater.xcvr_dom_threshold_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_threshold_tbl.get.return_value = (True, [])
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
-
-        temperature_updater.update()
-        # Verify Redis table was queried
-        temperature_updater.xcvr_dom_temp_tbl.get.assert_called_with('Ethernet0')
-
     def test_update_thermal_with_exception(self):
         chassis = MockChassis()
         chassis.make_error_thermal()
@@ -884,412 +854,13 @@ class TestTemperatureUpdater(object):
         chassis.set_modular_chassis(True)
         temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
         temperature_updater.update()
-        assert len(temperature_updater.all_thermals) == 3
+        # make_module_thermal adds 1 module thermal + 1 PSU thermal
+        # (SFP thermals are not polled by thermalctld)
+        assert len(temperature_updater.all_thermals) == 2
 
         chassis._module_list = []
         temperature_updater.update()
         assert len(temperature_updater.all_thermals) == 0
-
-    def test_sfp_temperature_from_redis(self):
-        """Test reading SFP temperature from Redis tables and verify TEMPERATURE_INFO is populated correctly"""
-        chassis = MockChassis()
-        sfp = MockSfp()
-        sfp._name = 'Ethernet0'
-        thermal = MockThermal()
-        thermal._name = 'xSFP module 1 Temp'
-        sfp._thermal_list.append(thermal)
-        chassis._sfp_list.append(sfp)
-
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-
-        # Mock the SfpUtilHelper to return correct port mapping
-        temperature_updater.sfp_util = mock.MagicMock()
-        temperature_updater.sfp_util.get_physical_to_logical.return_value = ['Ethernet0']
-
-        # Mock the Redis tables to return temperature data
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (True, [('temperature', '55.5')])
-
-        temperature_updater.xcvr_dom_threshold_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_threshold_tbl.get.return_value = (True, [
-            ('temphighwarning', '70.0'),
-            ('templowwarning', '-5.0'),
-            ('temphighalarm', '75.0'),
-            ('templowalarm', '-10.0')
-        ])
-
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
-
-        # Use a real Table object to capture the set() calls
-        temperature_updater.table = Table("STATE_DB", "TEMPERATURE_INFO")
-
-        temperature_updater.update()
-
-        # Verify temperature was read from Redis
-        temperature_updater.xcvr_dom_temp_tbl.get.assert_called_with('Ethernet0')
-        temperature_updater.xcvr_dom_threshold_tbl.get.assert_called_with('Ethernet0')
-
-        # Verify TEMPERATURE_INFO table was populated with correct values
-        assert 'xSFP module 1 Temp' in temperature_updater.table.mock_dict
-        stored_data = temperature_updater.table.mock_dict['xSFP module 1 Temp']
-
-        # Verify parsed temperature value
-        assert stored_data['temperature'] == '55.5'
-        # Verify parsed threshold values
-        assert stored_data['high_threshold'] == '70.0'
-        assert stored_data['low_threshold'] == '-5.0'
-        assert stored_data['critical_high_threshold'] == '75.0'
-        assert stored_data['critical_low_threshold'] == '-10.0'
-        # Verify warning status (should be False since 55.5 is within thresholds)
-        assert stored_data['warning_status'] == 'False'
-        # Verify other expected fields exist
-        assert 'minimum_temperature' in stored_data
-        assert 'maximum_temperature' in stored_data
-        assert 'is_replaceable' in stored_data
-        assert 'timestamp' in stored_data
-
-    def test_sfp_temperature_warning_status(self):
-        """Test that warning_status is True when temperature exceeds high threshold"""
-        chassis = MockChassis()
-        sfp = MockSfp()
-        thermal = MockThermal()
-        thermal._name = 'xSFP module 1 Temp'
-        sfp._thermal_list.append(thermal)
-        chassis._sfp_list.append(sfp)
-
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-        temperature_updater.sfp_util = mock.MagicMock()
-        temperature_updater.sfp_util.get_physical_to_logical.return_value = ['Ethernet0']
-
-        # Temperature exceeds high threshold (80 > 70)
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (True, [('temperature', '80.0')])
-
-        temperature_updater.xcvr_dom_threshold_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_threshold_tbl.get.return_value = (True, [
-            ('temphighwarning', '70.0'),
-            ('templowwarning', '-5.0')
-        ])
-
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
-        temperature_updater.table = Table("STATE_DB", "TEMPERATURE_INFO")
-
-        temperature_updater.update()
-
-        stored_data = temperature_updater.table.mock_dict['xSFP module 1 Temp']
-        assert stored_data['temperature'] == '80.0'
-        assert stored_data['warning_status'] == 'True'
-
-    def test_sfp_temperature_fallback_to_dom_sensor(self):
-        """Test fallback to TRANSCEIVER_DOM_SENSOR table when DOM_TEMPERATURE is not available"""
-        chassis = MockChassis()
-        sfp = MockSfp()
-        sfp._name = 'Ethernet0'
-        thermal = MockThermal()
-        thermal._name = 'xSFP module 1 Temp'
-        sfp._thermal_list.append(thermal)
-        chassis._sfp_list.append(sfp)
-
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-
-        # Mock the SfpUtilHelper
-        temperature_updater.sfp_util = mock.MagicMock()
-        temperature_updater.sfp_util.get_physical_to_logical.return_value = ['Ethernet0']
-
-        # Mock DOM_TEMPERATURE table to return no data
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (False, [])
-
-        # Mock DOM_THRESHOLD table to return no data
-        temperature_updater.xcvr_dom_threshold_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_threshold_tbl.get.return_value = (False, [])
-
-        # Mock DOM_SENSOR table to return temperature data (fallback)
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_sensor_tbl.get.return_value = (True, [
-            ('temperature', '60.0'),
-            ('temphighwarning', '75.0'),
-            ('templowwarning', '-5.0'),
-            ('temphighalarm', '80.0'),
-            ('templowalarm', '-10.0')
-        ])
-
-        # Use a real Table object to capture the set() calls
-        temperature_updater.table = Table("STATE_DB", "TEMPERATURE_INFO")
-
-        temperature_updater.update()
-
-        # Verify fallback to DOM_SENSOR table was called
-        temperature_updater.xcvr_dom_sensor_tbl.get.assert_called()
-
-        # Verify TEMPERATURE_INFO table was populated with fallback values
-        assert 'xSFP module 1 Temp' in temperature_updater.table.mock_dict
-        stored_data = temperature_updater.table.mock_dict['xSFP module 1 Temp']
-
-        # Verify temperature from DOM_SENSOR fallback
-        assert stored_data['temperature'] == '60.0'
-        # Verify thresholds from DOM_SENSOR fallback
-        assert stored_data['high_threshold'] == '75.0'
-        assert stored_data['low_threshold'] == '-5.0'
-        assert stored_data['critical_high_threshold'] == '80.0'
-        assert stored_data['critical_low_threshold'] == '-10.0'
-
-    def test_sfp_temperature_no_sfp_util(self):
-        """Test that SFP temperature is skipped when SfpUtilHelper is not available"""
-        chassis = MockChassis()
-        sfp = MockSfp()
-        sfp._thermal_list.append(MockThermal())
-        chassis._sfp_list.append(sfp)
-
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-
-        # Reset warning count after init (init may log SfpUtilHelper warning)
-        temperature_updater.log_warning.reset_mock()
-
-        # Set sfp_util to None (simulating import failure)
-        temperature_updater.sfp_util = None
-
-        # Should not raise exception
-        temperature_updater.update()
-        assert temperature_updater.log_warning.call_count == 0
-
-    def test_get_port_name_by_index(self):
-        """Test _get_port_name_by_index method"""
-        chassis = MockChassis()
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-
-        # Mock the SfpUtilHelper
-        temperature_updater.sfp_util = mock.MagicMock()
-        temperature_updater.sfp_util.get_physical_to_logical.return_value = ['Ethernet0', 'Ethernet1']
-
-        # Test getting port name for index 0 (physical index 1)
-        port_name = temperature_updater._get_port_name_by_index(0)
-        assert port_name == 'Ethernet0'
-        temperature_updater.sfp_util.get_physical_to_logical.assert_called_with(1)
-
-        # Test with no mapping found
-        temperature_updater.sfp_util.get_physical_to_logical.return_value = None
-        port_name = temperature_updater._get_port_name_by_index(5)
-        assert port_name is None
-
-        # Test with sfp_util not available
-        temperature_updater.sfp_util = None
-        port_name = temperature_updater._get_port_name_by_index(0)
-        assert port_name is None
-
-    def test_get_sfp_temperature_from_db(self):
-        """Test _get_sfp_temperature_from_db method"""
-        chassis = MockChassis()
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-
-        # Mock the Redis tables
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
-
-        # Test reading from DOM_TEMPERATURE table
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (True, [('temperature', '55.5')])
-        temp = temperature_updater._get_sfp_temperature_from_db('Ethernet0')
-        assert temp == 55.5
-
-        # Test fallback to DOM_SENSOR table
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (False, [])
-        temperature_updater.xcvr_dom_sensor_tbl.get.return_value = (True, [('temperature', '60.0')])
-        temp = temperature_updater._get_sfp_temperature_from_db('Ethernet0')
-        assert temp == 60.0
-
-        # Test with N/A value
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (True, [('temperature', 'N/A')])
-        temperature_updater.xcvr_dom_sensor_tbl.get.return_value = (False, [])
-        temp = temperature_updater._get_sfp_temperature_from_db('Ethernet0')
-        assert temp == thermalctld.NOT_AVAILABLE
-
-        # Test with temperature value containing unit suffix
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (True, [('temperature', '55.5 C')])
-        temp = temperature_updater._get_sfp_temperature_from_db('Ethernet0')
-        assert temp == 55.5
-
-    def test_sfp_temperature_na_value(self):
-        """Test that N/A temperature is stored correctly in TEMPERATURE_INFO"""
-        chassis = MockChassis()
-        sfp = MockSfp()
-        thermal = MockThermal()
-        thermal._name = 'xSFP module 1 Temp'
-        sfp._thermal_list.append(thermal)
-        chassis._sfp_list.append(sfp)
-
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-        temperature_updater.sfp_util = mock.MagicMock()
-        temperature_updater.sfp_util.get_physical_to_logical.return_value = ['Ethernet0']
-
-        # Return N/A temperature
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (True, [('temperature', 'N/A')])
-
-        temperature_updater.xcvr_dom_threshold_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_threshold_tbl.get.return_value = (False, [])
-
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_sensor_tbl.get.return_value = (False, [])
-
-        temperature_updater.table = Table("STATE_DB", "TEMPERATURE_INFO")
-
-        temperature_updater.update()
-
-        assert 'xSFP module 1 Temp' in temperature_updater.table.mock_dict
-        stored_data = temperature_updater.table.mock_dict['xSFP module 1 Temp']
-
-        # Verify N/A temperature is stored correctly
-        assert stored_data['temperature'] == 'N/A'
-        # Verify thresholds are also N/A when not available
-        assert stored_data['high_threshold'] == 'N/A'
-        assert stored_data['low_threshold'] == 'N/A'
-        # Warning status should be False when temperature is N/A
-        assert stored_data['warning_status'] == 'False'
-
-    def test_sfp_temperature_with_unit_suffix(self):
-        """Test parsing temperature values with unit suffix (e.g., '55.5 C')"""
-        chassis = MockChassis()
-        sfp = MockSfp()
-        thermal = MockThermal()
-        thermal._name = 'xSFP module 1 Temp'
-        sfp._thermal_list.append(thermal)
-        chassis._sfp_list.append(sfp)
-
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-        temperature_updater.sfp_util = mock.MagicMock()
-        temperature_updater.sfp_util.get_physical_to_logical.return_value = ['Ethernet0']
-
-        # Temperature with unit suffix
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (True, [('temperature', '55.5 C')])
-
-        # Thresholds with unit suffix
-        temperature_updater.xcvr_dom_threshold_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_threshold_tbl.get.return_value = (True, [
-            ('temphighwarning', '70.0 C'),
-            ('templowwarning', '-5.0 C'),
-            ('temphighalarm', '75.0 C'),
-            ('templowalarm', '-10.0 C')
-        ])
-
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
-        temperature_updater.table = Table("STATE_DB", "TEMPERATURE_INFO")
-
-        temperature_updater.update()
-
-        stored_data = temperature_updater.table.mock_dict['xSFP module 1 Temp']
-
-        # Verify unit suffix is stripped from values
-        assert stored_data['temperature'] == '55.5'
-        assert stored_data['high_threshold'] == '70.0'
-        assert stored_data['low_threshold'] == '-5.0'
-        assert stored_data['critical_high_threshold'] == '75.0'
-        assert stored_data['critical_low_threshold'] == '-10.0'
-
-    def test_init_sfp_util_helper_multi_asic(self):
-        """Test _init_sfp_util_helper with multi-asic configuration"""
-        chassis = MockChassis()
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-
-        with mock.patch.object(thermalctld, 'SfpUtilHelper') as mock_sfp_util_class, \
-             mock.patch.object(thermalctld.multi_asic, 'is_multi_asic', return_value=True), \
-             mock.patch.object(thermalctld.multi_asic, 'get_num_asics', return_value=2), \
-             mock.patch.object(thermalctld.device_info, 'get_paths_to_platform_and_hwsku_dirs', return_value=('/platform', '/hwsku')):
-            mock_sfp_util_instance = mock.MagicMock()
-            mock_sfp_util_class.return_value = mock_sfp_util_instance
-
-            result = temperature_updater._init_sfp_util_helper()
-
-            assert result is mock_sfp_util_instance
-            mock_sfp_util_instance.read_all_porttab_mappings.assert_called_once_with('/hwsku', 2)
-
-    def test_init_sfp_util_helper_system_exit(self):
-        """Test _init_sfp_util_helper handles SystemExit from read_porttab_mappings"""
-        chassis = MockChassis()
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-
-        with mock.patch.object(thermalctld, 'SfpUtilHelper') as mock_sfp_util_class, \
-             mock.patch.object(thermalctld.multi_asic, 'is_multi_asic', return_value=False), \
-             mock.patch.object(thermalctld.device_info, 'get_path_to_port_config_file', return_value='/path/to/port_config.ini'):
-            mock_sfp_util_instance = mock.MagicMock()
-            mock_sfp_util_instance.read_porttab_mappings.side_effect = SystemExit(1)
-            mock_sfp_util_class.return_value = mock_sfp_util_instance
-
-            result = temperature_updater._init_sfp_util_helper()
-
-            assert result is None
-            temperature_updater.log_warning.assert_called()
-
-    def test_init_sfp_util_helper_exception(self):
-        """Test _init_sfp_util_helper handles generic Exception"""
-        chassis = MockChassis()
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-
-        with mock.patch.object(thermalctld, 'SfpUtilHelper') as mock_sfp_util_class, \
-             mock.patch.object(thermalctld.multi_asic, 'is_multi_asic', return_value=False), \
-             mock.patch.object(thermalctld.device_info, 'get_path_to_port_config_file', return_value='/path/to/port_config.ini'):
-            mock_sfp_util_instance = mock.MagicMock()
-            mock_sfp_util_instance.read_porttab_mappings.side_effect = Exception("File not found")
-            mock_sfp_util_class.return_value = mock_sfp_util_instance
-
-            result = temperature_updater._init_sfp_util_helper()
-
-            assert result is None
-            temperature_updater.log_warning.assert_called()
-
-    def test_init_sfp_util_helper_not_available(self):
-        """Test _init_sfp_util_helper when SfpUtilHelper import failed"""
-        chassis = MockChassis()
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-
-        # Save original and set to None
-        original_sfp_util_helper = thermalctld.SfpUtilHelper
-        thermalctld.SfpUtilHelper = None
-
-        try:
-            result = temperature_updater._init_sfp_util_helper()
-            assert result is None
-            temperature_updater.log_warning.assert_called()
-        finally:
-            thermalctld.SfpUtilHelper = original_sfp_util_helper
-
-    def test_modular_chassis_sfp_thermals(self):
-        """Test SFP thermal updates on modular chassis with modules"""
-        chassis = MockChassis()
-        chassis.set_modular_chassis(True)
-        chassis.set_my_slot(1)
-
-        # Create a module with SFP
-        module = MockModule(1)
-        module._name = 'Module 1'
-        sfp = MockSfp()
-        thermal = MockThermal()
-        thermal._name = 'Module 1 xSFP module 1 Temp'
-        sfp._thermal_list.append(thermal)
-        module._sfp_list.append(sfp)
-        chassis._module_list.append(module)
-
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-        temperature_updater.sfp_util = mock.MagicMock()
-        temperature_updater.sfp_util.get_physical_to_logical.return_value = ['Ethernet0']
-
-        # Mock Redis tables
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (True, [('temperature', '45.0')])
-        temperature_updater.xcvr_dom_threshold_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_threshold_tbl.get.return_value = (True, [
-            ('temphighwarning', '70.0'),
-            ('templowwarning', '-5.0'),
-            ('temphighalarm', '75.0'),
-            ('templowalarm', '-10.0')
-        ])
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
-        temperature_updater.table = Table("STATE_DB", "TEMPERATURE_INFO")
-
-        temperature_updater.update()
-
-        # Verify module SFP thermal was updated
-        assert 'Module 1 xSFP module 1 Temp' in temperature_updater.table.mock_dict
 
     def test_remove_thermal_from_db_exceptions(self):
         """Test _remove_thermal_from_db handles exceptions gracefully"""
@@ -1312,53 +883,6 @@ class TestTemperatureUpdater(object):
 
         # Should not raise exception
         temperature_updater._remove_thermal_from_db(thermal, 'Test Parent', 0)
-
-    def test_get_sfp_temperature_from_db_exception_dom_temp(self):
-        """Test _get_sfp_temperature_from_db handles exception from DOM_TEMPERATURE table"""
-        chassis = MockChassis()
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_temp_tbl.get.side_effect = Exception("Redis error")
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_sensor_tbl.get.return_value = (True, [('temperature', '50.0')])
-
-        # Should fallback to DOM_SENSOR
-        temp = temperature_updater._get_sfp_temperature_from_db('Ethernet0')
-        assert temp == 50.0
-
-    def test_get_sfp_temperature_from_db_exception_dom_sensor(self):
-        """Test _get_sfp_temperature_from_db handles exception from DOM_SENSOR table"""
-        chassis = MockChassis()
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (False, [])
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_sensor_tbl.get.side_effect = Exception("Redis error")
-
-        temp = temperature_updater._get_sfp_temperature_from_db('Ethernet0')
-        assert temp == thermalctld.NOT_AVAILABLE
-
-    def test_get_sfp_thresholds_from_db_exception(self):
-        """Test _get_sfp_thresholds_from_db handles parsing exceptions"""
-        chassis = MockChassis()
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-
-        temperature_updater.xcvr_dom_threshold_tbl = mock.MagicMock()
-        # Return invalid threshold value that will cause float() to fail
-        temperature_updater.xcvr_dom_threshold_tbl.get.return_value = (True, [
-            ('temphighwarning', 'invalid_float'),
-        ])
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_sensor_tbl.get.return_value = (False, [])
-
-        # Should return N/A values without raising exception
-        high, low, high_crit, low_crit = temperature_updater._get_sfp_thresholds_from_db('Ethernet0')
-        assert high == thermalctld.NOT_AVAILABLE
-        assert low == thermalctld.NOT_AVAILABLE
-        assert high_crit == thermalctld.NOT_AVAILABLE
-        assert low_crit == thermalctld.NOT_AVAILABLE
 
     def test_collect_thermals_returns_true(self):
         """Test _collect_thermals returns True when processing completes normally"""
@@ -1387,47 +911,6 @@ class TestTemperatureUpdater(object):
         assert len(available) == 0
         assert temperature_updater._refresh_temperature_status.call_count == 0
 
-    def test_collect_sfp_thermals_returns_true(self):
-        """Test _collect_sfp_thermals returns True and calls _refresh_temperature_status with is_sfp=True"""
-        chassis = MockChassis()
-        thermal = MockThermal(1)
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-        temperature_updater._get_port_name_by_index = mock.MagicMock(return_value='Ethernet0')
-        temperature_updater._refresh_temperature_status = mock.MagicMock()
-        available = set()
-        result = temperature_updater._collect_sfp_thermals(available, 'SFP 1', 0, [thermal])
-        assert result is True
-        assert len(available) == 1
-        temperature_updater._refresh_temperature_status.assert_called_once_with(
-            'SFP 1', thermal, 0, is_sfp=True, port_name='Ethernet0')
-
-    def test_collect_sfp_thermals_stops_on_event(self):
-        """Test _collect_sfp_thermals returns False when task_stopping_event is set"""
-        chassis = MockChassis()
-        stopping_event = threading.Event()
-        stopping_event.set()
-        thermal = MockThermal(1)
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, stopping_event)
-        temperature_updater._refresh_temperature_status = mock.MagicMock()
-        available = set()
-        result = temperature_updater._collect_sfp_thermals(available, 'SFP 1', 0, [thermal])
-        assert result is False
-        assert len(available) == 0
-
-    def test_collect_sfp_thermals_no_port_name(self):
-        """Test _collect_sfp_thermals skips refresh when port_name is None"""
-        chassis = MockChassis()
-        thermal = MockThermal(1)
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-        temperature_updater._get_port_name_by_index = mock.MagicMock(return_value=None)
-        temperature_updater._refresh_temperature_status = mock.MagicMock()
-        available = set()
-        result = temperature_updater._collect_sfp_thermals(available, 'SFP 1', 0, [thermal])
-        assert result is True
-        assert len(available) == 1
-        # _refresh_temperature_status should NOT be called when port_name is None
-        assert temperature_updater._refresh_temperature_status.call_count == 0
-
     def test_update_stops_during_chassis_thermals(self):
         """Test update() returns early when _collect_thermals returns False for chassis thermals"""
         chassis = MockChassis()
@@ -1448,18 +931,6 @@ class TestTemperatureUpdater(object):
         temperature_updater._collect_thermals = mock.MagicMock(side_effect=[True, False])
         temperature_updater.update()
         assert temperature_updater._collect_thermals.call_count == 2
-
-    def test_update_stops_during_sfp_thermals(self):
-        """Test update() returns early when _collect_sfp_thermals returns False"""
-        chassis = MockChassis()
-        sfp = MockSfp()
-        sfp._thermal_list.append(MockThermal(1))
-        chassis._sfp_list.append(sfp)
-        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
-        temperature_updater._collect_thermals = mock.MagicMock(return_value=True)
-        temperature_updater._collect_sfp_thermals = mock.MagicMock(return_value=False)
-        temperature_updater.update()
-        assert temperature_updater._collect_sfp_thermals.call_count == 1
 
 
 # DPU chassis-related tests
@@ -2104,7 +1575,7 @@ class TestCollectFansEarlyReturn(object):
 
 
 class TestCollectThermalsEarlyReturn(object):
-    """Tests for TemperatureUpdater._collect_thermals() and _collect_sfp_thermals()"""
+    """Tests for TemperatureUpdater._collect_thermals()"""
 
     def test_collect_thermals_returns_false_on_stopping_event(self):
         chassis = MockChassis()
@@ -2127,33 +1598,3 @@ class TestCollectThermalsEarlyReturn(object):
         updater._refresh_temperature_status.assert_not_called()
         # Entity info should still be updated even without temperature refresh
         updater.phy_entity_table.set.assert_called()
-
-    def test_collect_sfp_thermals_returns_false_on_stopping_event(self):
-        chassis = MockChassis()
-        stopping_event = threading.Event()
-        stopping_event.set()
-        updater = thermalctld.TemperatureUpdater(chassis, stopping_event)
-        available = set()
-        result = updater._collect_sfp_thermals(available, 'SFP 1', 0, [MockThermal()])
-        assert result is False
-
-    def test_collect_sfp_thermals_throttled_by_default_interval(self):
-        chassis = MockChassis()
-        updater = thermalctld.TemperatureUpdater(
-            chassis, threading.Event(), default_interval=60)
-        updater._refresh_temperature_status = mock.MagicMock()
-        updater._get_port_name_by_index = mock.MagicMock(return_value='Ethernet0')
-        available = set()
-        now = time.time()
-
-        # First call — should refresh (last update time is 0)
-        result = updater._collect_sfp_thermals(available, 'SFP 1', 0, [MockThermal()], now=now)
-        assert result is True
-        assert updater._refresh_temperature_status.call_count == 1
-
-        updater._refresh_temperature_status.reset_mock()
-
-        # Second call immediately — should skip (60s not elapsed)
-        result = updater._collect_sfp_thermals(available, 'SFP 1', 0, [MockThermal()], now=now + 1)
-        assert result is True
-        assert updater._refresh_temperature_status.call_count == 0


### PR DESCRIPTION
#### Description
Remove SFP/transceiver temperature polling from thermalctld. SFP temperature reporting is owned by xcvrd and exposed via the `TRANSCEIVER_DOM_SENSOR`, `TANSCEIVER_DOM_TEMPERATURE` tables, so duplicating it in thermalctld is unnecessary.

Changes:
- Drop the chassis-level and per-module SFP enumeration loops in `TemperatureUpdater.update()`.
- Remove the now-unnecessary `'SFP' not in parent_name` guard around `PHYSICAL_ENTITY_INFO` updates in `_collect_thermals()`.
- Remove the SfpUtilHelper init, Redis-based SFP temperature/threshold readers, and `_collect_sfp_thermals()` helper.
- Update unit tests: drop SFP-specific tests and adjust the module thermal count expectation (no longer counts the SFP thermal).

Companion PR:
- sonic-net/sonic-utilities#4522 — `tempershow` reads SFP temperature directly from xcvrd-managed `TRANSCEIVER_DOM_TEMPERATURE` / `TRANSCEIVER_DOM_THRESHOLD` / `TRANSCEIVER_DOM_FLAG` tables instead of `TEMPERATURE_INFO`, so `show platform temperature` continues to display SFP modules after this change.

#### Motivation and Context
SFP/transceiver temperature was being read from Redis (`TRANSCEIVER_DOM_*` tables populated by xcvrd) inside thermalctld's update loop. On high-port-count platforms (e.g. 512 SFPs), this caused 3-5 Redis round-trips per SFP per cycle, which could delay fast-polling sensors (such as ASIC temperature) and added duplicate ownership of transceiver telemetry between xcvrd and thermalctld.

Other consumers of `TEMPERATURE_INFO` were reviewed and are unaffected:
- sonic-snmpagent `PhysicalSensorTableMIBUpdater` / `ThermalCacheUpdater` already filter out non-chassis thermals, and transceiver temperature is exposed via the dedicated `TRANSCEIVER_DOM_SENSOR` path (`update_xcvr_dom_data`).
- system-health `hardware_checker` only reads the `ASIC` entry.

#### How Has This Been Tested?
- `pytest sonic-thermalctld/tests/test_thermalctld.py` — all 89 tests pass.
- Verified on a chassis with SFPs: `TEMPERATURE_INFO` no longer contains SFP entries written by thermalctld, while xcvrd-owned `TRANSCEIVER_DOM_SENSOR` continues to report transceiver temperature unchanged, and `show platform temperature` (via the updated `tempershow` in sonic-net/sonic-utilities#4522) lists all SFP modules correctly.

#### Additional Information (Optional)
N/A
