### PR TITLE
[thermalctld] Fix SFP DOM to use per-ASIC STATE_DB on multi-ASIC

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -708,9 +708,16 @@ class TemperatureUpdater(logger.Logger):
         state_db = daemon_base.db_connect("STATE_DB")
         self.table = swsscommon.Table(state_db, TemperatureUpdater.TEMPER_INFO_TABLE_NAME)
         self.phy_entity_table = swsscommon.Table(state_db, PHYSICAL_ENTITY_INFO_TABLE)
-        self.xcvr_dom_temp_tbl = swsscommon.Table(state_db, TRANSCEIVER_DOM_TEMPERATURE_TABLE)
-        self.xcvr_dom_threshold_tbl = swsscommon.Table(state_db, TRANSCEIVER_DOM_THRESHOLD_TABLE)
-        self.xcvr_dom_sensor_tbl = swsscommon.Table(state_db, TRANSCEIVER_DOM_SENSOR_TABLE)
+        self.xcvr_dom_temp_tbl = {}
+        self.xcvr_dom_threshold_tbl = {}
+        self.xcvr_dom_sensor_tbl = {}
+        for namespace in multi_asic.get_front_end_namespaces():
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            ns_state_db = daemon_base.db_connect("STATE_DB", namespace)
+            self.xcvr_dom_temp_tbl[asic_id] = swsscommon.Table(ns_state_db, TRANSCEIVER_DOM_TEMPERATURE_TABLE)
+            self.xcvr_dom_threshold_tbl[asic_id] = swsscommon.Table(ns_state_db, TRANSCEIVER_DOM_THRESHOLD_TABLE)
+            self.xcvr_dom_sensor_tbl[asic_id] = swsscommon.Table(ns_state_db, TRANSCEIVER_DOM_SENSOR_TABLE)
+
         self.chassis_table = None
         self.all_thermals = set()
 
@@ -801,6 +808,20 @@ class TemperatureUpdater(logger.Logger):
             # Return the first logical port (for breakout, this is the primary port with DOM data)
             return logical_ports[0]
         return None
+
+    def _get_asic_id_for_port(self, port_name):
+        """
+        Get the ASIC index for a given logical port name.
+
+        :param port_name: Logical port name (e.g., 'Ethernet0')
+        :return: ASIC index (0 for single-ASIC, 0/1/... for multi-ASIC)
+        """
+        if self.sfp_util is None:
+            return 0
+        asic_id = self.sfp_util.get_asic_id_for_logical_port(port_name)
+        if asic_id is not None:
+            return int(asic_id)
+        return 0
 
     def _log_on_status_changed(self, normal_status, normal_log, abnormal_log):
         """
@@ -1042,9 +1063,13 @@ class TemperatureUpdater(logger.Logger):
         :param port_name: Port name (e.g., 'Ethernet0')
         :return: Temperature value as float, or NOT_AVAILABLE if not found
         """
+        asic_id = self._get_asic_id_for_port(port_name)
+        dom_temp_tbl = self.xcvr_dom_temp_tbl.get(asic_id)
+        dom_sensor_tbl = self.xcvr_dom_sensor_tbl.get(asic_id)
+
         # First try TRANSCEIVER_DOM_TEMPERATURE table
         try:
-            status, fvs = self.xcvr_dom_temp_tbl.get(port_name)
+            status, fvs = dom_temp_tbl.get(port_name)
             if status:
                 for field, value in fvs:
                     if field == 'temperature':
@@ -1056,7 +1081,7 @@ class TemperatureUpdater(logger.Logger):
 
         # Fallback to TRANSCEIVER_DOM_SENSOR table
         try:
-            status, fvs = self.xcvr_dom_sensor_tbl.get(port_name)
+            status, fvs = dom_sensor_tbl.get(port_name)
             if status:
                 for field, value in fvs:
                     if field == 'temperature':
@@ -1081,15 +1106,19 @@ class TemperatureUpdater(logger.Logger):
         high_critical_threshold = NOT_AVAILABLE
         low_critical_threshold = NOT_AVAILABLE
 
+        asic_id = self._get_asic_id_for_port(port_name)
+        dom_threshold_tbl = self.xcvr_dom_threshold_tbl.get(asic_id)
+        dom_sensor_tbl = self.xcvr_dom_sensor_tbl.get(asic_id)
+
         fvs_dict = {}
         try:
             # First try TRANSCEIVER_DOM_THRESHOLD table
-            status, fvs = self.xcvr_dom_threshold_tbl.get(port_name)
+            status, fvs = dom_threshold_tbl.get(port_name)
             if status:
                 fvs_dict = dict(fvs)
             # Fallback to TRANSCEIVER_DOM_SENSOR table if no thresholds found
             if not fvs_dict or 'temphighwarning' not in fvs_dict:
-                status, fvs = self.xcvr_dom_sensor_tbl.get(port_name)
+                status, fvs = dom_sensor_tbl.get(port_name)
                 if status:
                     fvs_dict = dict(fvs)
         except Exception as e:
@@ -1233,6 +1262,9 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
 
         # Set minimum logging level to INFO
         self.set_min_log_priority_info()
+
+        if multi_asic.is_multi_asic():
+            swsscommon.SonicDBConfig.initializeGlobalConfig()
 
         self.stop_event = threading.Event()
 

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -843,15 +843,17 @@ class TestTemperatureUpdater(object):
         # With sfp_util mocked and port_name available, Redis reading is attempted
         temperature_updater.sfp_util = mock.MagicMock()
         temperature_updater.sfp_util.get_physical_to_logical.return_value = ['Ethernet0']
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (True, [('temperature', '55.5')])
-        temperature_updater.xcvr_dom_threshold_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_threshold_tbl.get.return_value = (True, [])
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
+        temperature_updater.sfp_util.get_asic_id_for_logical_port.return_value = 0
+        mock_dom_temp_tbl = mock.MagicMock()
+        mock_dom_temp_tbl.get.return_value = (True, [('temperature', '55.5')])
+        temperature_updater.xcvr_dom_temp_tbl = {0: mock_dom_temp_tbl}
+        mock_dom_threshold_tbl = mock.MagicMock()
+        mock_dom_threshold_tbl.get.return_value = (True, [])
+        temperature_updater.xcvr_dom_threshold_tbl = {0: mock_dom_threshold_tbl}
+        temperature_updater.xcvr_dom_sensor_tbl = {0: mock.MagicMock()}
 
         temperature_updater.update()
-        # Verify Redis table was queried
-        temperature_updater.xcvr_dom_temp_tbl.get.assert_called_with('Ethernet0')
+        mock_dom_temp_tbl.get.assert_called_with('Ethernet0')
 
     def test_update_thermal_with_exception(self):
         chassis = MockChassis()
@@ -905,20 +907,23 @@ class TestTemperatureUpdater(object):
         # Mock the SfpUtilHelper to return correct port mapping
         temperature_updater.sfp_util = mock.MagicMock()
         temperature_updater.sfp_util.get_physical_to_logical.return_value = ['Ethernet0']
+        temperature_updater.sfp_util.get_asic_id_for_logical_port.return_value = 0
 
-        # Mock the Redis tables to return temperature data
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (True, [('temperature', '55.5')])
+        # Mock the per-ASIC Redis tables to return temperature data
+        mock_dom_temp_tbl = mock.MagicMock()
+        mock_dom_temp_tbl.get.return_value = (True, [('temperature', '55.5')])
+        temperature_updater.xcvr_dom_temp_tbl = {0: mock_dom_temp_tbl}
 
-        temperature_updater.xcvr_dom_threshold_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_threshold_tbl.get.return_value = (True, [
+        mock_dom_threshold_tbl = mock.MagicMock()
+        mock_dom_threshold_tbl.get.return_value = (True, [
             ('temphighwarning', '70.0'),
             ('templowwarning', '-5.0'),
             ('temphighalarm', '75.0'),
             ('templowalarm', '-10.0')
         ])
+        temperature_updater.xcvr_dom_threshold_tbl = {0: mock_dom_threshold_tbl}
 
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
+        temperature_updater.xcvr_dom_sensor_tbl = {0: mock.MagicMock()}
 
         # Use a real Table object to capture the set() calls
         temperature_updater.table = Table("STATE_DB", "TEMPERATURE_INFO")
@@ -926,8 +931,8 @@ class TestTemperatureUpdater(object):
         temperature_updater.update()
 
         # Verify temperature was read from Redis
-        temperature_updater.xcvr_dom_temp_tbl.get.assert_called_with('Ethernet0')
-        temperature_updater.xcvr_dom_threshold_tbl.get.assert_called_with('Ethernet0')
+        mock_dom_temp_tbl.get.assert_called_with('Ethernet0')
+        mock_dom_threshold_tbl.get.assert_called_with('Ethernet0')
 
         # Verify TEMPERATURE_INFO table was populated with correct values
         assert 'xSFP module 1 Temp' in temperature_updater.table.mock_dict
@@ -960,18 +965,21 @@ class TestTemperatureUpdater(object):
         temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
         temperature_updater.sfp_util = mock.MagicMock()
         temperature_updater.sfp_util.get_physical_to_logical.return_value = ['Ethernet0']
+        temperature_updater.sfp_util.get_asic_id_for_logical_port.return_value = 0
 
         # Temperature exceeds high threshold (80 > 70)
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (True, [('temperature', '80.0')])
+        mock_dom_temp_tbl = mock.MagicMock()
+        mock_dom_temp_tbl.get.return_value = (True, [('temperature', '80.0')])
+        temperature_updater.xcvr_dom_temp_tbl = {0: mock_dom_temp_tbl}
 
-        temperature_updater.xcvr_dom_threshold_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_threshold_tbl.get.return_value = (True, [
+        mock_dom_threshold_tbl = mock.MagicMock()
+        mock_dom_threshold_tbl.get.return_value = (True, [
             ('temphighwarning', '70.0'),
             ('templowwarning', '-5.0')
         ])
+        temperature_updater.xcvr_dom_threshold_tbl = {0: mock_dom_threshold_tbl}
 
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
+        temperature_updater.xcvr_dom_sensor_tbl = {0: mock.MagicMock()}
         temperature_updater.table = Table("STATE_DB", "TEMPERATURE_INFO")
 
         temperature_updater.update()
@@ -995,24 +1003,28 @@ class TestTemperatureUpdater(object):
         # Mock the SfpUtilHelper
         temperature_updater.sfp_util = mock.MagicMock()
         temperature_updater.sfp_util.get_physical_to_logical.return_value = ['Ethernet0']
+        temperature_updater.sfp_util.get_asic_id_for_logical_port.return_value = 0
 
         # Mock DOM_TEMPERATURE table to return no data
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (False, [])
+        mock_dom_temp_tbl = mock.MagicMock()
+        mock_dom_temp_tbl.get.return_value = (False, [])
+        temperature_updater.xcvr_dom_temp_tbl = {0: mock_dom_temp_tbl}
 
         # Mock DOM_THRESHOLD table to return no data
-        temperature_updater.xcvr_dom_threshold_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_threshold_tbl.get.return_value = (False, [])
+        mock_dom_threshold_tbl = mock.MagicMock()
+        mock_dom_threshold_tbl.get.return_value = (False, [])
+        temperature_updater.xcvr_dom_threshold_tbl = {0: mock_dom_threshold_tbl}
 
         # Mock DOM_SENSOR table to return temperature data (fallback)
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_sensor_tbl.get.return_value = (True, [
+        mock_dom_sensor_tbl = mock.MagicMock()
+        mock_dom_sensor_tbl.get.return_value = (True, [
             ('temperature', '60.0'),
             ('temphighwarning', '75.0'),
             ('templowwarning', '-5.0'),
             ('temphighalarm', '80.0'),
             ('templowalarm', '-10.0')
         ])
+        temperature_updater.xcvr_dom_sensor_tbl = {0: mock_dom_sensor_tbl}
 
         # Use a real Table object to capture the set() calls
         temperature_updater.table = Table("STATE_DB", "TEMPERATURE_INFO")
@@ -1020,7 +1032,7 @@ class TestTemperatureUpdater(object):
         temperature_updater.update()
 
         # Verify fallback to DOM_SENSOR table was called
-        temperature_updater.xcvr_dom_sensor_tbl.get.assert_called()
+        mock_dom_sensor_tbl.get.assert_called()
 
         # Verify TEMPERATURE_INFO table was populated with fallback values
         assert 'xSFP module 1 Temp' in temperature_updater.table.mock_dict
@@ -1082,31 +1094,61 @@ class TestTemperatureUpdater(object):
         chassis = MockChassis()
         temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
 
-        # Mock the Redis tables
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
+        # Mock the Redis tables keyed by asic_id (0 for single-ASIC)
+        mock_dom_temp_tbl = mock.MagicMock()
+        mock_dom_sensor_tbl = mock.MagicMock()
+        temperature_updater.xcvr_dom_temp_tbl = {0: mock_dom_temp_tbl}
+        temperature_updater.xcvr_dom_sensor_tbl = {0: mock_dom_sensor_tbl}
 
         # Test reading from DOM_TEMPERATURE table
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (True, [('temperature', '55.5')])
+        mock_dom_temp_tbl.get.return_value = (True, [('temperature', '55.5')])
         temp = temperature_updater._get_sfp_temperature_from_db('Ethernet0')
         assert temp == 55.5
 
         # Test fallback to DOM_SENSOR table
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (False, [])
-        temperature_updater.xcvr_dom_sensor_tbl.get.return_value = (True, [('temperature', '60.0')])
+        mock_dom_temp_tbl.get.return_value = (False, [])
+        mock_dom_sensor_tbl.get.return_value = (True, [('temperature', '60.0')])
         temp = temperature_updater._get_sfp_temperature_from_db('Ethernet0')
         assert temp == 60.0
 
         # Test with N/A value
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (True, [('temperature', 'N/A')])
-        temperature_updater.xcvr_dom_sensor_tbl.get.return_value = (False, [])
+        mock_dom_temp_tbl.get.return_value = (True, [('temperature', 'N/A')])
+        mock_dom_sensor_tbl.get.return_value = (False, [])
         temp = temperature_updater._get_sfp_temperature_from_db('Ethernet0')
         assert temp == thermalctld.NOT_AVAILABLE
 
         # Test with temperature value containing unit suffix
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (True, [('temperature', '55.5 C')])
+        mock_dom_temp_tbl.get.return_value = (True, [('temperature', '55.5 C')])
         temp = temperature_updater._get_sfp_temperature_from_db('Ethernet0')
         assert temp == 55.5
+
+    def test_get_sfp_temperature_from_db_multi_asic(self):
+        """Verify per-asic_id table lookup on multi-ASIC platforms."""
+        chassis = MockChassis()
+        temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
+        temperature_updater.sfp_util = mock.MagicMock()
+
+        # Set up two per-asic_id dom_temp tables with distinct values
+        mock_asic0_tbl = mock.MagicMock()
+        mock_asic0_tbl.get.return_value = (True, [('temperature', '40.0')])
+        mock_asic1_tbl = mock.MagicMock()
+        mock_asic1_tbl.get.return_value = (True, [('temperature', '70.0')])
+        temperature_updater.xcvr_dom_temp_tbl = {0: mock_asic0_tbl, 1: mock_asic1_tbl}
+        temperature_updater.xcvr_dom_sensor_tbl = {0: mock.MagicMock(), 1: mock.MagicMock()}
+
+        # Port resolves to asic1 -> asic1 table is queried, not asic0
+        temperature_updater.sfp_util.get_asic_id_for_logical_port.return_value = 1
+        assert temperature_updater._get_sfp_temperature_from_db('Ethernet64') == 70.0
+        mock_asic1_tbl.get.assert_called_with('Ethernet64')
+        mock_asic0_tbl.get.assert_not_called()
+
+        # Port resolves to asic0 -> asic0 table is queried
+        mock_asic0_tbl.get.reset_mock()
+        mock_asic1_tbl.get.reset_mock()
+        temperature_updater.sfp_util.get_asic_id_for_logical_port.return_value = 0
+        assert temperature_updater._get_sfp_temperature_from_db('Ethernet0') == 40.0
+        mock_asic0_tbl.get.assert_called_with('Ethernet0')
+        mock_asic1_tbl.get.assert_not_called()
 
     def test_sfp_temperature_na_value(self):
         """Test that N/A temperature is stored correctly in TEMPERATURE_INFO"""
@@ -1120,16 +1162,20 @@ class TestTemperatureUpdater(object):
         temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
         temperature_updater.sfp_util = mock.MagicMock()
         temperature_updater.sfp_util.get_physical_to_logical.return_value = ['Ethernet0']
+        temperature_updater.sfp_util.get_asic_id_for_logical_port.return_value = 0
 
         # Return N/A temperature
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (True, [('temperature', 'N/A')])
+        mock_dom_temp_tbl = mock.MagicMock()
+        mock_dom_temp_tbl.get.return_value = (True, [('temperature', 'N/A')])
+        temperature_updater.xcvr_dom_temp_tbl = {0: mock_dom_temp_tbl}
 
-        temperature_updater.xcvr_dom_threshold_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_threshold_tbl.get.return_value = (False, [])
+        mock_dom_threshold_tbl = mock.MagicMock()
+        mock_dom_threshold_tbl.get.return_value = (False, [])
+        temperature_updater.xcvr_dom_threshold_tbl = {0: mock_dom_threshold_tbl}
 
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_sensor_tbl.get.return_value = (False, [])
+        mock_dom_sensor_tbl = mock.MagicMock()
+        mock_dom_sensor_tbl.get.return_value = (False, [])
+        temperature_updater.xcvr_dom_sensor_tbl = {0: mock_dom_sensor_tbl}
 
         temperature_updater.table = Table("STATE_DB", "TEMPERATURE_INFO")
 
@@ -1158,21 +1204,24 @@ class TestTemperatureUpdater(object):
         temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
         temperature_updater.sfp_util = mock.MagicMock()
         temperature_updater.sfp_util.get_physical_to_logical.return_value = ['Ethernet0']
+        temperature_updater.sfp_util.get_asic_id_for_logical_port.return_value = 0
 
         # Temperature with unit suffix
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (True, [('temperature', '55.5 C')])
+        mock_dom_temp_tbl = mock.MagicMock()
+        mock_dom_temp_tbl.get.return_value = (True, [('temperature', '55.5 C')])
+        temperature_updater.xcvr_dom_temp_tbl = {0: mock_dom_temp_tbl}
 
         # Thresholds with unit suffix
-        temperature_updater.xcvr_dom_threshold_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_threshold_tbl.get.return_value = (True, [
+        mock_dom_threshold_tbl = mock.MagicMock()
+        mock_dom_threshold_tbl.get.return_value = (True, [
             ('temphighwarning', '70.0 C'),
             ('templowwarning', '-5.0 C'),
             ('temphighalarm', '75.0 C'),
             ('templowalarm', '-10.0 C')
         ])
+        temperature_updater.xcvr_dom_threshold_tbl = {0: mock_dom_threshold_tbl}
 
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
+        temperature_updater.xcvr_dom_sensor_tbl = {0: mock.MagicMock()}
         temperature_updater.table = Table("STATE_DB", "TEMPERATURE_INFO")
 
         temperature_updater.update()
@@ -1272,18 +1321,21 @@ class TestTemperatureUpdater(object):
         temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
         temperature_updater.sfp_util = mock.MagicMock()
         temperature_updater.sfp_util.get_physical_to_logical.return_value = ['Ethernet0']
+        temperature_updater.sfp_util.get_asic_id_for_logical_port.return_value = 0
 
-        # Mock Redis tables
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (True, [('temperature', '45.0')])
-        temperature_updater.xcvr_dom_threshold_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_threshold_tbl.get.return_value = (True, [
+        # Mock Redis tables keyed by asic_id (0 for single-ASIC)
+        mock_dom_temp_tbl = mock.MagicMock()
+        mock_dom_temp_tbl.get.return_value = (True, [('temperature', '45.0')])
+        temperature_updater.xcvr_dom_temp_tbl = {0: mock_dom_temp_tbl}
+        mock_dom_threshold_tbl = mock.MagicMock()
+        mock_dom_threshold_tbl.get.return_value = (True, [
             ('temphighwarning', '70.0'),
             ('templowwarning', '-5.0'),
             ('temphighalarm', '75.0'),
             ('templowalarm', '-10.0')
         ])
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
+        temperature_updater.xcvr_dom_threshold_tbl = {0: mock_dom_threshold_tbl}
+        temperature_updater.xcvr_dom_sensor_tbl = {0: mock.MagicMock()}
         temperature_updater.table = Table("STATE_DB", "TEMPERATURE_INFO")
 
         temperature_updater.update()
@@ -1318,10 +1370,12 @@ class TestTemperatureUpdater(object):
         chassis = MockChassis()
         temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
 
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_temp_tbl.get.side_effect = Exception("Redis error")
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_sensor_tbl.get.return_value = (True, [('temperature', '50.0')])
+        mock_dom_temp_tbl = mock.MagicMock()
+        mock_dom_temp_tbl.get.side_effect = Exception("Redis error")
+        temperature_updater.xcvr_dom_temp_tbl = {0: mock_dom_temp_tbl}
+        mock_dom_sensor_tbl = mock.MagicMock()
+        mock_dom_sensor_tbl.get.return_value = (True, [('temperature', '50.0')])
+        temperature_updater.xcvr_dom_sensor_tbl = {0: mock_dom_sensor_tbl}
 
         # Should fallback to DOM_SENSOR
         temp = temperature_updater._get_sfp_temperature_from_db('Ethernet0')
@@ -1332,10 +1386,12 @@ class TestTemperatureUpdater(object):
         chassis = MockChassis()
         temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
 
-        temperature_updater.xcvr_dom_temp_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_temp_tbl.get.return_value = (False, [])
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_sensor_tbl.get.side_effect = Exception("Redis error")
+        mock_dom_temp_tbl = mock.MagicMock()
+        mock_dom_temp_tbl.get.return_value = (False, [])
+        temperature_updater.xcvr_dom_temp_tbl = {0: mock_dom_temp_tbl}
+        mock_dom_sensor_tbl = mock.MagicMock()
+        mock_dom_sensor_tbl.get.side_effect = Exception("Redis error")
+        temperature_updater.xcvr_dom_sensor_tbl = {0: mock_dom_sensor_tbl}
 
         temp = temperature_updater._get_sfp_temperature_from_db('Ethernet0')
         assert temp == thermalctld.NOT_AVAILABLE
@@ -1345,13 +1401,14 @@ class TestTemperatureUpdater(object):
         chassis = MockChassis()
         temperature_updater = thermalctld.TemperatureUpdater(chassis, threading.Event())
 
-        temperature_updater.xcvr_dom_threshold_tbl = mock.MagicMock()
-        # Return invalid threshold value that will cause float() to fail
-        temperature_updater.xcvr_dom_threshold_tbl.get.return_value = (True, [
+        mock_dom_threshold_tbl = mock.MagicMock()
+        mock_dom_threshold_tbl.get.return_value = (True, [
             ('temphighwarning', 'invalid_float'),
         ])
-        temperature_updater.xcvr_dom_sensor_tbl = mock.MagicMock()
-        temperature_updater.xcvr_dom_sensor_tbl.get.return_value = (False, [])
+        temperature_updater.xcvr_dom_threshold_tbl = {0: mock_dom_threshold_tbl}
+        mock_dom_sensor_tbl = mock.MagicMock()
+        mock_dom_sensor_tbl.get.return_value = (False, [])
+        temperature_updater.xcvr_dom_sensor_tbl = {0: mock_dom_sensor_tbl}
 
         # Should return N/A values without raising exception
         high, low, high_crit, low_crit = temperature_updater._get_sfp_thresholds_from_db('Ethernet0')


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

#### Description
thermalctld now reads SFP DOM tables (temperature, thresholds, sensor) from the
correct STATE_DB based on platform type: host namespace on single-ASIC (unchanged),
per-ASIC namespace on multi-ASIC. Table dictionaries are keyed by asic_id (integer),
matching the xcvrd/ycabled pattern.
#### Motivation and Context
thermalctld reads SFP temperature and thresholds from STATE_DB tables populated
by xcvrd. On multi-ASIC platforms these tables reside in per-ASIC namespace
databases. This change ensures thermalctld connects to the correct STATE_DB
for each ASIC, while preserving existing single-ASIC behavior.
#### How Has This Been Tested?
Tested on single-asic and multi-asic platforms

#### Additional Information (Optional)
