### PR TITLE
Deinit all lanes when module is ModuleLowPwr

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -3389,6 +3389,7 @@ class TestXcvrdScript(object):
         task.port_dict['Ethernet0']['appl'] = 2
         task.port_dict['Ethernet0']['host_lanes_mask'] = 0x0f       # breakout subport: 4 of 8 lanes
         task.port_dict['Ethernet0']['max_host_lanes_mask'] = 0xff   # QSFP-DD: all 8 lanes
+        task.port_dict['Ethernet0']['max_media_lanes_mask'] = 0xff
         task.port_dict['Ethernet0']['media_lanes_mask'] = 0x0f
 
         task.process_single_lport('Ethernet0', task.port_dict['Ethernet0'])

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -3346,6 +3346,57 @@ class TestXcvrdScript(object):
         # Verify we moved to DP_DEINIT state (the state machine continues despite tx power config failure)
         assert common.get_cmis_state_from_state_db('Ethernet0', mock_get_status_sw_tbl) == CMIS_STATE_DP_DEINIT
 
+    @patch('xcvrd.xcvrd.XcvrTableHelper.get_status_sw_tbl')
+    @patch('xcvrd.xcvrd.platform_chassis')
+    @patch('xcvrd.xcvrd_utilities.common.is_fast_reboot_enabled', MagicMock(return_value=False))
+    def test_CmisManagerTask_dp_deinit_low_pwr_deinits_and_disables_all_lanes(self, mock_chassis, mock_get_status_sw_tbl):
+        """In ModuleLowPwr (first power-up), set_datapath_deinit must use max_host_lanes_mask, not the
+        breakout subport's host_lanes_mask, because DPDeinitLanes is 0x00 after module reset. Similarly, we
+        should disable all tx output since OutputDisableTx = 0x0 after module reset."""
+        mock_get_status_sw_tbl = Table("STATE_DB", TRANSCEIVER_STATUS_SW_TABLE)
+
+        mock_xcvr_api = MagicMock()
+        mock_xcvr_api.is_flat_memory = MagicMock(return_value=False)
+        mock_xcvr_api.is_coherent_module = MagicMock(return_value=False)
+        mock_xcvr_api.get_module_type_abbreviation = MagicMock(return_value='QSFP-DD')
+        mock_xcvr_api.get_module_state = MagicMock(return_value='ModuleLowPwr')
+        mock_xcvr_api.tx_disable_channel = MagicMock(return_value=True)
+        mock_xcvr_api.set_lpmode = MagicMock(return_value=True)
+        mock_xcvr_api.get_datapath_deinit_duration = MagicMock(return_value=0)
+        mock_xcvr_api.get_module_pwr_up_duration = MagicMock(return_value=0)
+
+        mock_sfp = MagicMock()
+        mock_sfp.get_presence = MagicMock(return_value=True)
+        mock_sfp.get_xcvr_api = MagicMock(return_value=mock_xcvr_api)
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+
+        port_mapping = PortMapping()
+        port_mapping.handle_port_change_event(PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD))
+        stop_event = threading.Event()
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event, platform_chassis=mock_chassis)
+        task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
+        task.xcvr_table_helper.get_status_sw_tbl.return_value = mock_get_status_sw_tbl
+
+        # Simulate a 2x200G breakout: subport 1 owns lanes 1-4 (host_lanes_mask=0x0f, media_lanes_mask=0x0f)
+        port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_SET,
+                                            {'speed': '200000', 'lanes': '1,2,3,4', 'subport': '1'})
+        task.on_port_update_event(port_change_event)
+
+        # Jump straight to DP_DEINIT with pre-computed masks
+        task.update_port_transceiver_status_table_sw_cmis_state('Ethernet0', CMIS_STATE_DP_DEINIT)
+        task.port_dict['Ethernet0']['host_tx_ready'] = 'true'
+        task.port_dict['Ethernet0']['admin_status'] = 'up'
+        task.port_dict['Ethernet0']['appl'] = 2
+        task.port_dict['Ethernet0']['host_lanes_mask'] = 0x0f       # breakout subport: 4 of 8 lanes
+        task.port_dict['Ethernet0']['max_host_lanes_mask'] = 0xff   # QSFP-DD: all 8 lanes
+        task.port_dict['Ethernet0']['media_lanes_mask'] = 0x0f
+
+        task.process_single_lport('Ethernet0', task.port_dict['Ethernet0'])
+
+        # Must ensure the DPDeinitLanes and OutputDisableTx registers are set
+        mock_xcvr_api.set_datapath_deinit.assert_called_once_with(0xff)
+        mock_xcvr_api.tx_disable_channel.assert_called_once_with(0xff, True)
+
     @patch('xcvrd.xcvrd.platform_chassis')
     @patch('xcvrd.xcvrd_utilities.common.is_fast_reboot_enabled', MagicMock(return_value=(False)))
     @patch('xcvrd.cmis.cmis_manager_task.PortChangeObserver', MagicMock(handle_port_update_event=MagicMock()))

--- a/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
+++ b/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
@@ -888,6 +888,7 @@ class CmisManagerTask(threading.Thread):
         self.port_dict[lport]['media_lane_assignment_options'] = int(api.get_media_lane_assignment_option(appl))
         media_lane_count = self.port_dict[lport]['media_lane_count']
         media_lane_assignment_options = self.port_dict[lport]['media_lane_assignment_options']
+        self.port_dict[lport]['max_media_lanes_mask'] = self.port_dict[lport]['max_host_lanes_mask']
         self.port_dict[lport]['media_lanes_mask'] = self.get_cmis_media_lanes_mask(api,
                                                         appl, lport, subport)
         if self.port_dict[lport]['media_lanes_mask'] <= 0:
@@ -906,9 +907,9 @@ class CmisManagerTask(threading.Thread):
             # Set all the DP lanes AppSel to unused(0) when non default app code needs to be configured
             self.port_dict[lport]['appl'] = appl = 0
             self.port_dict[lport]['host_lanes_mask'] = self.port_dict[lport]['max_host_lanes_mask']
-            self.port_dict[lport]['media_lanes_mask'] = self.port_dict[lport]['max_host_lanes_mask']
+            self.port_dict[lport]['media_lanes_mask'] = self.port_dict[lport]['max_media_lanes_mask']
             self.log_notice("{}: DECOMMISSION: setting appl={} and "
-                            "host_lanes_mask/media_lanes_mask={:#x}".format(lport, appl, self.port_dict[lport]['max_host_lanes_mask']))
+                            "host_lanes_mask={:#x},media_lanes_mask={:#x}".format(lport, appl, self.port_dict[lport]['max_host_lanes_mask'], self.port_dict[lport]['max_media_lanes_mask']))
             # Skip rest of the deinit/pre-init when this is the lead logical port for decommission
             self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_DP_DEINIT)
             return False
@@ -1028,19 +1029,21 @@ class CmisManagerTask(threading.Thread):
         port_info = self.port_dict[lport]
         api = port_info.get('api')
         retries = port_info.get('cmis_retries', 0)
-        host_lanes_mask = port_info.get('host_lanes_mask', 0)
-        media_lanes_mask = port_info['media_lanes_mask']
+        deinit_host_lanes_mask = port_info.get('host_lanes_mask', 0)
+        disable_media_lanes_mask = port_info['media_lanes_mask']
+        # Deinit and disable all lanes if we are in ModuleLowPwr to avoid unintentional 
+        # initialization of other datapaths during transition to ModuleReady 
         if self.check_module_state(api, ['ModuleLowPwr']):
             self.log_notice("{}: deinit all datapaths and disable all Tx output for first module power up".format(lport))
-            host_lanes_mask = self.port_dict[lport]['max_host_lanes_mask']
-            media_lanes_mask = self.port_dict[lport]['max_host_lanes_mask']
+            deinit_host_lanes_mask = self.port_dict[lport]['max_host_lanes_mask']
+            disable_media_lanes_mask = self.port_dict[lport]['max_media_lanes_mask']
 
         # D.2.2 Software Deinitialization
-        api.set_datapath_deinit(host_lanes_mask)
+        api.set_datapath_deinit(deinit_host_lanes_mask)
 
         # D.1.3 Software Configuration and Initialization
-        if not api.tx_disable_channel(media_lanes_mask, True):
-            self.log_notice("{}: unable to turn off tx power with host_lanes_mask {} media_lanes_mask {}".format(lport, host_lanes_mask, media_lanes_mask))
+        if not api.tx_disable_channel(disable_media_lanes_mask, True):
+            self.log_notice("{}: unable to turn off tx power with host_lanes_mask {} media_lanes_mask {}".format(lport, deinit_host_lanes_mask, disable_media_lanes_mask))
             self.port_dict[lport]['cmis_retries'] = retries + 1
             return False
 

--- a/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
+++ b/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
@@ -1027,16 +1027,20 @@ class CmisManagerTask(threading.Thread):
         """
         port_info = self.port_dict[lport]
         api = port_info.get('api')
+        retries = port_info.get('cmis_retries', 0)
         host_lanes_mask = port_info.get('host_lanes_mask', 0)
         media_lanes_mask = port_info['media_lanes_mask']
-        retries = port_info.get('cmis_retries', 0)
+        if self.check_module_state(api, ['ModuleLowPwr']):
+            self.log_notice("{}: deinit all datapaths and disable all Tx output for first module power up".format(lport))
+            host_lanes_mask = self.port_dict[lport]['max_host_lanes_mask']
+            media_lanes_mask = self.port_dict[lport]['max_host_lanes_mask']
 
         # D.2.2 Software Deinitialization
         api.set_datapath_deinit(host_lanes_mask)
 
         # D.1.3 Software Configuration and Initialization
         if not api.tx_disable_channel(media_lanes_mask, True):
-            self.log_notice("{}: unable to turn off tx power with host_lanes_mask {}".format(lport, host_lanes_mask))
+            self.log_notice("{}: unable to turn off tx power with host_lanes_mask {} media_lanes_mask {}".format(lport, host_lanes_mask, media_lanes_mask))
             self.port_dict[lport]['cmis_retries'] = retries + 1
             return False
 

--- a/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
+++ b/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
@@ -1034,7 +1034,7 @@ class CmisManagerTask(threading.Thread):
         # Deinit and disable all lanes if we are in ModuleLowPwr to avoid unintentional 
         # initialization of other datapaths during transition to ModuleReady 
         if self.check_module_state(api, ['ModuleLowPwr']):
-            self.log_notice("{}: deinit all datapaths and disable all Tx output for first module power up".format(lport))
+            self.log_notice("{}: ModuleLowPwr detected, set datapath deinit and disable Tx output for all lanes".format(lport))
             deinit_host_lanes_mask = self.port_dict[lport]['max_host_lanes_mask']
             disable_media_lanes_mask = self.port_dict[lport]['max_media_lanes_mask']
 


### PR DESCRIPTION
# Deinit all lanes when module is ModuleLowPwr

#### Description
This is a small change to conditionally set `DPDeinitLane` for all datapaths if the module is in `ModuleLowPwr` during `CMIS_STATE_DP_DEINIT`. 

#### Motivation and Context
This change addresses CMIS failures (fixes #810) where DPSMs for a subinterface in a breakout configuration would be unintentionally transitioned to `DPInit` during the bringup of the sibling subinterface on the same module. This would cause a timeout and `CMIS_FAILED` for the bringup of the second subinterface, given that the second subinterface bringup was initiated within a certain timing window where MSM = `ModuleReady`, DPSM = `DPInit`. 

Here we can see logs where the first subinterface sets the DPSMs for the second subinterface to `DPInit`:
```
2026 Apr 22 17:53:31.381270 gold206 NOTICE pmon#CmisManagerTask[40]: Ethernet316: 400G, lanemask=0xf0, CMIS state=AP_CONFIGURED, Module state=ModulePwrUp, DP state={'DP1State': 'DataPathDeactivated', 'DP2State': 'DataPathDeactivated', 'DP3State': 'DataPathDeactivated', 'DP4State': 'DataPathDeactivated', 'DP5State': 'DataPathDeactivated', 'DP6State': 'DataPathDeactivated', 'DP7State': 'DataPathDeactivated', 'DP8State': 'DataPathDeactivated'}, appl 1 host_lane_count 4 retries=0
2026 Apr 22 17:53:31.452014 gold206 NOTICE pmon#CmisManagerTask[40]: Ethernet316: 400G, lanemask=0xf0, CMIS state=AP_CONFIGURED, Module state=ModuleReady, DP state={'DP1State': 'DataPathInit', 'DP2State': 'DataPathInit', 'DP3State': 'DataPathInit', 'DP4State': 'DataPathInit', 'DP5State': 'DataPathDeactivated', 'DP6State': 'DataPathDeactivated', 'DP7State': 'DataPathDeactivated', 'DP8State': 'DataPathDeactivated'}, appl 1 host_lane_count 4 retries=0
```
Note that `lanemask=0xf0` but we have transitioned the DPSMs to `DPInit` for `lanemask=0x0f`.

During the bringup of the second (chronological) subinterface (`Ethernet312`), the laser would be disabled due to `host_tx_ready = 'false'`:
```
2026 Apr 22 17:53:32.047504 gold206 NOTICE swss#orchagent: :- doPortTask: Set port Ethernet312 admin status to up
2026 Apr 22 17:53:32.047710 gold206 NOTICE pmon#xcvrd[40]: SFF-PORT-UPDATE: *** ('Ethernet312', 'STATE_DB', 'PORT_TABLE') handle_port_update_event() fvp {'host_tx_ready': 'true', 'index': '-1', 'port_name': 'Ethernet312', 'asic_id': 0, 'op': 'SET'}
2026 Apr 22 17:53:32.059564 gold206 NOTICE pmon#CmisManagerTask[40]: Ethernet312: 400G, lanemask=0xf, CMIS state=INSERTED, Module state=ModuleReady, DP state={'DP1State': 'DataPathInit', 'DP2State': 'DataPathInit', 'DP3State': 'DataPathInit', 'DP4State': 'DataPathInit', 'DP5State': 'DataPathInit', 'DP6State': 'DataPathInit', 'DP7State': 'DataPathInit', 'DP8State': 'DataPathInit'}, appl 1 host_lane_count 4 retries=0
2026 Apr 22 17:53:32.059564 gold206 NOTICE pmon#CmisManagerTask[40]: Ethernet312: Setting appl=1
2026 Apr 22 17:53:32.059702 gold206 NOTICE pmon#CmisManagerTask[40]: Ethernet312: Setting host_lanemask=0xf
2026 Apr 22 17:53:32.059702 gold206 NOTICE pmon#CmisManagerTask[40]: Ethernet312: Setting media_lanemask=0xf
2026 Apr 22 17:53:32.065851 gold206 NOTICE pmon#CmisManagerTask[40]: Ethernet312 Forcing Tx laser OFF
2026 Apr 22 17:53:32.067324 gold206 NOTICE pmon#CmisManagerTask[40]: Ethernet312: Tx turn off duration 1.0 secs
2026 Apr 22 17:53:32.067685 gold206 NOTICE pmon#CmisManagerTask[40]: Ethernet312: updated TRANSCEIVER_INFO_TABLE [('active_apsel_hostlane1', 'N/A'), ('active_apsel_hostlane2', 'N/A'), ('active_apsel_hostlane3', 'N/A'), ('active_apsel_hostlane4', 'N/A'), ('active_apsel_hostlane5', 'N/A'), ('active_apsel_hostlane6', 'N/A'), ('active_apsel_hostlane7', 'N/A'), ('active_apsel_hostlane8', 'N/A'), ('host_lane_count', 'N/A'), ('media_lane_count', 'N/A')]
2026 Apr 22 17:53:32.121494 gold206 NOTICE pmon#CmisManagerTask[40]: *** ('Ethernet312', 'STATE_DB', 'PORT_TABLE') handle_port_update_event() fvp {'host_tx_ready': 'true', 'index': '-1', 'port_name': 'Ethernet312', 'asic_id': 0, 'op': 'SET'}
2026 Apr 22 17:53:32.130960 gold206 NOTICE pmon#CmisManagerTask[40]: Ethernet312: 400G, lanemask=0xf, CMIS state=INSERTED, Module state=ModuleReady, DP state={'DP1State': 'DataPathInit', 'DP2State': 'DataPathInit', 'DP3State': 'DataPathInit', 'DP4State': 'DataPathInit', 'DP5State': 'DataPathInit', 'DP6State': 'DataPathInit', 'DP7State': 'DataPathInit', 'DP8State': 'DataPathInit'}, appl 1 host_lane_count 4 retries=0
```

Then, it would repeatedly time out and eventually fail in `CMIS_STATE_DP_PREINIT_CHECK` because the DPSMs were stuck in `DPInit`:
```
2026 Apr 23 16:47:30.778520 gold206 NOTICE pmon#CmisManagerTask[40]: Ethernet312: timeout for 'DataPathDeactivated/DataPathInitialized'
```

This situation only occurred when the module had been reset to its defaults, which are `ModuleLowPwr` and `DPDeinitLane = 00h`, and when the default appsel for the module was a breakout configuration that matched the desired configuration in CONFIG_DB. Modules that do not meet this criteria go into decommission instead.

It's a fairly specific scenario that we only reproduced on the FINISAR FTCE4717E2PCB which has a breakout configuration for default appsel that matches the HWSKU we were testing with. However, it has exposed this correctness issue within xcvrd, since the CMIS spec states:

> The Host shall provide a valid high-speed Tx input signal at the required signaling rate and encoding type prior to causing a DPSM to exit the DPDeactivated state.

Here are some other relevants snippets from the spec:

> The direct effect control settings for muting a lane output, may remain temporarily ineffective as per Data Path
State Machine specifications (e.g. clearing OutputDisableTx has no immediate effect in DPSM state DPInit).

> Note: By default, all Data Paths will begin initializing when the Module State reaches ModuleReady. The host can prevent this auto-initialization behavior by setting all DPDeinit bits while the module is in the ModuleLowPwr state.

This change also sets all lanes of `OutputDisableTx` when the module state is in `ModuleLowPwr` during `CMIS_STATE_DP_DEINIT`. This is also suggested in the CMIS spec in the example for software initialization:
>Host writes FFh to the DPDeinit register to prevent automatic Data Path initialization when the module reaches ModuleReady, and writes FFh into the OutputDisableTx register to prevent automatic Data Path activation when the Data Path state reaches DPInitialized.

By inspecting the current code, it is impossible for the DPSM for an interface to reach `DPInitialized` without first setting `OutputDisableTx` for that interface's media lanes mask, but it is more reliable to just disable all output when in `ModuleLowPwr` to prevent similar unintended behavior in the future.

#### How Has This Been Tested?
This command has been a reliable way to reproduce this issue on FINISAR FTCE4717E2PCB (when modules are in `ModuleLowPwr` following a reset):
```
$ python3 -c "
import random
interfaces = ['Ethernet{}'.format(i*4) for i in range(0, 129)]
random.shuffle(interfaces)
for intf in interfaces:
    print(f'sudo config interface startup {intf}')
" | bash
```
It now succeeds in bringing up all interfaces after this change. 

This change also includes a unit test which passes when run on a local sonic build image container. This test confirms that `CMIS_STATE_DP_DEINIT` results in a call to `set_deinit_lanes` with the value `0xff` passed and a call to `tx_disable_channel` with the values `0xff` and `True` passed when the MSM is in `ModuleLowPwr`. This tells us that the mechanism is working as intended.