### PR TITLE
Removed unused is_warm_reboot_enabled utility

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -6235,10 +6235,10 @@ class TestXcvrdScript(object):
     @patch('xcvrd.xcvrd.DaemonXcvrd.load_platform_util', MagicMock())
     @patch('xcvrd.xcvrd_utilities.port_event_helper.get_port_mapping', MagicMock(return_value=MockPortMapping))
     @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/tmp', '/tmp')))
-    @patch('xcvrd.xcvrd_utilities.common.is_warm_reboot_enabled', MagicMock(return_value=False))
     @patch('xcvrd.xcvrd.DaemonXcvrd.wait_for_port_config_done', MagicMock())
     @patch('xcvrd.xcvrd.DaemonXcvrd.initialize_sfp_obj_dict', MagicMock())
     @patch('subprocess.check_output', MagicMock(return_value='false'))
+    @patch('xcvrd.xcvrd.common.is_syncd_warm_restore_complete', MagicMock(return_value=False))
     @patch('xcvrd.xcvrd_utilities.common.del_port_sfp_dom_info_from_db')
     def test_DaemonXcvrd_init_deinit_cold(self, mock_del_port_sfp_dom_info_from_db):
         xcvrd.platform_chassis = MagicMock()

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/common.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/common.py
@@ -150,14 +150,6 @@ def is_fast_reboot_enabled():
     fastboot_enabled = subprocess.check_output('sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable', shell=True, universal_newlines=True)
     return "true" in fastboot_enabled
 
-def is_warm_reboot_enabled():
-    """Check if warm reboot is enabled"""
-    warmstart = swsscommon.WarmStart()
-    warmstart.initialize("xcvrd", "pmon")
-    warmstart.checkWarmStart("xcvrd", "pmon", False)
-    is_warm_start = warmstart.isWarmStart()
-    return is_warm_start
-
 def is_syncd_warm_restore_complete(namespace=''):
     """
     This function determines whether syncd's restore count is not 0, which indicates warm-reboot


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

The `is_warm_reboot_enabled()` helper in sonic-platform-daemons/sonic-xcvrd/xcvrd/xcvrd_utilities/common.py is currently unused in production code. [PR #680](https://github.com/sonic-net/sonic-platform-daemons/pull/680) replaced its call sites with `is_syncd_warm_restore_complete()`, but the function is still defined and importable. It should be removed to prevent it being reintroduced as a footgun that risks causing data plane impact in warm-reboot.

The changes here remove the utility.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

**Why this is a footgun**

`is_warm_reboot_enabled()` calls `WarmStart::checkWarmStart("xcvrd", "pmon", False)`, which has a critical side-effect -> on cold boot it writes `restore_count=0` into `STATE_DB:WARM_RESTART_TABLE|xcvrd`. That row is what makes the next warm reboot recognise xcvrd as a registered warm-restart participant.

After PR [PR #680](https://github.com/sonic-net/sonic-platform-daemons/pull/680), nothing in xcvrd calls this function on startup any more, so the row is no longer being seeded on cold boot. If a future PR re-introduces a call to `is_warm_reboot_enabled()`, it will:

   1. Run on a cold boot where the row was never seeded (because no other startup path seeds it now).
   2. Hit the `restore_count == ""``branch in `swss-common/common/warm_restart.cpp`.
   3. Log `"xcvrd doing warm start, but restore_count not found... fall back to cold start"`.
   4. Cache `m_enabled = false` and `m_systemWarmRebootEnabled = false` on the singleton.
   5. Cause xcvrd to **take the cold-start branch on what is actually a warm reboot — almost certainly a data-plane hit**.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
CI unit tests

#### Additional Information (Optional)
This is very-low risk to 202511 branch so no cherry-pick required