### PR TITLE
Fix Issue #816: Regression in chassis_db_init causing PMON Failure

### DIFF
--- a/sonic-chassisd/scripts/chassis_db_init
+++ b/sonic-chassisd/scripts/chassis_db_init
@@ -11,6 +11,7 @@ try:
     import sys
 
     from sonic_py_common import daemon_base, logger
+    from sonic_platform_base.module_base import ModuleBase
 
     # If unit testing is occurring, mock swsscommon and module_base
     if os.getenv("CHASSIS_DB_INIT_UNIT_TESTING") == "1":
@@ -77,7 +78,7 @@ def provision_db(platform_chassis, log):
         # BMC must also populate the switch host serial number. BMC Chassis object is expected to have
         # the switch host module at index 0.
         switch_host_mod = platform_chassis.get_module(0)
-        if not switch_host_mod or switch_host_mod.get_type() != MODULE_TYPE_SWITCH_HOST:
+        if not switch_host_mod or switch_host_mod.get_type() != ModuleBase.MODULE_TYPE_SWITCH_HOST:
             raise RuntimeError("Switch Host Module must be present in the BMC chassis module at index 0")
         switch_host_serial = switch_host_mod.get_serial()
 

--- a/sonic-chassisd/scripts/chassis_db_init
+++ b/sonic-chassisd/scripts/chassis_db_init
@@ -74,7 +74,8 @@ def provision_db(platform_chassis, log):
     # Determine switch host serial number
     if platform_chassis.is_bmc():
         # BMC must also populate the switch host serial number
-        switch_host_serial = try_get(platform_chassis.get_switch_host_serial)
+        get_switch_host_serial = getattr(platform_chassis, "get_switch_host_serial", None)
+        switch_host_serial = try_get(get_switch_host_serial) if get_switch_host_serial else NOT_AVAILABLE
     else:
         switch_host_serial = NOT_AVAILABLE
 

--- a/sonic-chassisd/scripts/chassis_db_init
+++ b/sonic-chassisd/scripts/chassis_db_init
@@ -72,12 +72,14 @@ def provision_db(platform_chassis, log):
     chassis_table = swsscommon.Table(state_db, CHASSIS_INFO_TABLE)
 
     # Determine switch host serial number
+    switch_host_serial = NOT_AVAILABLE
     if platform_chassis.is_bmc():
-        # BMC must also populate the switch host serial number
-        get_switch_host_serial = getattr(platform_chassis, "get_switch_host_serial", None)
-        switch_host_serial = try_get(get_switch_host_serial) if get_switch_host_serial else NOT_AVAILABLE
-    else:
-        switch_host_serial = NOT_AVAILABLE
+        # BMC must also populate the switch host serial number. BMC Chassis object is expected to have
+        # the switch host module at index 0.
+        switch_host_mod = platform_chassis.get_module(0)
+        if not switch_host_mod or switch_host_mod.get_type() != MODULE_TYPE_SWITCH_HOST:
+            raise RuntimeError("Switch Host Module must be present in the BMC chassis module at index 0")
+        switch_host_serial = switch_host_mod.get_serial()
 
     # Populate DB with chassis hardware info
     fvs = swsscommon.FieldValuePairs([

--- a/sonic-chassisd/tests/mock_module_base.py
+++ b/sonic-chassisd/tests/mock_module_base.py
@@ -7,7 +7,7 @@ class ModuleBase():
     MODULE_TYPE_LINE = "LINE-CARD"
     MODULE_TYPE_FABRIC = "FABRIC-CARD"
     MODULE_TYPE_DPU = "DPU"
-    MODULE_TYPE_SWITCH_HOST = "SWITCH_HOST"
+    MODULE_TYPE_SWITCH_HOST = "SWITCH-HOST"
 
     # Possible card status for modular chassis
     # Module state is Empty if no module is inserted in the slot

--- a/sonic-chassisd/tests/mock_platform.py
+++ b/sonic-chassisd/tests/mock_platform.py
@@ -163,6 +163,32 @@ class MockChassis:
     def get_supervisor_slot(self):
         return 0
 
+class MockBMCChassis(MockChassis):
+    """
+    Mock BMC Chassis for testing BMC-specific functionality.
+    Inherits from MockChassis and overrides is_bmc() to return True.
+    Always includes a switch host module at index 0.
+    """
+    def __init__(self):
+        """Initialize MockBMCChassis with a switch host module at index 0."""
+        from .mock_module_base import ModuleBase
+        super(MockBMCChassis, self).__init__()
+
+        # BMC chassis always has a switch host module at index 0
+        switch_host_module = MockModule(
+            module_index=0,
+            module_name="SWITCH-HOST0",
+            module_desc="Switch Host Module",
+            module_type=ModuleBase.MODULE_TYPE_SWITCH_HOST,
+            module_slot=0,
+            module_serial="MOCK-SWITCH-HOST-SERIAL"
+        )
+        self.module_list.append(switch_host_module)
+
+    def is_bmc(self):
+        """Override to return True for BMC chassis"""
+        return True
+
 class MockSmartSwitchChassis:
     def __init__(self):
         self.module_list = []

--- a/sonic-chassisd/tests/test_chassis_db_init.py
+++ b/sonic-chassisd/tests/test_chassis_db_init.py
@@ -16,7 +16,7 @@ def load_source(module_name, module_path):
 from mock import Mock, MagicMock, patch
 from sonic_py_common import daemon_base
 
-from .mock_platform import MockChassis, MockModule
+from .mock_platform import MockChassis, MockBMCChassis, MockModule
 from .mock_module_base import ModuleBase
 
 SYSLOG_IDENTIFIER = 'chassis_db_init_test'
@@ -53,63 +53,16 @@ def test_provision_db():
     assert switch_host_serial == fvs[CHASSIS_INFO_SWITCH_HOST_SERIAL_FIELD]
 
 def test_provision_db_bmc():
-    chassis = MockChassis()
     log = MagicMock()
-    switch_host_serial = "Switch Host Serial"
 
-    # Create a mock switch host module at index 0
-    switch_host_module = MockModule(
-        module_index=0,
-        module_name="SWITCH-HOST0",
-        module_desc="Switch Host Module",
-        module_type=ModuleBase.MODULE_TYPE_SWITCH_HOST,
-        module_slot=0,
-        module_serial=switch_host_serial
-    )
-    chassis.module_list.append(switch_host_module)
+    chassis = MockBMCChassis()
 
-    with patch.object(chassis, 'is_bmc', return_value=True):
-        chassis_table = provision_db(chassis, log)
+    chassis_table = provision_db(chassis, log)
 
     fvs = chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
-    assert switch_host_serial == fvs[CHASSIS_INFO_SWITCH_HOST_SERIAL_FIELD]
-
-def test_provision_db_bmc_no_module():
-    """Test that BMC chassis without module at index 0 raises RuntimeError"""
-    chassis = MockChassis()
-    log = MagicMock()
-
-    with patch.object(chassis, 'is_bmc', return_value=True):
-        try:
-            chassis_table = provision_db(chassis, log)
-            assert False, "Expected RuntimeError to be raised"
-        except RuntimeError as e:
-            assert "Switch Host Module must be present" in str(e)
-
-def test_provision_db_bmc_wrong_module_type():
-    """Test that BMC chassis with wrong module type at index 0 raises RuntimeError"""
-    chassis = MockChassis()
-    log = MagicMock()
-
-    # Create a line card module instead of switch host module
-    wrong_module = MockModule(
-        module_index=0,
-        module_name="LINE-CARD0",
-        module_desc="Line Card Module",
-        module_type=ModuleBase.MODULE_TYPE_LINE,
-        module_slot=0,
-        module_serial="LC Serial"
-    )
-    chassis.module_list.append(wrong_module)
-
-    with patch.object(chassis, 'is_bmc', return_value=True):
-        try:
-            chassis_table = provision_db(chassis, log)
-            assert False, "Expected RuntimeError to be raised"
-        except RuntimeError as e:
-            assert "Switch Host Module must be present" in str(e)
+    assert "MOCK-SWITCH-HOST-SERIAL" == fvs[CHASSIS_INFO_SWITCH_HOST_SERIAL_FIELD]
 
 def test_try_get_timeout_error():
     def raise_timeout():

--- a/sonic-chassisd/tests/test_chassis_db_init.py
+++ b/sonic-chassisd/tests/test_chassis_db_init.py
@@ -57,14 +57,59 @@ def test_provision_db_bmc():
     log = MagicMock()
     switch_host_serial = "Switch Host Serial"
 
-    with patch.object(chassis, 'is_bmc', return_value=True), \
-         patch.object(chassis, 'get_switch_host_serial', create=True, return_value=switch_host_serial):
+    # Create a mock switch host module at index 0
+    switch_host_module = MockModule(
+        module_index=0,
+        module_name="SWITCH-HOST0",
+        module_desc="Switch Host Module",
+        module_type=ModuleBase.MODULE_TYPE_SWITCH_HOST,
+        module_slot=0,
+        module_serial=switch_host_serial
+    )
+    chassis.module_list.append(switch_host_module)
+
+    with patch.object(chassis, 'is_bmc', return_value=True):
         chassis_table = provision_db(chassis, log)
 
     fvs = chassis_table.get(CHASSIS_INFO_KEY_TEMPLATE.format(1))
     if isinstance(fvs, list):
         fvs = dict(fvs[-1])
     assert switch_host_serial == fvs[CHASSIS_INFO_SWITCH_HOST_SERIAL_FIELD]
+
+def test_provision_db_bmc_no_module():
+    """Test that BMC chassis without module at index 0 raises RuntimeError"""
+    chassis = MockChassis()
+    log = MagicMock()
+
+    with patch.object(chassis, 'is_bmc', return_value=True):
+        try:
+            chassis_table = provision_db(chassis, log)
+            assert False, "Expected RuntimeError to be raised"
+        except RuntimeError as e:
+            assert "Switch Host Module must be present" in str(e)
+
+def test_provision_db_bmc_wrong_module_type():
+    """Test that BMC chassis with wrong module type at index 0 raises RuntimeError"""
+    chassis = MockChassis()
+    log = MagicMock()
+
+    # Create a line card module instead of switch host module
+    wrong_module = MockModule(
+        module_index=0,
+        module_name="LINE-CARD0",
+        module_desc="Line Card Module",
+        module_type=ModuleBase.MODULE_TYPE_LINE,
+        module_slot=0,
+        module_serial="LC Serial"
+    )
+    chassis.module_list.append(wrong_module)
+
+    with patch.object(chassis, 'is_bmc', return_value=True):
+        try:
+            chassis_table = provision_db(chassis, log)
+            assert False, "Expected RuntimeError to be raised"
+        except RuntimeError as e:
+            assert "Switch Host Module must be present" in str(e)
 
 def test_try_get_timeout_error():
     def raise_timeout():


### PR DESCRIPTION
Use getattr to ensure if the chassis object defines a get_switch_host_serial method before invoking the same. Nexthop's platforms implement the API to read the switch host serial number in the Chassis object that represents the BMC card. This API may not be present in other vendor's code, so check before invoking the same. Ideally this API must be part of the BMC chassis object as that object has collection of all system objects. Where the switch host's serial number is present may differ between vendors implementation and hence having it as part of chassis object (which can then get to the appropriate module object and read) is better IMHO rather than assuming that the CPU card will have it. @judyjoseph Let me know if this makes sense.

Issue #816 

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
