### PR TITLE
thermalctld: convert leak data to strings before writing to db

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -564,7 +564,7 @@ class LiquidCoolingUpdater(threading.Thread, logger.Logger):
         for profile in self.liquid_cooling.get_all_profiles():
             fvs = swsscommon.FieldValuePairs([
                 ('type', profile.get_type()),
-                ('max_minor_duration_sec', profile.get_leak_max_minor_duration_sec()),
+                ('max_minor_duration_sec', str(profile.get_leak_max_minor_duration_sec())),
             ])
             self.profile_table.set(profile.get_type(), fvs)
 
@@ -636,8 +636,8 @@ class LiquidCoolingUpdater(threading.Thread, logger.Logger):
                 ('name', sensor_name),
                 ('leaking', leaking),
                 ('leak_sensor_status', 'Good' if sensor_is_ok else 'Fault'),
-                ('type', sensor.get_leak_sensor_type()),
-                ('location', sensor.get_leak_sensor_location()),
+                ('type', str(sensor.get_leak_sensor_type())),
+                ('location', str(sensor.get_leak_sensor_location())),
                 ('severity', str(sensor_leak_severity)),
             ])
             self.sensor_table.set(sensor_name, fvs)


### PR DESCRIPTION
thermalctld: convert leak data to strings before writing to db

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

This helps avoid issues where implementations return non-string data, which will fault when trying to write to the state db.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

Partially fixes https://github.com/sonic-net/sonic-buildimage/issues/27515

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Test suite for thermalctld was run.

#### Additional Information (Optional)
