### PR TITLE
[xcvrd] Fix outdated state machine comments for SYSTEM_NOT_READY event

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1677,7 +1677,7 @@ class SfpStateUpdateTask(threading.Thread):
         #       - else
         #             max retry reached, treat as fatal, transition to EXIT
         #     - NORMAL
-        #         Treat as an error, transition to INIT
+        #         Treat as fatal, transition to EXIT
         # 2. SYSTEM_BECOME_READY
         #     - INIT
         #         transition to NORMAL
@@ -1706,7 +1706,7 @@ class SfpStateUpdateTask(threading.Thread):
         # NORMAL          SYSTEM BECOME READY NORMAL
         # NORMAL          SYSTEM FAIL         INIT
         # INIT/NORMAL     NORMAL EVENT        NORMAL
-        # NORMAL          SYSTEM NOT READY    INIT
+        # NORMAL          SYSTEM NOT READY    EXIT
         # EXIT            -
 
         retry = 0


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

#### Description
The comments in xcvrd.py describing the state machine transition for the SYSTEM_NOT_READY event while in the NORMAL state were outdated.

The comments previously indicated that the daemon would transition back to the INIT state. However, the actual implementation safely treats this condition as a fatal error and transitions to the EXIT state, relying on supervisord to cleanly restart the daemon.

This commit updates the comments to align with the actual code behavior to prevent developer confusion.


#### Motivation and Context
Why is this change required? What problem does it solve? The contradiction between the state machine documentation (comments) and the actual source code logic caused confusion for developers reading the codebase. By aligning the comments with the code's intended fail-fast design (`treat as fatal. Exiting...`), this PR improves code readability and maintainability.

#### How Has This Been Tested?
This is a comment-only change that aligns documentation with existing behavior. No functional code modifications were made.

#### Additional Information (Optional)
