### PR TITLE
Add CPO to list of supported module types for the CMIS state machine

### DIFF
--- a/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
+++ b/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
@@ -42,7 +42,7 @@ class CmisManagerTask(threading.Thread):
 
     CMIS_MAX_RETRIES     = 3
     CMIS_DEF_EXPIRED     = 60 # seconds, default expiration time
-    CMIS_MODULE_TYPES    = ['QSFP-DD', 'QSFP_DD', 'OSFP', 'OSFP-8X', 'QSFP+C']
+    CMIS_MODULE_TYPES    = ['QSFP-DD', 'QSFP_DD', 'OSFP', 'OSFP-8X', 'QSFP+C', 'CPO']
     CMIS_MAX_HOST_LANES    = 8
     CMIS_EXPIRATION_BUFFER_MS = 2
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Add `'CPO'` to the `CMIS_MODULE_TYPES` list in `CmisManagerTask` so that Co-Packaged Optics (CPO) modules are recognized as CMIS-managed modules and are taken through the full CMIS bring-up state machine.

In `CmisManagerTask.task_worker()` the module type abbreviation returned by `api.get_module_type_abbreviation()` is checked against `CMIS_MODULE_TYPES`, and any module whose abbreviation is not in that list is treated as
"non-CMIS": it is forced straight to `CMIS_STATE_READY` and the CMIS state machine is skipped.

#### Motivation and Context
CPO modules are CMIS-compliant, but because the abbreviation `'CPO'` was missing from `CMIS_MODULE_TYPES`, `xcvrd` was skipping the CMIS state machine for them and transitioning the port directly to `CMIS_STATE_READY`. As a result, CPO ports were not getting proper data-path initialization, application-code configuration, or Tx turn-on sequencing through `xcvrd`.

This change enables the existing CMIS initialization flow for CPO modules so they are brought up the same way as other CMIS form factors already supported by `CmisManagerTask`.

#### How Has This Been Tested?
Manual testing.

#### Additional Information (Optional)
