### PR TITLE
Remove PENDING flag check in CMIS SM

### DIFF
--- a/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
+++ b/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
@@ -1181,14 +1181,6 @@ class CmisManagerTask(threading.Thread):
                     self.force_cmis_reinit(lport)
                     return
 
-                if hasattr(api, 'get_cmis_rev'):
-                    # Check datapath init pending on module that supports CMIS 5.x
-                    majorRev = int(api.get_cmis_rev().split('.')[0])
-                    if majorRev >= 5 and not self.check_datapath_init_pending(api, host_lanes_mask):
-                        self.log_notice("{}: datapath init not pending".format(lport))
-                        self.force_cmis_reinit(lport, retries + 1)
-                        return
-
                 # Ensure the Datapath is NOT Activated unless the host Tx siganl is good.
                 # NOTE: Some CMIS compliant modules may have 'auto-squelch' feature where
                 # the module won't take datapaths to Activated state if host tries to enable


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Removed the check in CMIS SM that waits for PENDING flag. 
This PR aims to fix https://github.com/sonic-net/sonic-buildimage/issues/27582

#### Motivation and Context
The removed code block is not accurate according to CMIS spec - this flag is not a good indicator for states transition. 
1. The DP_INIT_PENDING flag is not defined as a reliable indicator for validating the DP_INIT state. It is intended only as supplementary information and should not be used by the NOS to control state progression.
2. The specification does not define a minimum duration for which the PENDING flag must remain asserted. On faster modules, the transition may complete before the NOS has a chance to observe this flag.
3.  In the next CMIS state (TXON), we will check whether the module state is DataPathInitialized. This is the required indicator, making the PENDING check unnecessary.

#### How Has This Been Tested?
This is only informational flag, so removing it cannot fail anything. 
The next state check is the right indicator and already exists. 
this was tested with CMIS host mgmt. modules.

#### Additional Information (Optional)
