### PR TITLE
[chassisd] Add testbed script for DPU reboot cause persistence

### DIFF
--- a/sonic-chassisd/tests/testbed/README.md
+++ b/sonic-chassisd/tests/testbed/README.md
@@ -1,0 +1,28 @@
+# Chassisd Testbed Scripts
+
+End-to-end verification scripts for SmartSwitch DPU reboot-cause tracking.
+These scripts run on a real SmartSwitch testbed (not in CI) and validate
+chassisd behavior across various status transitions.
+
+## Scripts
+
+- **test_dpu_reboot_cause_persistence.sh** — Full testbed script covering
+  6 scenarios: normal reboot, config-reload during reboot, config-reload with
+  DPU offline, history preservation, deferred same-cause, and back-to-back
+  reboot deduplication.
+
+## Usage
+
+```bash
+# Copy patched chassisd to the switch
+scp sonic-chassisd/scripts/chassisd admin@<SWITCH>:/tmp/chassisd_patched
+
+# SSH to the switch and run
+sudo bash test_dpu_reboot_cause_persistence.sh -d DPU0
+```
+
+## Prerequisites
+
+- SmartSwitch with at least one DPU
+- Root access on the switch
+- Patched chassisd copied to the switch

--- a/sonic-chassisd/tests/testbed/test_dpu_reboot_cause_persistence.sh
+++ b/sonic-chassisd/tests/testbed/test_dpu_reboot_cause_persistence.sh
@@ -1,0 +1,1029 @@
+#!/bin/bash
+#
+# Testbed verification script for SmartSwitchModuleUpdater.module_db_update
+#
+# Covers:
+#   Test 1: Normal ONLINE→OFFLINE→ONLINE transition records reboot cause
+#   Test 2: Config reload during DPU reboot (EMPTY→OFFLINE→ONLINE deferred check)
+#   Test 3: Config reload with DPU already offline (admin-shutdown power cycle)
+#   Test 4: Reboot cause history is not lost after config reload
+#   Test 5: Deferred EMPTY→OFFLINE→ONLINE with same cause (no duplicate)
+#   Test 6: Back-to-back reboot skips duplicate persist
+#   Test 7: Reboot during pmon restart — same cause skips persist (Path C3)
+#
+
+SCRIPT_NAME=$(basename "$0")
+
+usage() {
+    cat <<EOF
+Usage: sudo bash $SCRIPT_NAME [OPTIONS]
+
+Verify SmartSwitch DPU reboot-cause tracking across all status transitions
+on a real testbed.  The script installs a patched chassisd inside the pmon
+container, runs 6 end-to-end tests, and optionally restores the original.
+
+Prerequisites:
+  - Run on a SmartSwitch with at least one DPU
+  - Run as root (sudo)
+  - Copy the patched chassisd to the switch before running:
+      scp <workspace>/sonic-chassisd/scripts/chassisd admin@<SWITCH>:/tmp/chassisd_patched
+
+Options:
+  -d DPU        DPU name to test (default: DPU0)
+  -p PATH       Path to patched chassisd on the switch (default: /tmp/chassisd_patched)
+  -t SECONDS    Delay between DPU reboot and config reload in Test 2 (default: 10)
+  -h            Show this help message and exit
+
+Tests:
+  1. Normal ONLINE → OFFLINE → ONLINE
+     Reboots the DPU normally and verifies reboot cause is recorded,
+     history file count increases, DB entries exist, and syslog shows
+     both offline and online transition messages.
+
+  2. Config reload during DPU reboot (deferred check)
+     Reboots the DPU, then issues 'config reload -y' while the DPU is
+     still rebooting.  Chassisd restarts with an empty STATE_DB and
+     discovers the DPU offline (EMPTY→OFFLINE).  The deferred check
+     should fire when the DPU comes online, persisting the updated
+     reboot cause.
+
+  3. Config reload with DPU already stable offline
+     Shuts down the DPU (admin down), then issues config reload.
+     Chassisd sees EMPTY→OFFLINE but the DPU stays offline, so
+     no reboot cause should be persisted.  Verifies no duplicate
+     entries are created, including after the DPU is brought back.
+
+  4. Reboot cause history preserved across config reload
+     Issues config reload with the DPU online and verifies on-disk
+     history files survive the STATE_DB flush and that CHASSIS_STATE_DB
+     entries are repopulated.
+
+  5. Deferred check with same reboot cause
+     Issues config reload (no DPU reboot) so the DPU cycles through
+     EMPTY→OFFLINE→ONLINE with the same reboot cause.  Verifies that
+     the deferred check detects the cause is unchanged and does NOT
+     create a duplicate entry.
+
+  6. Back-to-back rapid reboot
+     Reboots the DPU twice in quick succession.  The second online
+     transition should detect the cause was already persisted and skip
+     creating a duplicate reboot cause entry.
+
+  7. Reboot during pmon restart — same cause (Path C3 skip)
+     Reboots DPU, then stops pmon and deletes the STATE_DB key while
+     DPU is still rebooting.  After pmon restarts, chassisd sees
+     EMPTY→Offline→Online (Path B then Path C3).  Because the cause
+     is unchanged, persist is skipped but STATE_DB is repopulated.
+     Validates sonic-net/sonic-buildimage#24275 reproducer.
+
+Examples:
+  sudo bash $SCRIPT_NAME
+  sudo bash $SCRIPT_NAME -d DPU1
+  sudo bash $SCRIPT_NAME -d DPU0 -p /tmp/my_chassisd -t 15
+
+EOF
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+DPU="DPU0"
+CONFIG_RELOAD_DELAY=10
+PATCHED_CHASSISD="/tmp/chassisd_patched"
+
+while getopts "d:p:t:h" opt; do
+    case $opt in
+        d) DPU="$OPTARG" ;;
+        p) PATCHED_CHASSISD="$OPTARG" ;;
+        t) CONFIG_RELOAD_DELAY="$OPTARG" ;;
+        h) usage ;;
+        *) usage ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+set -uo pipefail
+
+CHASSISD_PATH="/usr/local/bin/chassisd"
+BACKUP_CHASSISD="/tmp/chassisd_original"
+PMON_CONTAINER="pmon"
+REBOOT_CAUSE_DIR="/host/reboot-cause/module"
+MAX_HISTORY_FILES=10
+PASSED=0
+FAILED=0
+SKIPPED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+log_step()  { echo -e "\n${CYAN}=== $* ===${NC}"; }
+
+pass() { echo -e "  ${GREEN}PASS${NC}: $*"; (( PASSED++ )) || true; }
+fail() { echo -e "  ${RED}FAIL${NC}: $*"; (( FAILED++ )) || true; }
+skip() { echo -e "  ${YELLOW}SKIP${NC}: $*"; (( SKIPPED++ )) || true; }
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+find_chassisd_path() {
+    if ! docker ps --format '{{.Names}}' | grep -q "^${PMON_CONTAINER}$"; then
+        log_error "pmon container is not running"
+        return 1
+    fi
+    for candidate in \
+        "/usr/local/bin/chassisd" \
+        "$(docker exec "$PMON_CONTAINER" which chassisd 2>/dev/null || true)" \
+        "$(docker exec "$PMON_CONTAINER" find /usr -name chassisd 2>/dev/null | head -1 || true)"; do
+        if [[ -n "$candidate" ]] && docker exec "$PMON_CONTAINER" test -f "$candidate" 2>/dev/null; then
+            CHASSISD_PATH="$candidate"
+            return 0
+        fi
+    done
+    log_error "Could not find chassisd inside $PMON_CONTAINER container"
+    return 1
+}
+
+wait_for_system_ready() {
+    local timeout=${1:-300}
+    local elapsed=0
+    log_info "Waiting for system ready (timeout: ${timeout}s)..."
+    while (( elapsed < timeout )); do
+        if show system-health summary 2>/dev/null | grep -q "System is ready"; then
+            log_info "System is ready after ${elapsed}s"
+            return 0
+        fi
+        sleep 5
+        (( elapsed += 5 ))
+    done
+    log_warn "System not ready after ${timeout}s, proceeding anyway"
+    return 1
+}
+
+wait_for_dpu_online() {
+    local dpu=$1
+    local timeout=${2:-600}
+    local elapsed=0
+    log_info "Waiting for $dpu to come online (timeout: ${timeout}s)..."
+    while (( elapsed < timeout )); do
+        local status
+        status=$(sonic-db-cli STATE_DB HGET "CHASSIS_MODULE_TABLE|${dpu}" "oper_status" 2>/dev/null || true)
+        if [[ "$status" == "Online" || "$status" == "Partial Online" ]]; then
+            log_info "$dpu is online (status: $status) after ${elapsed}s"
+            return 0
+        fi
+        sleep 10
+        (( elapsed += 10 ))
+    done
+    log_error "$dpu did not come online within ${timeout}s"
+    return 1
+}
+
+wait_for_dpu_offline() {
+    local dpu=$1
+    local timeout=${2:-300}
+    local elapsed=0
+    log_info "Waiting for $dpu to go offline (timeout: ${timeout}s)..."
+    while (( elapsed < timeout )); do
+        local status
+        status=$(sonic-db-cli STATE_DB HGET "CHASSIS_MODULE_TABLE|${dpu}" "oper_status" 2>/dev/null || true)
+        if [[ "$status" == "Offline" ]]; then
+            log_info "$dpu is offline after ${elapsed}s"
+            return 0
+        fi
+        sleep 5
+        (( elapsed += 5 ))
+    done
+    log_error "$dpu did not go offline within ${timeout}s"
+    return 1
+}
+
+get_dpu_status() {
+    sonic-db-cli STATE_DB HGET "CHASSIS_MODULE_TABLE|${1}" "oper_status" 2>/dev/null || echo "Unknown"
+}
+
+get_latest_reboot_cause() {
+    local dpu=$1
+    show reboot-cause all 2>/dev/null | grep -i "$dpu" | head -1 || echo "(none)"
+}
+
+get_reboot_history_count() {
+    local dpu=$1
+    local dir="${REBOOT_CAUSE_DIR}/${dpu,,}/history"
+    if [[ -d "$dir" ]]; then
+        find "$dir" -name '*_reboot_cause.json' 2>/dev/null | wc -l
+    else
+        echo 0
+    fi
+}
+
+get_previous_reboot_cause_json() {
+    local dpu=$1
+    local path="${REBOOT_CAUSE_DIR}/${dpu,,}/previous-reboot-cause.json"
+    if [[ -L "$path" ]] || [[ -f "$path" ]]; then
+        cat "$path" 2>/dev/null || echo "{}"
+    else
+        echo "(not found)"
+    fi
+}
+
+extract_cause_fields() {
+    # Extract only "cause" and "comment" from JSON (ignore time/name which change on every persist)
+    local json=$1
+    local cause comment
+    cause=$(echo "$json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('cause',''))" 2>/dev/null || echo "")
+    comment=$(echo "$json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('comment',''))" 2>/dev/null || echo "")
+    echo "${cause}|${comment}"
+}
+
+get_db_reboot_cause_keys() {
+    local dpu=$1
+    sonic-db-cli CHASSIS_STATE_DB KEYS "REBOOT_CAUSE|${dpu}|*" 2>/dev/null || true
+}
+
+snapshot_reboot_state() {
+    local label=$1
+    log_step "Snapshot: $label"
+    echo "--- DPU status ---"
+    get_dpu_status "$DPU"
+    echo ""
+    echo "--- show reboot-cause all ---"
+    show reboot-cause all 2>/dev/null || true
+    echo ""
+    echo "--- show reboot-cause history $DPU ---"
+    show reboot-cause history "$DPU" 2>/dev/null || true
+    echo ""
+    echo "--- previous-reboot-cause.json ---"
+    get_previous_reboot_cause_json "$DPU"
+    echo ""
+    echo "--- History file count ---"
+    get_reboot_history_count "$DPU"
+    echo ""
+    echo "--- CHASSIS_STATE_DB keys ---"
+    get_db_reboot_cause_keys "$DPU"
+    echo ""
+}
+
+check_syslog_for() {
+    local pattern=$1
+    local since=${2:-"10 minutes ago"}
+    local result=""
+    # Try journalctl filtered by chassisd identifier
+    result=$(journalctl -t chassisd --since "$since" 2>/dev/null | grep -i "$pattern" | tail -5)
+    if [[ -n "$result" ]]; then echo "$result"; return; fi
+    # Try journalctl unfiltered (in case identifier differs)
+    result=$(journalctl --since "$since" 2>/dev/null | grep -i "chassisd" | grep -i "$pattern" | tail -5)
+    if [[ -n "$result" ]]; then echo "$result"; return; fi
+    # Try host /var/log/syslog filtered by chassisd with time filtering.
+    # SONiC syslog format: "2026 May 23 20:15:26.123456 hostname ..."
+    if [[ -f /var/log/syslog ]]; then
+        # Convert 'since' to numeric timestamp (YYYYMMDDHHmmss) for comparison
+        local since_numeric
+        since_numeric=$(date -d "$since" +%Y%m%d%H%M%S 2>/dev/null || echo 0)
+        if [[ "$since_numeric" != "0" && ${#since_numeric} -eq 14 ]]; then
+            # Pure awk comparison — no external commands per line
+            result=$(grep -i "chassisd" /var/log/syslog 2>/dev/null | grep -i "$pattern" | \
+                awk -v since_ts="$since_numeric" '
+                BEGIN {
+                    mon["Jan"]=1; mon["Feb"]=2; mon["Mar"]=3; mon["Apr"]=4
+                    mon["May"]=5; mon["Jun"]=6; mon["Jul"]=7; mon["Aug"]=8
+                    mon["Sep"]=9; mon["Oct"]=10; mon["Nov"]=11; mon["Dec"]=12
+                }
+                {
+                    # Parse "YYYY Mon DD HH:MM:SS.usec" from fields 1-4
+                    year = $1+0; m = mon[$2]+0; day = $3+0
+                    split($4, t, /[:.]/)
+                    h = t[1]+0; mi = t[2]+0; s = t[3]+0
+                    if (year > 0 && m > 0) {
+                        line_ts = sprintf("%04d%02d%02d%02d%02d%02d", year, m, day, h, mi, s)
+                        if (line_ts >= since_ts) print
+                    }
+                }' | tail -5)
+            if [[ -n "$result" ]]; then echo "$result"; return; fi
+            # Time filtering was applied — trust the result (even if empty).
+            # Do NOT fall through to unfiltered grep, which would defeat
+            # "should not find" assertions in Test 5.
+            return
+        fi
+        # since_numeric could not be computed — use unfiltered grep as last resort
+        result=$(grep -i "chassisd" /var/log/syslog 2>/dev/null | grep -i "$pattern" | tail -5)
+        if [[ -n "$result" ]]; then echo "$result"; return; fi
+    fi
+    # Try inside pmon container
+    result=$(docker exec "$PMON_CONTAINER" cat /var/log/syslog 2>/dev/null | grep -i "$pattern" | tail -5)
+    if [[ -n "$result" ]]; then echo "$result"; return; fi
+    # Try supervisord stdout log inside pmon container
+    result=$(docker exec "$PMON_CONTAINER" cat /var/log/supervisor/supervisord.log 2>/dev/null | grep -i "$pattern" | tail -5)
+    if [[ -n "$result" ]]; then echo "$result"; return; fi
+}
+
+restart_chassisd() {
+    log_info "Restarting pmon (chassisd)..."
+    systemctl restart pmon
+    sleep 15
+    log_info "pmon restarted"
+}
+
+# ---------------------------------------------------------------------------
+# Pre-flight checks
+# ---------------------------------------------------------------------------
+log_step "Pre-flight checks"
+
+if [[ $EUID -ne 0 ]]; then
+    log_error "This script must be run as root (sudo)"
+    exit 1
+fi
+
+find_chassisd_path
+log_info "Found chassisd at: $PMON_CONTAINER:$CHASSISD_PATH"
+
+if [[ ! -f "$PATCHED_CHASSISD" ]]; then
+    log_error "Patched chassisd not found at $PATCHED_CHASSISD"
+    log_error "Please copy it first:"
+    log_error "  scp <workspace>/sonic-chassisd/scripts/chassisd admin@<switch>:$PATCHED_CHASSISD"
+    log_error "Run '$SCRIPT_NAME -h' for help."
+    exit 1
+fi
+
+# Verify DPU exists
+DPU_STATUS=$(get_dpu_status "$DPU")
+if [[ "$DPU_STATUS" == "Unknown" ]]; then
+    log_error "$DPU not found in STATE_DB. Is this a smartswitch platform?"
+    exit 1
+fi
+log_info "$DPU current status: $DPU_STATUS"
+
+# ---------------------------------------------------------------------------
+# Install patched chassisd
+# ---------------------------------------------------------------------------
+log_step "Installing patched chassisd"
+
+docker cp "$PMON_CONTAINER:$CHASSISD_PATH" "$BACKUP_CHASSISD"
+log_info "Backup saved to $BACKUP_CHASSISD"
+
+docker cp "$PATCHED_CHASSISD" "$PMON_CONTAINER:$CHASSISD_PATH"
+log_info "Patched chassisd installed"
+
+restart_chassisd
+
+log_step "Ensuring $DPU is online before tests"
+wait_for_dpu_online "$DPU" 600 || {
+    log_error "Cannot proceed: $DPU is not online"
+    exit 1
+}
+
+# Record initial state
+INITIAL_HISTORY_COUNT=$(get_reboot_history_count "$DPU")
+log_info "Initial history file count: $INITIAL_HISTORY_COUNT"
+
+TIMESTAMP_START=$(date '+%Y-%m-%d %H:%M:%S')
+
+# ===========================================================================
+# Test 1: Normal ONLINE → OFFLINE → ONLINE transition
+# ===========================================================================
+log_step "Test 1: Normal ONLINE → OFFLINE → ONLINE reboot cause recording"
+
+snapshot_reboot_state "Test 1 — BEFORE"
+
+CAUSE_BEFORE=$(get_previous_reboot_cause_json "$DPU")
+HISTORY_BEFORE=$(get_reboot_history_count "$DPU")
+
+log_info "Issuing 'reboot -d $DPU'..."
+reboot -d "$DPU" &
+
+log_info "Waiting for $DPU to go offline..."
+wait_for_dpu_offline "$DPU" 300 || {
+    fail "Test 1: $DPU did not go offline after reboot"
+}
+
+log_info "Waiting for $DPU to come back online..."
+wait_for_dpu_online "$DPU" 600 || {
+    fail "Test 1: $DPU did not come back online"
+}
+
+# Give chassisd a few poll cycles
+sleep 30
+
+snapshot_reboot_state "Test 1 — AFTER"
+
+CAUSE_AFTER=$(get_previous_reboot_cause_json "$DPU")
+HISTORY_AFTER=$(get_reboot_history_count "$DPU")
+
+# Verify reboot cause was recorded
+if [[ "$CAUSE_AFTER" != "$CAUSE_BEFORE" ]]; then
+    pass "Test 1: Reboot cause updated (normal transition)"
+else
+    fail "Test 1: Reboot cause did NOT change after normal reboot"
+fi
+
+# Verify history file count increased (capped at MAX_HISTORY_FILES)
+if (( HISTORY_BEFORE < MAX_HISTORY_FILES )); then
+    if (( HISTORY_AFTER > HISTORY_BEFORE )); then
+        pass "Test 1: History file count increased ($HISTORY_BEFORE -> $HISTORY_AFTER)"
+    else
+        fail "Test 1: History file count did not increase ($HISTORY_BEFORE -> $HISTORY_AFTER)"
+    fi
+else
+    if (( HISTORY_AFTER == MAX_HISTORY_FILES )); then
+        pass "Test 1: History file count at max ($HISTORY_AFTER), oldest rotated out"
+    else
+        fail "Test 1: History file count unexpected ($HISTORY_BEFORE -> $HISTORY_AFTER)"
+    fi
+fi
+
+# Verify DB entry exists
+DB_KEYS=$(get_db_reboot_cause_keys "$DPU")
+if [[ -n "$DB_KEYS" ]]; then
+    pass "Test 1: CHASSIS_STATE_DB has reboot cause entries"
+else
+    fail "Test 1: No reboot cause entries in CHASSIS_STATE_DB"
+fi
+
+# Check syslog for the offline transition log
+OFFLINE_LOG=$(check_syslog_for "operational status transitioning to offline" "$TIMESTAMP_START")
+if [[ -n "$OFFLINE_LOG" ]]; then
+    pass "Test 1: Syslog shows offline transition"
+else
+    fail "Test 1: No offline transition logged in syslog"
+fi
+
+# Check syslog for the online transition log
+ONLINE_LOG=$(check_syslog_for "operational status transitioning to online" "$TIMESTAMP_START")
+if [[ -n "$ONLINE_LOG" ]]; then
+    pass "Test 1: Syslog shows online transition"
+else
+    fail "Test 1: No online transition logged in syslog"
+fi
+
+# ===========================================================================
+# Test 2: Config reload during DPU reboot (deferred EMPTY→OFFLINE→ONLINE)
+# ===========================================================================
+log_step "Test 2: Config reload during DPU reboot (deferred cause check)"
+
+log_info "Ensuring $DPU is online..."
+wait_for_dpu_online "$DPU" 600 || {
+    fail "Test 2: $DPU not online, cannot proceed"
+}
+
+TIMESTAMP_T2=$(date '+%Y-%m-%d %H:%M:%S')
+
+CAUSE_BEFORE_T2=$(get_previous_reboot_cause_json "$DPU")
+HISTORY_BEFORE_T2=$(get_reboot_history_count "$DPU")
+
+log_info "Issuing 'reboot -d $DPU'..."
+reboot -d "$DPU" &
+
+log_info "Waiting ${CONFIG_RELOAD_DELAY}s before config reload..."
+sleep "$CONFIG_RELOAD_DELAY"
+
+log_info "Issuing 'config reload -y' (STATE_DB will be flushed, chassisd restarts)..."
+config reload -y &>/dev/null &
+
+log_info "Waiting for system to recover..."
+sleep 30
+wait_for_system_ready 300 || true
+
+# After config reload, chassisd restarts.  It will see EMPTY→OFFLINE for the
+# DPU (STATE_DB was flushed).  With the deferred check, it should NOT call
+# get_reboot_cause now — it should wait until the DPU comes online.
+
+log_info "Waiting for $DPU to come back online..."
+wait_for_dpu_online "$DPU" 600 || {
+    fail "Test 2: $DPU did not come back online after config reload + reboot"
+}
+
+# Give chassisd poll cycles to detect the online transition and run deferred check
+sleep 30
+
+snapshot_reboot_state "Test 2 — AFTER"
+
+CAUSE_AFTER_T2=$(get_previous_reboot_cause_json "$DPU")
+HISTORY_AFTER_T2=$(get_reboot_history_count "$DPU")
+
+# The deferred check should have detected the cause changed and persisted it
+if [[ "$CAUSE_AFTER_T2" != "$CAUSE_BEFORE_T2" ]]; then
+    pass "Test 2: Reboot cause updated after deferred check (config reload during reboot)"
+else
+    # The cause might be the same type ("Power Loss") but the timestamp should differ.
+    # Check history count instead (capped at MAX_HISTORY_FILES).
+    if (( HISTORY_BEFORE_T2 < MAX_HISTORY_FILES && HISTORY_AFTER_T2 > HISTORY_BEFORE_T2 )); then
+        pass "Test 2: New history entry created after deferred check"
+    elif (( HISTORY_BEFORE_T2 >= MAX_HISTORY_FILES && HISTORY_AFTER_T2 == MAX_HISTORY_FILES )); then
+        pass "Test 2: History at max ($MAX_HISTORY_FILES), oldest rotated (deferred check)"
+    else
+        fail "Test 2: Reboot cause NOT updated after config reload during reboot"
+    fi
+fi
+
+# Check for syslog messages.
+# The deferred=='reboot' path (Online→Offline→Online after config reload)
+# will persist the cause unless it was already persisted after the reboot time.
+# - "Reboot cause changed while chassisd was down" only appears for deferred=='restart'.
+# - "Reboot cause already persisted" appears when the cause was already recorded.
+# Neither is guaranteed in Test 2, so treat as informational.
+DEFERRED_LOG=$(check_syslog_for "Reboot cause changed while chassisd was down" "$TIMESTAMP_T2")
+ALREADY_PERSISTED_LOG=$(check_syslog_for "Reboot cause already persisted after reboot" "$TIMESTAMP_T2")
+if [[ -n "$DEFERRED_LOG" ]]; then
+    pass "Test 2: Syslog shows deferred reboot cause detection (restart path)"
+    log_info "  $DEFERRED_LOG"
+elif [[ -n "$ALREADY_PERSISTED_LOG" ]]; then
+    pass "Test 2: Syslog shows cause already persisted (same cause, recent — expected)"
+    log_info "  $ALREADY_PERSISTED_LOG"
+else
+    log_info "Test 2: No deferred-check syslog (expected for normal deferred reboot path)"
+fi
+
+# Check that the online transition was logged after config reload.
+ONLINE_LOG_T2=$(check_syslog_for "operational status transitioning to online" "$TIMESTAMP_T2")
+ONLINE_COUNT=$(echo "$ONLINE_LOG_T2" | grep -c . 2>/dev/null || echo 0)
+log_info "Online transition log count since test start: $ONLINE_COUNT"
+
+# ===========================================================================
+# Test 3: Config reload with DPU already stable offline (same cause)
+# ===========================================================================
+log_step "Test 3: Config reload with DPU already stable offline (no duplicate)"
+
+log_info "Ensuring $DPU is online..."
+wait_for_dpu_online "$DPU" 600 || {
+    skip "Test 3: $DPU not online, skipping"
+}
+
+# Reboot the DPU and let it fully come back to create a known reboot cause
+log_info "Rebooting $DPU and waiting for full cycle..."
+reboot -d "$DPU" &
+wait_for_dpu_offline "$DPU" 300 || true
+wait_for_dpu_online "$DPU" 600 || {
+    fail "Test 3: $DPU did not recover"
+}
+sleep 30
+
+# Now power off DPU so it stays offline
+log_info "Powering off $DPU (it will stay offline)..."
+config chassis modules shutdown "$DPU" 2>/dev/null || \
+    sonic-db-cli CONFIG_DB HSET "CHASSIS_MODULE|$DPU" "admin_status" "down" 2>/dev/null || true
+sleep 30
+
+TIMESTAMP_T3=$(date '+%Y-%m-%d %H:%M:%S')
+HISTORY_BEFORE_T3=$(get_reboot_history_count "$DPU")
+CAUSE_BEFORE_T3=$(get_previous_reboot_cause_json "$DPU")
+
+# Config reload — STATE_DB flushed, chassisd will see EMPTY→OFFLINE for DPU
+# But DPU stays offline this time (admin down), so the deferred check should
+# remain pending and no reboot cause should be persisted.
+log_info "Issuing 'config reload -y'..."
+config reload -y &>/dev/null &
+sleep 30
+wait_for_system_ready 300 || true
+
+# DPU should still be offline (admin down)
+sleep 30
+DPU_STATUS_T3=$(get_dpu_status "$DPU")
+log_info "$DPU status after config reload: $DPU_STATUS_T3"
+
+HISTORY_AFTER_T3=$(get_reboot_history_count "$DPU")
+CAUSE_AFTER_T3=$(get_previous_reboot_cause_json "$DPU")
+
+# Note: admin-shutdown is a RUNTIME command — not persisted to config_db.
+# After config reload, DPU comes back online (config says admin_status=up).
+# The deferred check fires immediately and detects the admin-shutdown power cycle
+# via prev_reboot_time.txt timestamp > stored cause timestamp.
+# So either:
+#   - DPU is still offline: no new entry yet (deferred hasn't fired)
+#   - DPU is already online: new entry persisted (deferred already fired)
+if [[ "$DPU_STATUS_T3" == *"Online"* ]]; then
+    # DPU already came back online — deferred check already fired and persisted
+    if (( HISTORY_BEFORE_T3 >= MAX_HISTORY_FILES )); then
+        if (( HISTORY_AFTER_T3 == MAX_HISTORY_FILES )); then
+            pass "Test 3: History at max after deferred persist (rotation handled)"
+        else
+            fail "Test 3: Unexpected history count ($HISTORY_BEFORE_T3 -> $HISTORY_AFTER_T3)"
+        fi
+    else
+        if (( HISTORY_AFTER_T3 == HISTORY_BEFORE_T3 + 1 )); then
+            pass "Test 3: New entry persisted (DPU came online after config reload)"
+        else
+            fail "Test 3: Expected history+1 ($HISTORY_BEFORE_T3 -> $HISTORY_AFTER_T3)"
+        fi
+    fi
+    if [[ "$CAUSE_AFTER_T3" != "$CAUSE_BEFORE_T3" ]]; then
+        pass "Test 3: previous-reboot-cause.json updated (admin-shutdown is real power cycle)"
+    else
+        fail "Test 3: previous-reboot-cause.json should have changed (DPU already online)"
+    fi
+else
+    # DPU shows offline at check time.  However, admin_status=up was restored
+    # by config reload (runtime shutdown is not persisted), so DPU is being
+    # brought back up.  It may have briefly come online (firing the deferred
+    # check and persisting) before going to Offline again, or chassisd may
+    # not have seen the transition yet.  Accept BOTH outcomes.
+    if (( HISTORY_AFTER_T3 == HISTORY_BEFORE_T3 )) || (( HISTORY_BEFORE_T3 >= MAX_HISTORY_FILES && HISTORY_AFTER_T3 == MAX_HISTORY_FILES )); then
+        pass "Test 3: History count stable while DPU shows offline ($HISTORY_AFTER_T3)"
+    elif (( HISTORY_AFTER_T3 == HISTORY_BEFORE_T3 + 1 )); then
+        pass "Test 3: Deferred already fired (DPU briefly came online)"
+    else
+        fail "Test 3: Unexpected history count while DPU offline ($HISTORY_BEFORE_T3 -> $HISTORY_AFTER_T3)"
+    fi
+    if [[ "$CAUSE_AFTER_T3" == "$CAUSE_BEFORE_T3" ]]; then
+        pass "Test 3: previous-reboot-cause.json unchanged (deferred still pending)"
+    else
+        # Deferred already fired — DPU briefly came online during the wait
+        pass "Test 3: previous-reboot-cause.json updated (deferred fired early)"
+    fi
+fi
+
+# Bring DPU back up for next test.
+# Note: the deferred flag is set from the config reload above (deferred='restart').
+# When DPU comes online, the deferred check will fire and detect that
+# prev_reboot_time.txt (written during admin-shutdown) is newer than the stored
+# cause timestamp.  Since admin-shutdown + startup is a real power cycle,
+# a new reboot cause entry SHOULD be persisted.
+log_info "Bringing $DPU back online..."
+config chassis modules startup "$DPU" 2>/dev/null || \
+    sonic-db-cli CONFIG_DB HSET "CHASSIS_MODULE|$DPU" "admin_status" "up" 2>/dev/null || true
+wait_for_dpu_online "$DPU" 600 || log_warn "$DPU did not come back online"
+sleep 30
+
+# The deferred check should persist a new entry (admin-shutdown is a real power cycle)
+HISTORY_AFTER_T3_ONLINE=$(get_reboot_history_count "$DPU")
+if (( HISTORY_BEFORE_T3 < MAX_HISTORY_FILES )); then
+    if (( HISTORY_AFTER_T3_ONLINE == HISTORY_BEFORE_T3 + 1 )); then
+        pass "Test 3: New entry persisted when DPU came back (admin-shutdown is a real power cycle)"
+    elif (( HISTORY_AFTER_T3_ONLINE == HISTORY_BEFORE_T3 )); then
+        fail "Test 3: No new entry — deferred check should detect power cycle via timestamp"
+    else
+        fail "Test 3: Unexpected history count ($HISTORY_BEFORE_T3 -> $HISTORY_AFTER_T3_ONLINE)"
+    fi
+else
+    if (( HISTORY_AFTER_T3_ONLINE == MAX_HISTORY_FILES )); then
+        pass "Test 3: History at max ($MAX_HISTORY_FILES), rotation handled"
+    else
+        fail "Test 3: Unexpected history count at max ($HISTORY_AFTER_T3_ONLINE)"
+    fi
+fi
+
+# ===========================================================================
+# Test 4: Reboot cause history preserved across config reload
+# ===========================================================================
+log_step "Test 4: Reboot cause history preserved across config reload"
+
+HISTORY_BEFORE_T4=$(get_reboot_history_count "$DPU")
+DB_KEYS_BEFORE_T4=$(get_db_reboot_cause_keys "$DPU" | wc -l)
+
+log_info "History files before: $HISTORY_BEFORE_T4, DB keys before: $DB_KEYS_BEFORE_T4"
+
+log_info "Issuing 'config reload -y'..."
+config reload -y &>/dev/null &
+sleep 30
+wait_for_system_ready 300 || true
+wait_for_dpu_online "$DPU" 600 || true
+sleep 30
+
+HISTORY_AFTER_T4=$(get_reboot_history_count "$DPU")
+DB_KEYS_AFTER_T4=$(get_db_reboot_cause_keys "$DPU" | wc -l)
+
+log_info "History files after: $HISTORY_AFTER_T4, DB keys after: $DB_KEYS_AFTER_T4"
+
+# History files on disk should be preserved (they live under /host, not in STATE_DB)
+# When at max, count stays the same; otherwise it should not decrease.
+if (( HISTORY_AFTER_T4 >= HISTORY_BEFORE_T4 )) || (( HISTORY_BEFORE_T4 >= MAX_HISTORY_FILES && HISTORY_AFTER_T4 == MAX_HISTORY_FILES )); then
+    pass "Test 4: History files preserved across config reload"
+else
+    fail "Test 4: History files lost after config reload ($HISTORY_BEFORE_T4 -> $HISTORY_AFTER_T4)"
+fi
+
+# DB entries should be repopulated by update_dpu_reboot_cause_to_db
+if (( DB_KEYS_AFTER_T4 > 0 )); then
+    pass "Test 4: CHASSIS_STATE_DB reboot cause entries present after config reload"
+else
+    fail "Test 4: No CHASSIS_STATE_DB entries after config reload"
+fi
+
+# ===========================================================================
+# Test 5: Deferred EMPTY→OFFLINE→ONLINE with same cause (no duplicate)
+# ===========================================================================
+log_step "Test 5: Deferred check with same reboot cause (no duplicate entry)"
+
+log_info "Ensuring $DPU is online..."
+wait_for_dpu_online "$DPU" 600 || {
+    skip "Test 5: $DPU not online, skipping"
+}
+
+# Reboot DPU, let it fully cycle to establish a known reboot cause
+log_info "Rebooting $DPU for a clean reboot cause baseline..."
+reboot -d "$DPU" &
+wait_for_dpu_offline "$DPU" 300 || true
+wait_for_dpu_online "$DPU" 600 || {
+    fail "Test 5: $DPU did not recover from baseline reboot"
+}
+sleep 30
+
+TIMESTAMP_T5=$(date '+%Y-%m-%d %H:%M:%S')
+HISTORY_BEFORE_T5=$(get_reboot_history_count "$DPU")
+CAUSE_BEFORE_T5=$(get_previous_reboot_cause_json "$DPU")
+log_info "Baseline cause: $CAUSE_BEFORE_T5"
+log_info "Baseline history count: $HISTORY_BEFORE_T5"
+
+# Config reload — no DPU reboot this time, DPU just stays online then
+# becomes EMPTY→OFFLINE→ONLINE as pmon/chassisd restarts.
+# The deferred path fires, but the cause is the SAME as stored (no new reboot
+# happened), so nothing should be persisted.
+log_info "Issuing 'config reload -y' (no DPU reboot — same cause expected)..."
+config reload -y &>/dev/null &
+sleep 30
+wait_for_system_ready 300 || true
+wait_for_dpu_online "$DPU" 600 || {
+    fail "Test 5: $DPU did not come back online after config reload"
+}
+sleep 30
+
+HISTORY_AFTER_T5=$(get_reboot_history_count "$DPU")
+CAUSE_AFTER_T5=$(get_previous_reboot_cause_json "$DPU")
+
+if (( HISTORY_AFTER_T5 == HISTORY_BEFORE_T5 )) || (( HISTORY_BEFORE_T5 >= MAX_HISTORY_FILES && HISTORY_AFTER_T5 == MAX_HISTORY_FILES )); then
+    pass "Test 5: No duplicate history entry (same cause after deferred check)"
+else
+    fail "Test 5: Unexpected history entry created ($HISTORY_BEFORE_T5 -> $HISTORY_AFTER_T5)"
+fi
+
+# Compare cause/comment fields (ignoring timestamp which may differ on re-persist)
+CAUSE_FIELDS_BEFORE_T5=$(extract_cause_fields "$CAUSE_BEFORE_T5")
+CAUSE_FIELDS_AFTER_T5=$(extract_cause_fields "$CAUSE_AFTER_T5")
+
+if [[ "$CAUSE_AFTER_T5" == "$CAUSE_BEFORE_T5" ]]; then
+    pass "Test 5: previous-reboot-cause.json unchanged (same cause, no re-persist)"
+elif [[ "$CAUSE_FIELDS_AFTER_T5" == "$CAUSE_FIELDS_BEFORE_T5" ]]; then
+    # Same cause/comment but different timestamp — chassisd re-persisted unnecessarily
+    # This is acceptable behavior (not a correctness bug) but worth noting
+    log_warn "Test 5: previous-reboot-cause.json timestamp changed (same cause re-persisted)"
+    log_info "  Before: $CAUSE_BEFORE_T5"
+    log_info "  After:  $CAUSE_AFTER_T5"
+    pass "Test 5: Reboot cause type unchanged (same cause after deferred check)"
+else
+    fail "Test 5: Reboot cause type changed unexpectedly"
+    log_info "  Before: $CAUSE_BEFORE_T5"
+    log_info "  After:  $CAUSE_AFTER_T5"
+fi
+
+# Check syslog — should NOT show "Reboot cause changed" or "New reboot detected"
+DEFERRED_LOG_T5=$(check_syslog_for "Reboot cause changed while chassisd was down" "$TIMESTAMP_T5")
+if [[ -z "$DEFERRED_LOG_T5" ]]; then
+    pass "Test 5: No deferred-cause-changed syslog (expected — cause is the same)"
+else
+    fail "Test 5: Unexpected 'Reboot cause changed' in syslog: $DEFERRED_LOG_T5"
+fi
+
+NEW_REBOOT_LOG_T5=$(check_syslog_for "New reboot detected" "$TIMESTAMP_T5")
+if [[ -z "$NEW_REBOOT_LOG_T5" ]]; then
+    pass "Test 5: No 'New reboot detected' syslog (expected — no prev_reboot_time.txt)"
+else
+    fail "Test 5: Unexpected 'New reboot detected' in syslog: $NEW_REBOOT_LOG_T5"
+fi
+
+# ===========================================================================
+# Test 6: Back-to-back reboot skips duplicate persist
+# ===========================================================================
+log_step "Test 6: Back-to-back rapid reboot skips duplicate persist"
+
+log_info "Ensuring $DPU is online..."
+wait_for_dpu_online "$DPU" 600 || {
+    skip "Test 6: $DPU not online, skipping"
+}
+
+# Reboot the DPU and let it fully cycle (creates a reboot cause entry)
+log_info "First reboot: establishing reboot cause..."
+reboot -d "$DPU" &
+wait_for_dpu_offline "$DPU" 300 || true
+wait_for_dpu_online "$DPU" 600 || {
+    fail "Test 6: $DPU did not recover from first reboot"
+}
+sleep 30
+
+TIMESTAMP_T6=$(date '+%Y-%m-%d %H:%M:%S')
+HISTORY_BEFORE_T6=$(get_reboot_history_count "$DPU")
+log_info "History count after first reboot: $HISTORY_BEFORE_T6"
+
+# Immediately reboot again — chassisd should detect the cause was already
+# persisted after this reboot time and skip the duplicate.
+log_info "Second reboot: rapid back-to-back (duplicate skip expected)..."
+reboot -d "$DPU" &
+wait_for_dpu_offline "$DPU" 300 || true
+wait_for_dpu_online "$DPU" 600 || {
+    fail "Test 6: $DPU did not recover from second reboot"
+}
+sleep 30
+
+HISTORY_AFTER_T6=$(get_reboot_history_count "$DPU")
+log_info "History count after second reboot: $HISTORY_AFTER_T6"
+
+# The second reboot has a distinct reboot_time (T2 > T1 from first reboot),
+# so the deferred='reboot' path correctly detects it as a new event and
+# persists it.  History should increase by exactly 1 from the second reboot.
+if (( HISTORY_BEFORE_T6 < MAX_HISTORY_FILES )); then
+    EXPECTED_T6=$(( HISTORY_BEFORE_T6 + 1 ))
+    if (( HISTORY_AFTER_T6 == EXPECTED_T6 )); then
+        pass "Test 6: History increased by exactly 1 (second reboot correctly persisted)"
+    elif (( HISTORY_AFTER_T6 == HISTORY_BEFORE_T6 )); then
+        fail "Test 6: No new history entry — second reboot should be persisted"
+    else
+        fail "Test 6: Expected $EXPECTED_T6 history entries, got $HISTORY_AFTER_T6"
+    fi
+else
+    if (( HISTORY_AFTER_T6 == MAX_HISTORY_FILES )); then
+        pass "Test 6: History at max ($MAX_HISTORY_FILES), rotation handled correctly"
+    else
+        fail "Test 6: Expected $MAX_HISTORY_FILES history entries at max, got $HISTORY_AFTER_T6"
+    fi
+fi
+
+# Check syslog for duplicate-skip detection (informational).
+# In the back-to-back case, each reboot has a distinct reboot_time so both
+# legitimately persist a new cause.  The "already persisted" message only
+# fires when the same reboot's cause was somehow recorded twice (e.g. race).
+IS_REBOOT_LOG_T6=$(check_syslog_for "Reboot cause already persisted after reboot" "$TIMESTAMP_T6")
+if [[ -n "$IS_REBOOT_LOG_T6" ]]; then
+    pass "Test 6: Syslog confirms duplicate reboot cause skipped"
+    log_info "  $IS_REBOOT_LOG_T6"
+else
+    log_info "Test 6: No 'already persisted' syslog (expected — each reboot has unique time)"
+fi
+
+# ===========================================================================
+# Test 7: Reboot during pmon restart — same cause skips persist (Path C3)
+# ===========================================================================
+log_step "Test 7: Reboot during pmon restart with same cause (Path C3 skip)"
+
+# Reproduces test_empty_to_offline_skips_same_reboot_cause on real hardware.
+# Related: sonic-net/sonic-buildimage#24275
+#
+# Flow:
+#   1. Establish baseline with one full reboot cycle (stored_cause).
+#   2. Immediately reboot DPU again (same cause type expected).
+#   3. While DPU is rebooting, stop pmon + delete STATE_DB entry (simulate
+#      flushed STATE_DB; forces prev_status=EMPTY on next chassisd start).
+#   4. Start pmon. Chassisd sees EMPTY→Offline (Path B: deferred='restart').
+#   5. DPU comes Online (Path C3). Since current_cause == stored_cause,
+#      chassisd skips persist but repopulates STATE_DB.
+#
+# Expected:
+#   - History count unchanged (persist_dpu_reboot_cause NOT called)
+#   - previous-reboot-cause.json timestamp unchanged (persist_dpu_reboot_time NOT called)
+#   - STATE_DB CHASSIS_MODULE_TABLE|DPU repopulated (update_dpu_reboot_cause_to_db called)
+
+log_info "Ensuring $DPU is online..."
+wait_for_dpu_online "$DPU" 600 || {
+    skip "Test 7: $DPU not online, skipping"
+}
+
+# Stage 1: Establish baseline with one full reboot cycle
+log_info "Stage 1: Baseline reboot to establish stored_cause..."
+reboot -d "$DPU" &
+wait_for_dpu_offline "$DPU" 300 || true
+wait_for_dpu_online "$DPU" 600 || {
+    fail "Test 7: $DPU did not recover from baseline reboot"
+}
+sleep 30
+
+HISTORY_BEFORE_T7=$(get_reboot_history_count "$DPU")
+CAUSE_BEFORE_T7=$(get_previous_reboot_cause_json "$DPU")
+log_info "Baseline: cause=$CAUSE_BEFORE_T7  history=$HISTORY_BEFORE_T7"
+if [[ -z "$CAUSE_BEFORE_T7" || "$CAUSE_BEFORE_T7" == "{}" ]]; then
+    fail "Test 7: Baseline previous-reboot-cause.json missing/empty"
+fi
+
+# Stage 2: Reboot DPU again, then stop pmon + flush STATE_DB while DPU is rebooting
+TIMESTAMP_T7=$(date '+%Y-%m-%d %H:%M:%S')
+STATE_KEY_T7="CHASSIS_MODULE_TABLE|${DPU}"
+
+log_info "Stage 2a: Trigger second 'reboot -d $DPU' (same cause expected)..."
+reboot -d "$DPU" &
+sleep 3
+
+log_info "Stage 2b: Stop pmon (kills chassisd; clears in-memory state)..."
+systemctl stop pmon
+sleep 5
+
+log_info "Stage 2c: Delete STATE_DB entry for $DPU (simulates flushed STATE_DB)..."
+sonic-db-cli STATE_DB DEL "$STATE_KEY_T7" >/dev/null 2>&1 || true
+
+log_info "Stage 2d: Start pmon (fresh chassisd; first poll → Path B 'restart')..."
+systemctl start pmon
+
+# Wait for chassisd to observe DPU offline (confirms Path B fired)
+log_info "Stage 2e: Waiting for chassisd to write $DPU=Offline..."
+WAIT_OBS=90
+ELAPSED_OBS=0
+while (( ELAPSED_OBS < WAIT_OBS )); do
+    OBS_STATUS=$(sonic-db-cli STATE_DB HGET "$STATE_KEY_T7" oper_status 2>/dev/null || echo "")
+    if [[ "$OBS_STATUS" == "Offline" ]]; then
+        log_info "chassisd observed $DPU=Offline after ${ELAPSED_OBS}s (Path B fired)"
+        break
+    fi
+    sleep 5; ELAPSED_OBS=$(( ELAPSED_OBS + 5 ))
+done
+if (( ELAPSED_OBS >= WAIT_OBS )); then
+    log_warn "chassisd never wrote $DPU=Offline; Path B may not have fired"
+fi
+
+log_info "Stage 2f: Waiting for $DPU to come back Online (→ Path C3)..."
+wait_for_dpu_online "$DPU" 600 || {
+    fail "Test 7: $DPU never came back Online after pmon restart"
+}
+sleep 45  # let chassisd Path C3 finish
+
+# Stage 3: Verify
+HISTORY_AFTER_T7=$(get_reboot_history_count "$DPU")
+CAUSE_AFTER_T7=$(get_previous_reboot_cause_json "$DPU")
+log_info "After: cause=$CAUSE_AFTER_T7  history=$HISTORY_AFTER_T7"
+
+# Verify history count unchanged
+if (( HISTORY_AFTER_T7 == HISTORY_BEFORE_T7 )); then
+    pass "Test 7: History count unchanged ($HISTORY_AFTER_T7 == $HISTORY_BEFORE_T7) — persist_cause NOT called"
+else
+    fail "Test 7: History count changed ($HISTORY_BEFORE_T7 -> $HISTORY_AFTER_T7) — persist_cause was called"
+fi
+
+# Verify previous-reboot-cause.json timestamp unchanged
+if [[ "$CAUSE_AFTER_T7" == "$CAUSE_BEFORE_T7" ]]; then
+    pass "Test 7: previous-reboot-cause.json unchanged — persist_time NOT called"
+else
+    CAUSE_FIELDS_BEFORE_T7=$(extract_cause_fields "$CAUSE_BEFORE_T7")
+    CAUSE_FIELDS_AFTER_T7=$(extract_cause_fields "$CAUSE_AFTER_T7")
+    if [[ "$CAUSE_FIELDS_AFTER_T7" == "$CAUSE_FIELDS_BEFORE_T7" ]]; then
+        log_warn "Test 7: Timestamp changed but cause type unchanged (re-persisted)"
+        log_info "  Before: $CAUSE_BEFORE_T7"
+        log_info "  After:  $CAUSE_AFTER_T7"
+        pass "Test 7: Cause type unchanged (acceptable — timestamp drift only)"
+    else
+        fail "Test 7: Cause type changed unexpectedly"
+        log_info "  Before: $CAUSE_BEFORE_T7"
+        log_info "  After:  $CAUSE_AFTER_T7"
+    fi
+fi
+
+# Verify STATE_DB repopulated (update_dpu_reboot_cause_to_db was called)
+STATE_EXISTS_T7=$(sonic-db-cli STATE_DB EXISTS "$STATE_KEY_T7" 2>/dev/null || echo "0")
+if [[ "$STATE_EXISTS_T7" == "1" ]]; then
+    pass "Test 7: STATE_DB $STATE_KEY_T7 repopulated — update_dpu_reboot_cause_to_db called"
+else
+    fail "Test 7: STATE_DB $STATE_KEY_T7 NOT repopulated"
+fi
+
+# Check syslog — should NOT show "New reboot detected" or "Reboot cause changed"
+DEFERRED_LOG_T7=$(check_syslog_for "Reboot cause changed while chassisd was down" "$TIMESTAMP_T7")
+if [[ -z "$DEFERRED_LOG_T7" ]]; then
+    pass "Test 7: No 'Reboot cause changed' syslog (same cause — expected)"
+else
+    fail "Test 7: Unexpected 'Reboot cause changed' in syslog: $DEFERRED_LOG_T7"
+fi
+
+NEW_REBOOT_LOG_T7=$(check_syslog_for "New reboot detected" "$TIMESTAMP_T7")
+if [[ -z "$NEW_REBOOT_LOG_T7" ]]; then
+    pass "Test 7: No 'New reboot detected' syslog (expected)"
+else
+    fail "Test 7: Unexpected 'New reboot detected' in syslog: $NEW_REBOOT_LOG_T7"
+fi
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+log_step "Test Summary"
+
+TOTAL=$(( PASSED + FAILED + SKIPPED ))
+echo ""
+echo -e "  Total:   $TOTAL"
+echo -e "  ${GREEN}Passed:  $PASSED${NC}"
+echo -e "  ${RED}Failed:  $FAILED${NC}"
+echo -e "  ${YELLOW}Skipped: $SKIPPED${NC}"
+echo ""
+
+if (( FAILED > 0 )); then
+    log_error "Some tests FAILED. Check syslog for chassisd messages:"
+    log_error "  grep -i 'chassisd\\|reboot.cause\\|transitioning' /var/log/syslog | tail -30"
+fi
+
+# ---------------------------------------------------------------------------
+# Cleanup prompt
+# ---------------------------------------------------------------------------
+echo ""
+read -p "Restore original chassisd? [y/N] " -r
+if [[ "$REPLY" =~ ^[Yy]$ ]]; then
+    docker cp "$BACKUP_CHASSISD" "$PMON_CONTAINER:$CHASSISD_PATH"
+    restart_chassisd
+    log_info "Original chassisd restored"
+else
+    log_info "Patched chassisd left in place at $PMON_CONTAINER:$CHASSISD_PATH"
+    log_info "To restore later: docker cp $BACKUP_CHASSISD $PMON_CONTAINER:$CHASSISD_PATH && systemctl restart pmon"
+fi
+
+log_step "Done"
+
+if (( FAILED > 0 )); then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
#### Description

Add end-to-end testbed verification script for SmartSwitch DPU reboot-cause
tracking in chassisd.  The script (`test_dpu_reboot_cause_persistence.sh`) runs
on a real SmartSwitch testbed and validates chassisd behavior across 7 scenarios:

1. Normal ONLINE→OFFLINE→ONLINE transition records reboot cause
2. Config reload during DPU reboot (EMPTY→OFFLINE→ONLINE deferred check)
3. Config reload with DPU already offline (admin-shutdown power cycle)
4. Reboot cause history is not lost after config reload
5. Deferred EMPTY→OFFLINE→ONLINE with same cause (no duplicate)
6. Back-to-back reboot skips duplicate persist
7. Reboot during pmon restart — same cause skips persist (Path C3)

Test 7 specifically reproduces the scenario from sonic-net/sonic-buildimage#24275
on real hardware (validates `test_empty_to_offline_skips_same_reboot_cause` unit test).

#### Motivation and Context

The DPU reboot-cause persistence logic in chassisd has complex state
machine paths that benefit from end-to-end validation on real hardware.

#### How Has This Been Tested?

- Script is a testbed-only verification tool (not part of CI)
- Validated script syntax with `bash -n`
- Designed to run on a SmartSwitch with at least one DPU
- Usage: `sudo bash test_dpu_reboot_cause_persistence.sh -d DPU0`

#### Additional Information (Optional)
