### PR TITLE
[sonic-ycabled] Add grpcio and protobuf to install_requires for trixie compatibility

### DIFF
--- a/sonic-ycabled/setup.py
+++ b/sonic-ycabled/setup.py
@@ -67,6 +67,8 @@ setup(
         # NOTE: This package also requires swsscommon, but it is not currently installed as a wheel
         'enum34; python_version < "3.4"',
         'sonic-py-common',
+        'grpcio',
+        'protobuf>=5.26.0',
     ],
     setup_requires=[
         'wheel',


### PR DESCRIPTION
## Description
The VS image build on Azure DevOps is failing on the `sonic_ycabled-1.0-py3-none-any.whl` target in the trixie environment (Python 3.13).

**Root cause:** `grpcio-tools==1.71.0` (pinned in the trixie build slave) generates `linkmgr_grpc_driver_pb2.py` with `runtime_version` checks that require `protobuf >= 5.x`. However, during pytest collection, the system `python3-protobuf` (3.21.12 from apt at `/usr/lib/python3/dist-packages`) can shadow the pip-installed version (5.29.6), causing:

```
ImportError: cannot import name 'runtime_version' from 'google.protobuf'
```

This results in collection errors for both `test_y_cable_helper.py` and `test_ycable.py`, failing the wheel build.

**Fix:** Add `grpcio` and `protobuf>=5.26.0` to `install_requires` in setup.py so pip ensures the correct protobuf version is installed and importable before tests run.

## Motivation
Unblocks the VS image build on master for trixie (Python 3.13).

Example failing build: https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_apis/build/builds/1130434/logs/177

## Test
- The fix adds runtime dependencies that were already implicitly required (the generated pb2 code imports from both packages)
- No functional change to ycabled behavior
