### PR TITLE
[xcvrd] Don't crash when no physical port is found

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1535,6 +1535,31 @@ class TestXcvrdScript(object):
         task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, mock_sfp_obj_dict, stop_event, sfp_error_event)
         task._init_port_sfp_status_sw_tbl(port_mapping, xcvr_table_helper, stop_event)
 
+    @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))
+    @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())
+    @patch('xcvrd.xcvrd.common.update_port_transceiver_status_table_sw')
+    def test_init_port_sfp_status_sw_tbl_no_physical_port_found(self, mock_update_status):
+        """
+        Test that when a logical port has no physical port, we successfully mark the transceiver
+        as removed and move on to the next logical port.
+        """
+        port_mapping = PortMapping()
+        port_change_event = PortChangeEvent('Ethernet0', 1, 0, PortChangeEvent.PORT_ADD)
+        port_mapping.handle_port_change_event(port_change_event)
+        # Simulate the "no physical ports found" condition
+        port_mapping.logical_port_name_to_physical_port_list = MagicMock(return_value=None)
+        mock_sfp_obj_dict = MagicMock()
+        stop_event = threading.Event()
+        xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
+        sfp_error_event = threading.Event()
+        task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, mock_sfp_obj_dict, stop_event, sfp_error_event)
+        task._init_port_sfp_status_sw_tbl(port_mapping, xcvr_table_helper, stop_event)
+
+        # The port with no physical mapping should be marked REMOVED
+        mock_update_status.assert_called_once()
+        assert mock_update_status.call_args.args[0] == 'Ethernet0'
+        assert mock_update_status.call_args.args[2] == SFP_STATUS_REMOVED
+
     @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/invalid/path', '/invalid/path')))
     def test_load_media_settings_missing_file(self):
         assert media_settings_parser.load_media_settings() == {}

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -370,6 +370,7 @@ class SfpStateUpdateTask(threading.Thread):
             if physical_port_list is None:
                 helper_logger.log_error("No physical ports found for logical port '{}' during sfp status table init".format(logical_port_name))
                 common.update_port_transceiver_status_table_sw(logical_port_name, xcvr_table_helper.get_status_sw_tbl(asic_index), sfp_status_helper.SFP_STATUS_REMOVED)
+                continue
 
             for physical_port in physical_port_list:
                 if stop_event.is_set():


### PR DESCRIPTION
Fixes #832.

#### Description
If no physical port is found for a logical port, `physical_port_list` will be `None`. `xcvrd` marks the transceiver as removed in this case, but does not skip to the next logical port and instead attempts to execute `for physical_port in physical_port_list`, which will crash since `None` is not iterable.

This PR fixes the issue by just simply continuing to the next logical port after marking the transceiver removed.

#### Motivation and Context
This change prevents `xcvrd` from crashing when encountering this bug.

#### How Has This Been Tested?
A failing unit-test was written and then made pass with the change in this PR.