### PR TITLE
[sonic-ycabled] prefer pip packages over distro packages to fix runtime_version ImportError

### DIFF
--- a/sonic-ycabled/tests/conftest.py
+++ b/sonic-ycabled/tests/conftest.py
@@ -29,3 +29,11 @@ def _prefer_newer_python_sites() -> None:
 
 
 _prefer_newer_python_sites()
+
+
+def pytest_sessionstart(session):
+    import google.protobuf
+
+    protobuf_path = getattr(google.protobuf, "__file__", "")
+    print(f"google.protobuf loaded from: {protobuf_path}")
+    assert "/usr/local/" in protobuf_path, protobuf_path

--- a/sonic-ycabled/tests/conftest.py
+++ b/sonic-ycabled/tests/conftest.py
@@ -1,0 +1,31 @@
+import site
+import sys
+
+
+def _prefer_newer_python_sites() -> None:
+    """Ensure test imports prefer user/local site-packages over distro site-packages."""
+    preferred = []
+
+    try:
+        preferred.append(site.getusersitepackages())
+    except Exception:
+        pass
+
+    for path in list(sys.path):
+        if path.startswith("/usr/local/lib/python") and path.endswith("/dist-packages"):
+            preferred.append(path)
+
+    ordered = []
+    seen = set()
+    for path in preferred:
+        if path and path not in seen:
+            ordered.append(path)
+            seen.add(path)
+
+    for path in reversed(ordered):
+        if path in sys.path:
+            sys.path.remove(path)
+        sys.path.insert(0, path)
+
+
+_prefer_newer_python_sites()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
When building `target/python-wheels/trixie/sonic_ycabled-1.0-py3-none-any.whl`, test failed with following error:
```
==================================== ERRORS ====================================
________________ ERROR collecting tests/test_y_cable_helper.py _________________
ImportError while importing test module '/sonic/src/sonic-platform-daemons/sonic-ycabled/tests/test_y_cable_helper.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_y_cable_helper.py:5: in <module>
    from ycable.ycable_utilities.y_cable_helper import *
ycable/ycable_utilities/y_cable_helper.py:21: in <module>
    from proto_out import linkmgr_grpc_driver_pb2_grpc
proto_out/linkmgr_grpc_driver_pb2_grpc.py:6: in <module>
    from proto_out import linkmgr_grpc_driver_pb2 as proto__out_dot_linkmgr__grpc__driver__pb2
proto_out/linkmgr_grpc_driver_pb2.py:9: in <module>
    from google.protobuf import runtime_version as _runtime_version
E   ImportError: cannot import name 'runtime_version' from 'google.protobuf' (/usr/lib/python3/dist-packages/google/protobuf/__init__.py)
```
The build environment contains two protobuf installations:

- a pip-installed protobuf (new, in /usr/local/lib/python3.13/dist-packages)
```
Step 30/78 : RUN pip3 install grpcio==1.71.0 grpcio-tools==1.71.0
 ---> Running in 47803f5069b2
Collecting grpcio==1.71.0
  Downloading grpcio-1.71.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (3.8 kB)
Collecting grpcio-tools==1.71.0
  Downloading grpcio_tools-1.71.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (5.3 kB)
Collecting protobuf<6.0dev,>=5.26.1 (from grpcio-tools==1.71.0)
  .
  .
  .
Successfully installed grpcio-1.71.0 grpcio-tools-1.71.0 protobuf-5.29.6 setuptools-75.8.0
```
- a distro protobuf from apt (older, in /usr/lib/python3/dist-packages)
```
Step 20/78 : RUN eatmydata apt-get install -y         ...        python3-protobuf         python3-grpcio 
.
.
.
Setting up python3-protobuf (3.21.12-11) ...
```
During dependency install, pip confirms the new protobuf satisfies ycabled (protobuf>=5.26.0). But during pytest import, Python loads google.protobuf from the distro path (/usr/lib/...) first. The generated gRPC file expects a newer protobuf API (runtime_version), which does not exist in that older distro package, so test collection fails with ImportError.
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Removing `python3-protobuf` from the apt-get install list is not fixing the issue, because when installing `python3-grpcio`, `python3-protobuf` will also get installed. `python3-grpcio` is needed for p4lang targets, can not be removed.
This change is to prioritizes newer version for test execution.
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
