### PR TITLE
[cmis] Fix issue: Potential race condition between split ports while doing DPSM

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -3800,6 +3800,50 @@ class TestXcvrdScript(object):
 
         assert task.is_cmis_application_update_required(mock_xcvr_api, app_new, host_lanes_mask) == expected
 
+    @pytest.mark.parametrize("dp_state, timer_expired, expect_reinit, expect_forced_tx_cleared, expect_continue", [
+        ('DataPathDeactivated', False, False, True, True),
+        ('DataPathInitialized', False, False, True, True),
+        ('DataPathInit', False, False, True, True),
+        ('DataPathActivated', True, True, False, False),
+    ])
+    def test_CmisManagerTask_dp_pre_init_check_forced_tx_disabled_datapath_states(
+            self, dp_state, timer_expired, expect_reinit, expect_forced_tx_cleared, expect_continue):
+        """When forced_tx_disabled is set, DP_PRE_INIT_CHECK accepts DataPathInit as a valid Tx-off state."""
+        mock_xcvr_api = MagicMock()
+        mock_xcvr_api.get_datapath_state = MagicMock(return_value=gen_cmis_dp_state_dict(dp_state))
+        mock_xcvr_api.is_coherent_module = MagicMock(return_value=False)
+
+        port_mapping = PortMapping()
+        stop_event = threading.Event()
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event, platform_chassis=MagicMock())
+        task.port_dict['Ethernet0'] = {
+            'api': mock_xcvr_api,
+            'host_lanes_mask': 0xFF,
+            'appl': 1,
+            'cmis_expired': time.time() + 100,
+            'cmis_retries': 0,
+            'forced_tx_disabled': True,
+        }
+        task.is_cmis_application_update_required = MagicMock(return_value=True)
+        task.is_timer_expired = MagicMock(return_value=timer_expired)
+        task.force_cmis_reinit = MagicMock()
+        task.update_port_transceiver_status_table_sw_cmis_state = MagicMock()
+
+        assert task.handle_cmis_dp_pre_init_check_state('Ethernet0') == expect_continue
+
+        if expect_reinit:
+            task.force_cmis_reinit.assert_called_once_with('Ethernet0', 1)
+        else:
+            task.force_cmis_reinit.assert_not_called()
+
+        assert task.port_dict['Ethernet0']['forced_tx_disabled'] == (not expect_forced_tx_cleared)
+
+        if expect_continue:
+            task.update_port_transceiver_status_table_sw_cmis_state.assert_called_once_with(
+                'Ethernet0', CMIS_STATE_DP_DEINIT)
+        else:
+            task.update_port_transceiver_status_table_sw_cmis_state.assert_not_called()
+
     @pytest.mark.parametrize("ifname, expected", [
         ('1.6TBASE-CR8 (Clause179)', 1600000),
         ('1.6TAUI-8 (Annex176E)', 1600000),

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -3800,50 +3800,6 @@ class TestXcvrdScript(object):
 
         assert task.is_cmis_application_update_required(mock_xcvr_api, app_new, host_lanes_mask) == expected
 
-    @pytest.mark.parametrize("dp_state, timer_expired, expect_reinit, expect_forced_tx_cleared, expect_continue", [
-        ('DataPathDeactivated', False, False, True, True),
-        ('DataPathInitialized', False, False, True, True),
-        ('DataPathInit', False, False, True, True),
-        ('DataPathActivated', True, True, False, False),
-    ])
-    def test_CmisManagerTask_dp_pre_init_check_forced_tx_disabled_datapath_states(
-            self, dp_state, timer_expired, expect_reinit, expect_forced_tx_cleared, expect_continue):
-        """When forced_tx_disabled is set, DP_PRE_INIT_CHECK accepts DataPathInit as a valid Tx-off state."""
-        mock_xcvr_api = MagicMock()
-        mock_xcvr_api.get_datapath_state = MagicMock(return_value=gen_cmis_dp_state_dict(dp_state))
-        mock_xcvr_api.is_coherent_module = MagicMock(return_value=False)
-
-        port_mapping = PortMapping()
-        stop_event = threading.Event()
-        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event, platform_chassis=MagicMock())
-        task.port_dict['Ethernet0'] = {
-            'api': mock_xcvr_api,
-            'host_lanes_mask': 0xFF,
-            'appl': 1,
-            'cmis_expired': time.time() + 100,
-            'cmis_retries': 0,
-            'forced_tx_disabled': True,
-        }
-        task.is_cmis_application_update_required = MagicMock(return_value=True)
-        task.is_timer_expired = MagicMock(return_value=timer_expired)
-        task.force_cmis_reinit = MagicMock()
-        task.update_port_transceiver_status_table_sw_cmis_state = MagicMock()
-
-        assert task.handle_cmis_dp_pre_init_check_state('Ethernet0') == expect_continue
-
-        if expect_reinit:
-            task.force_cmis_reinit.assert_called_once_with('Ethernet0', 1)
-        else:
-            task.force_cmis_reinit.assert_not_called()
-
-        assert task.port_dict['Ethernet0']['forced_tx_disabled'] == (not expect_forced_tx_cleared)
-
-        if expect_continue:
-            task.update_port_transceiver_status_table_sw_cmis_state.assert_called_once_with(
-                'Ethernet0', CMIS_STATE_DP_DEINIT)
-        else:
-            task.update_port_transceiver_status_table_sw_cmis_state.assert_not_called()
-
     @pytest.mark.parametrize("ifname, expected", [
         ('1.6TBASE-CR8 (Clause179)', 1600000),
         ('1.6TAUI-8 (Annex176E)', 1600000),
@@ -4692,9 +4648,14 @@ class TestXcvrdScript(object):
     def test_CmisManagerTask_task_worker_host_tx_ready_false_to_true(self, mock_chassis, mock_get_status_sw_tbl):
         mock_get_status_sw_tbl = Table("STATE_DB", TRANSCEIVER_STATUS_TABLE)
         mock_xcvr_api = MagicMock()
-        mock_xcvr_api.set_datapath_deinit = MagicMock(return_value=True)
+        dp_deinit_tx_disable_calls = []
+        mock_xcvr_api.set_datapath_deinit = MagicMock(
+            side_effect=lambda *args, **kwargs: dp_deinit_tx_disable_calls.append('set_datapath_deinit') or True
+        )
         mock_xcvr_api.set_datapath_init = MagicMock(return_value=True)
-        mock_xcvr_api.tx_disable_channel = MagicMock(return_value=True)
+        mock_xcvr_api.tx_disable_channel = MagicMock(
+            side_effect=lambda *args, **kwargs: dp_deinit_tx_disable_calls.append('tx_disable_channel') or True
+        )
         mock_xcvr_api.set_lpmode = MagicMock(return_value=True)
         mock_xcvr_api.set_application = MagicMock(return_value=True)
         mock_xcvr_api.is_flat_memory = MagicMock(return_value=False)
@@ -4858,7 +4819,9 @@ class TestXcvrdScript(object):
         task.task_worker()
 
         assert task.post_port_active_apsel_to_db.call_count == 1
+        assert mock_xcvr_api.set_datapath_deinit.call_count == 1
         assert mock_xcvr_api.tx_disable_channel.call_count == 1
+        assert dp_deinit_tx_disable_calls == ['set_datapath_deinit', 'tx_disable_channel']
         assert common.get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_sw_tbl(task.get_asic_id('Ethernet0'))) == CMIS_STATE_READY
         assert task.port_dict['Ethernet0']['forced_tx_disabled'] == True
 

--- a/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
+++ b/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
@@ -968,9 +968,13 @@ class CmisManagerTask(threading.Thread):
             # Ensure that Tx is OFF
             # Transceiver will remain in DataPathDeactivated state while it is in Low Power Mode (even if Tx is disabled)
             # Transceiver will enter DataPathInitialized state if Tx was disabled after CMIS initialization was completed
-            if not self.check_datapath_state(api, host_lanes_mask, ['DataPathDeactivated', 'DataPathInitialized']):
+            # Rarely, a ModuleReady module may enter DataPathInit as part of the hardware initialization flow before
+            # explicitly setting the datapath deinit
+            if not self.check_datapath_state(api, host_lanes_mask, ['DataPathDeactivated',
+                                                                    'DataPathInitialized',
+                                                                    'DataPathInit']):
                 if self.is_timer_expired(expired):
-                    self.log_notice("{}: timeout for 'DataPathDeactivated/DataPathInitialized'".format(lport))
+                    self.log_notice("{}: timeout for 'DataPathDeactivated/DataPathInitialized/DataPathInit'".format(lport))
                     self.force_cmis_reinit(lport, retries + 1)
                 return False
             self.port_dict[lport]['forced_tx_disabled'] = False

--- a/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
+++ b/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
@@ -928,6 +928,8 @@ class CmisManagerTask(threading.Thread):
             if is_fast_reboot and self.check_datapath_state(api, host_lanes_mask, ['DataPathActivated']):
                 self.log_notice("{} Skip datapath re-init in fast-reboot".format(lport))
             else:
+                self.log_notice("{} DEINIT datapath".format(lport))
+                api.set_datapath_deinit(host_lanes_mask)
                 self.log_notice("{} Forcing Tx laser OFF".format(lport))
                 # Force DataPath re-init
                 api.tx_disable_channel(media_lanes_mask, True)
@@ -968,13 +970,9 @@ class CmisManagerTask(threading.Thread):
             # Ensure that Tx is OFF
             # Transceiver will remain in DataPathDeactivated state while it is in Low Power Mode (even if Tx is disabled)
             # Transceiver will enter DataPathInitialized state if Tx was disabled after CMIS initialization was completed
-            # Rarely, a ModuleReady module may enter DataPathInit as part of the hardware initialization flow before
-            # explicitly setting the datapath deinit
-            if not self.check_datapath_state(api, host_lanes_mask, ['DataPathDeactivated',
-                                                                    'DataPathInitialized',
-                                                                    'DataPathInit']):
+            if not self.check_datapath_state(api, host_lanes_mask, ['DataPathDeactivated', 'DataPathInitialized']):
                 if self.is_timer_expired(expired):
-                    self.log_notice("{}: timeout for 'DataPathDeactivated/DataPathInitialized/DataPathInit'".format(lport))
+                    self.log_notice("{}: timeout for 'DataPathDeactivated/DataPathInitialized'".format(lport))
                     self.force_cmis_reinit(lport, retries + 1)
                 return False
             self.port_dict[lport]['forced_tx_disabled'] = False


### PR DESCRIPTION
## Why I did it

Fix issue: https://github.com/sonic-net/sonic-buildimage/issues/27373

CMIS datapath deinitialization should follow the expected software deinit sequence. When forcing a datapath re-init because `host_tx_ready` is false or the port is administratively down, xcvrd should request datapath deinit before disabling media-side Tx.

This keeps the forced re-init path consistent with the normal `CMIS_STATE_DP_DEINIT` flow and CMIS datapath state machine behavior.

## How I did it

Updated the forced re-init path in `cmis_manager_task.py` to call `set_datapath_deinit()` before `tx_disable_channel()`.

Updated the existing `test_CmisManagerTask_task_worker_host_tx_ready_false_to_true` unit test to record the mock API call order and verify that datapath deinit is issued before Tx disable.

## How to verify it

Run the xcvrd unit test:

```bash
python3 -m pytest sonic-xcvrd/tests/test_xcvrd.py -k test_CmisManagerTask_task_worker_host_tx_ready_false_to_true