### PR TITLE
[chassisd] Record operator in DPU reboot-cause 'user' field

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -1019,6 +1019,21 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
         except FileNotFoundError:
             return None
 
+    def retrieve_dpu_reboot_user(self, module):
+        """Retrieve the user who issued a user-initiated DPU reboot/shutdown.
+
+        Returns "N/A" for hardware or auto-detected reboots where no user is
+        recorded (matching the NPU default in determine-reboot-cause).
+        """
+        path = os.path.join(MODULE_REBOOT_CAUSE_DIR, module.lower(), "prev_reboot_user.txt")
+
+        try:
+            with open(path, 'r') as f:
+                user = f.read().strip()
+                return user if user else "N/A"
+        except FileNotFoundError:
+            return "N/A"
+
     def persist_dpu_reboot_cause(self, reboot_cause, module):
         """Persist the reboot cause information and handle file rotation."""
         # Extract cause and comment from the reboot_cause
@@ -1037,11 +1052,16 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
         if prev_reboot_time is None:
             prev_reboot_time = self._get_current_time_str()
 
+        reboot_user = self.retrieve_dpu_reboot_user(module)
+
         file_name = f"{prev_reboot_time}_reboot_cause.json"
         prev_reboot_path = os.path.join(MODULE_REBOOT_CAUSE_DIR, module.lower(), "prev_reboot_time.txt")
+        prev_reboot_user_path = os.path.join(MODULE_REBOOT_CAUSE_DIR, module.lower(), "prev_reboot_user.txt")
 
         if os.path.exists(prev_reboot_path):
             os.remove(prev_reboot_path)
+        if os.path.exists(prev_reboot_user_path):
+            os.remove(prev_reboot_user_path)
 
         file_path = self._get_history_path(module, file_name)
         try:
@@ -1053,6 +1073,7 @@ class SmartSwitchModuleUpdater(ModuleUpdater):
             "cause": cause,
             "comment": comment,
             "device": module,
+            "user": reboot_user,
             "time": formatted_time,
             "name": prev_reboot_time,
         }

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -713,6 +713,80 @@ def test_smartswitch_module_db_update():
         module_updater.update_dpu_reboot_cause_to_db(name)
 
 
+def test_persist_dpu_reboot_cause_includes_user_field():
+    """The reboot-cause JSON written by chassisd must contain a 'user' field so
+    that entries rewritten by update_dpu_reboot_cause_to_db stay schema-consistent
+    with the entries produced by process-reboot-cause (which always sets 'user').
+    For hardware/auto-detected reboots no user is recorded, so 'user' is 'N/A'
+    (matching the NPU determine-reboot-cause default)."""
+    chassis = MockSmartSwitchChassis()
+    module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
+
+    captured = {}
+
+    def capture_dump(obj, fp, *args, **kwargs):
+        captured.update(obj)
+
+    with patch("os.path.exists", return_value=True), \
+         patch("os.makedirs"), \
+         patch("builtins.open", mock_open(read_data="Power loss")), \
+         patch("os.remove"), \
+         patch("os.symlink"), \
+         patch.object(module_updater, "_rotate_files"), \
+         patch.object(module_updater, "retrieve_dpu_reboot_time", return_value="2024_11_13_15_06_40"), \
+         patch.object(module_updater, "retrieve_dpu_reboot_user", return_value="N/A"), \
+         patch("chassisd.json.dump", side_effect=capture_dump):
+
+        module_updater.persist_dpu_reboot_cause("Power loss,test comment", "DPU0")
+
+    assert "user" in captured
+    assert captured["user"] == "N/A"
+
+
+def test_persist_dpu_reboot_cause_records_user_for_user_initiated_reboot():
+    """For a user-initiated DPU reboot, reboot_smartswitch_helper persists the
+    operator's username (via retrieve_dpu_reboot_user); chassisd must record it
+    in the reboot-cause 'user' field, mirroring the NPU reboot-cause flow."""
+    chassis = MockSmartSwitchChassis()
+    module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
+
+    captured = {}
+
+    def capture_dump(obj, fp, *args, **kwargs):
+        captured.update(obj)
+
+    with patch("os.path.exists", return_value=True), \
+         patch("os.makedirs"), \
+         patch("builtins.open", mock_open(read_data="Power loss")), \
+         patch("os.remove"), \
+         patch("os.symlink"), \
+         patch.object(module_updater, "_rotate_files"), \
+         patch.object(module_updater, "retrieve_dpu_reboot_time", return_value="2024_11_13_15_06_40"), \
+         patch.object(module_updater, "retrieve_dpu_reboot_user", return_value="admin"), \
+         patch("chassisd.json.dump", side_effect=capture_dump):
+
+        module_updater.persist_dpu_reboot_cause("Power loss,test comment", "DPU0")
+
+    assert captured["user"] == "admin"
+
+
+def test_retrieve_dpu_reboot_user():
+    """retrieve_dpu_reboot_user returns the recorded username (stripped), and
+    'N/A' when no prev_reboot_user.txt marker exists or it is empty (matching
+    the NPU non-user-reboot default)."""
+    chassis = MockSmartSwitchChassis()
+    module_updater = SmartSwitchModuleUpdater(SYSLOG_IDENTIFIER, chassis)
+
+    with patch("builtins.open", mock_open(read_data="admin\n")):
+        assert module_updater.retrieve_dpu_reboot_user("DPU0") == "admin"
+
+    with patch("builtins.open", mock_open(read_data="  \n")):
+        assert module_updater.retrieve_dpu_reboot_user("DPU0") == "N/A"
+
+    with patch("builtins.open", side_effect=FileNotFoundError):
+        assert module_updater.retrieve_dpu_reboot_user("DPU0") == "N/A"
+
+
 def test_platform_json_file_exists_and_valid():
     """Test case where the platform JSON file exists with valid data."""
     chassis = MockSmartSwitchChassis()


### PR DESCRIPTION
#### Description

DPU reboot-cause history records written by `chassisd` hardcoded the dict in
`persist_dpu_reboot_cause()` **without a `user` key**, so when
`update_dpu_reboot_cause_to_db()` deletes and rewrites the
`REBOOT_CAUSE|DPU<N>|*` keys in `CHASSIS_STATE_DB`, the `user` field
disappeared — diverging from `process-reboot-cause` (sonic-host-services),
which always writes `user`.

This change:
- Adds the `user` field to the persisted DPU reboot-cause record.
- Populates it with the operator who triggered a **user-initiated** DPU
  reboot/shutdown, read from a one-shot marker
  `/host/reboot-cause/module/<dpu>/prev_reboot_user.txt` written by the
  sonic-utilities producers (`reboot_smartswitch_helper` and
  `config chassis modules shutdown` — see companion PR). chassisd reads the
  marker via `retrieve_dpu_reboot_user()` and removes it after use.
- Defaults `user` to **`N/A`** for hardware/auto-detected reboots where no
  marker exists, matching the NPU `determine-reboot-cause` default and keeping
  the JSON schema consistent with `process-reboot-cause`.

#### Motivation and Context

Addresses sonic-net/sonic-buildimage#28149 — on SmartSwitch, DPU reboot-cause
entries were schema-inconsistent because `chassisd` omitted the `user` field
when rewriting `CHASSIS_STATE_DB`. Beyond just restoring schema parity, this
attributes user-initiated DPU reboots/shutdowns, mirroring the NPU
reboot-cause `user` field shown by `show reboot-cause history`.

Producer (marker-writer) companion PR in sonic-utilities: https://github.com/sonic-net/sonic-utilities/pull/4653

#### How Has This Been Tested?

Unit tests — full `sonic-chassisd` suite passes (53 tests). New/updated cases:
- `test_persist_dpu_reboot_cause_includes_user_field` — `user` present, defaults to `N/A`.
- `test_persist_dpu_reboot_cause_records_user_for_user_initiated_reboot` — records the marker user (`admin`).
- `test_retrieve_dpu_reboot_user` — returns the user when the marker is present, `N/A` when empty/missing.

Manual (SmartSwitch DUT):
1. Trigger a user-initiated DPU reboot (`reboot -d DPU0`) or shutdown (`config chassis modules shutdown DPU0`).
2. After chassisd processes it: `redis-cli -h redis_chassis.server -p 6380 -n 13 HGETALL "REBOOT_CAUSE|DPU0|<name>"` → `user` = operator.
3. Hardware/auto reboot → `user` = `N/A`.

#### Additional Information (Optional)

This is the consumer side. The marker files are produced by the companion
sonic-utilities PR; both are required for end-to-end user attribution.
