### PR TITLE
[BMC] Fix bmcctld startup race and honor admin_status on air-cooled boot

### DIFF
--- a/sonic-bmcctld/scripts/bmcctld
+++ b/sonic-bmcctld/scripts/bmcctld
@@ -855,6 +855,22 @@ class BmcEventHandler(EventLogger):
         self.sel.addSelectable(self.rack_mgr_alert_sub)
         self.sel.addSelectable(self.system_leak_sub)
 
+    def seed_chassis_module_admin_status(self):
+        """
+        Record the current CONFIG admin_status before the event loop starts.
+
+        SubscriberStateTable replays existing CHASSIS_MODULE rows on subscribe. Without
+        seeding, the replay can look like a new admin transition and enqueue
+        ACTION_POWER_ON before HOST_STATE is synchronized and before the main-thread
+        action loop is ready to process the queue.
+        """
+        admin_status = self.policy_reader._get_chassis_module_entry().get(FIELD_ADMIN_STATUS, "")
+        if admin_status:
+            self._last_chassis_module_admin_status[SWITCH_HOST_MODULE_KEY] = admin_status
+            self.log_info(
+                "Seeded CHASSIS_MODULE admin_status dedup for {}: {}".format(
+                    SWITCH_HOST_MODULE_KEY, admin_status))
+
     # ---- public ----
 
     def run_event_loop(self):
@@ -1293,21 +1309,30 @@ class BmcctldDaemon(daemon_base.DaemonBase):
         """
         Called once by the main loop.  Startup flow:
 
-          1. If Switch-Host is already ONLINE (daemon restart): skip boot
-             sequence, refresh STATE_DB, enter action loop immediately.
-          2. Non-liquid-cooled: power on immediately, no boot delay or
-             leak/alert checks, then enter action loop.
-          3. Liquid-cooled (normal boot): run _initial_power_on_sequence
-             (boot delay + leak check), then enter action loop.
+          1. Sync HOST_STATE from live oper_status and seed CONFIG dedup state.
+          2. Start the BmcEventHandler thread (CLI admin up/down, Rack Manager, leaks).
+          3. If Switch-Host is already ONLINE: skip boot power-on sequence.
+          4. Non-liquid-cooled + OFFLINE + admin_status=up: power on immediately.
+          5. Liquid-cooled + OFFLINE: run _initial_power_on_sequence (boot delay).
+          6. Enter the action processing loop.
 
-        The BmcEventHandler thread is always started first so CLI admin
-        commands are captured regardless of the startup path.
+        HOST_STATE sync and CONFIG dedup (step 1) run before the event thread so
+        SubscriberStateTable replays are treated as already handled and do not
+        enqueue ACTION_POWER_ON ahead of action-loop readiness. The BmcEventHandler
+        thread (step 2) is started before the boot sequence so CLI admin commands
+        and other CONFIG/STATE events are captured regardless of the startup path.
+        startup power-on or the action loop.
 
         Returns False to terminate the outer while-loop.
         """
         self._event_log.log_notice("bmcctld starting up")
 
-        # Always start the event thread — it handles CLI admin up/down commands
+        # Publish HOST_STATE and seed CONFIG dedup before SubscriberStateTable
+        # replays can enqueue ACTION_POWER_ON before the action loop is ready.
+        self.controller.init_host_state()
+        self.event_handler.seed_chassis_module_admin_status()
+
+        # Start the event thread — it handles CLI admin up/down commands
         # (CHASSIS_MODULE admin_status) regardless of cooling type.
         event_thread = threading.Thread(
             target=self.event_handler.run_event_loop,
@@ -1321,11 +1346,18 @@ class BmcctldDaemon(daemon_base.DaemonBase):
         if self.controller.get_oper_status() == SWITCH_HOST_ONLINE:
             self._event_log.log_notice("STARTUP: Switch-Host already ONLINE (daemon restart); "
                                        "skipping boot sequence")
-            self.controller.init_host_state()
         elif not self.chassis.is_liquid_cooled():
-            self._event_log.log_notice("STARTUP: non-liquid-cooled system — "
-                                       "immediate power_on, no additional checks")
-            self.controller.power_on()
+            admin_status = self.policy_reader.get_switch_host_admin_status()
+            if admin_status != ADMIN_UP:
+                self._event_log.log_notice(
+                    "STARTUP: SWITCH-HOST admin_status='{}'; "
+                    "Switch-Host will remain powered off. "
+                    "Run 'config chassis modules startup SWITCH-HOST' to power on.".format(
+                        admin_status))
+            else:
+                self._event_log.log_notice("STARTUP: non-liquid-cooled system — "
+                                           "immediate power_on, no additional checks")
+                self.controller.power_on()
         else:
             # Liquid-cooled: wait for Rack Manager to verify liquid flow, check for
             # leaks/alerts, then power on if safe.

--- a/sonic-bmcctld/tests/test_bmcctld.py
+++ b/sonic-bmcctld/tests/test_bmcctld.py
@@ -680,6 +680,26 @@ class TestBmcEventHandlerChassisModule:
         item = event_handler.action_queue.get_nowait()
         assert item.action == bmcctld.ACTION_POWER_ON
 
+    def test_seed_chassis_module_admin_status_ignores_config_replay(self, event_handler, controller):
+        """CONFIG replay after seed must not enqueue ACTION_POWER_ON."""
+        event_handler.policy_reader._get_chassis_module_entry = MagicMock(
+            return_value={bmcctld.FIELD_ADMIN_STATUS: bmcctld.ADMIN_UP})
+        _set_table_entry(controller.host_state_table, bmcctld.HOST_STATE_KEY,
+                         {bmcctld.FIELD_DEVICE_STATUS: bmcctld.SWITCH_HOST_OFFLINE})
+
+        event_handler.seed_chassis_module_admin_status()
+        event_handler.critical_event_checker.has_any_critical_event = MagicMock(return_value=False)
+        event_handler._handle_chassis_module(
+            bmcctld.SWITCH_HOST_MODULE_KEY,
+            {bmcctld.FIELD_ADMIN_STATUS: bmcctld.ADMIN_UP},
+        )
+        assert event_handler.action_queue.empty()
+
+    def test_seed_chassis_module_admin_status_noop_when_config_missing(self, event_handler):
+        event_handler.policy_reader._get_chassis_module_entry = MagicMock(return_value={})
+        event_handler.seed_chassis_module_admin_status()
+        assert event_handler._last_chassis_module_admin_status == {}
+
 
 # --------------------------------------------------------------------------
 # Tests: BmcEventHandler - System leak events
@@ -1283,10 +1303,12 @@ class TestBmcctldDaemonRun:
         with patch('sonic_platform.platform.Platform') as MockPlatform:
             MockPlatform.return_value.get_chassis.return_value = chassis
             daemon = bmcctld.BmcctldDaemon(bmcctld.SYSLOG_IDENTIFIER)
+            daemon.policy_reader.get_switch_host_admin_status = MagicMock(
+                return_value=bmcctld.ADMIN_UP)
         return daemon
 
     def test_run_not_liquid_cooled_powers_on_immediately(self, chassis):
-        """Non-liquid-cooled: power_on is called immediately, no boot delay or leak checks."""
+        """Non-liquid-cooled + admin up: power_on is called immediately."""
         chassis.switch_host.set_oper_status(MockModule.MODULE_STATUS_OFFLINE)
         daemon = self._make_daemon(chassis)
         daemon.controller.power_on = MagicMock(return_value=True)
@@ -1296,6 +1318,20 @@ class TestBmcctldDaemonRun:
         result = daemon.run()
         assert result is False
         daemon.controller.power_on.assert_called_once()
+        daemon._run_action_loop.assert_called_once()
+
+    def test_run_not_liquid_cooled_skips_power_on_when_admin_down(self, chassis):
+        """Non-liquid-cooled + admin down: Switch-Host stays off at BMC reboot."""
+        chassis.switch_host.set_oper_status(MockModule.MODULE_STATUS_OFFLINE)
+        daemon = self._make_daemon(chassis)
+        daemon.policy_reader.get_switch_host_admin_status = MagicMock(
+            return_value=bmcctld.ADMIN_DOWN)
+        daemon.controller.power_on = MagicMock(return_value=True)
+        daemon._run_action_loop = MagicMock()
+        daemon.event_handler.run_event_loop = MagicMock()
+        chassis.set_liquid_cooled(False)
+        daemon.run()
+        daemon.controller.power_on.assert_not_called()
         daemon._run_action_loop.assert_called_once()
 
     def test_run_not_liquid_cooled_skips_initial_sequence_but_starts_event_thread(self, chassis):
@@ -1327,6 +1363,30 @@ class TestBmcctldDaemonRun:
         daemon.controller.power_on.assert_not_called()
         daemon.controller.init_host_state.assert_called_once()
         daemon._run_action_loop.assert_called_once()
+
+    def test_run_initializes_host_state_before_event_thread(self, chassis):
+        """HOST_STATE sync and CONFIG dedup happen before the event thread starts."""
+        chassis.switch_host.set_oper_status(MockModule.MODULE_STATUS_ONLINE)
+        daemon = self._make_daemon(chassis)
+        call_order = []
+
+        def track_init():
+            call_order.append("init_host_state")
+
+        def track_seed():
+            call_order.append("seed")
+
+        def track_event_loop():
+            call_order.append("event_loop")
+
+        daemon.controller.init_host_state = MagicMock(side_effect=track_init)
+        daemon.event_handler.seed_chassis_module_admin_status = MagicMock(side_effect=track_seed)
+        daemon.event_handler.run_event_loop = MagicMock(side_effect=track_event_loop)
+        daemon._run_action_loop = MagicMock()
+        chassis.set_liquid_cooled(True)
+        daemon.run()
+        assert call_order.index("init_host_state") < call_order.index("seed")
+        assert call_order.index("seed") < call_order.index("event_loop")
 
     def test_run_liquid_cooled_runs_full_sequence(self, chassis):
         """Liquid-cooled: event thread and initial power-on sequence are both invoked."""


### PR DESCRIPTION
Fix bmcctld startup race and honor admin_status on air-cooled boot

#### Description
1) sync HOST_STATE and seed CHASSIS_MODULE admin_status dedup before starting the BmcEventHandler thread;
add BmcEventHandler.seed_chassis_module_admin_status() so CONFIG SubscriberStateTable replays are treated as already handled. 
2) For non-liquid-cooled platforms, gate automatic startup power_on on CONFIG admin_status=up and skip power_on if admin_status=down. Update run() docstring and add unit tests for seed/dedup, startup ordering and admin-down skip paths.


#### Motivation and Context
1) bmcctld start can enqueue ACTION_POWER_ON from CONFIG replay before HOST_STATE init and action-loop readiness; CLI changes are logged as "initiating ..." but may never reach "Executing action ...". With a single action-loop consumer, an early or stuck power_on blocks subsequent CLI-driven actions until bmcctld restart.
2) Also fix air-cooled boot ignoring if CONFIG_DB has admin_status=down.

#### How Has This Been Tested?
 run() order is init_host_state() -> seed_chassis_module_admin_status() ->
event thread -> boot sequence -> action loop. Dedup seed records the current CONFIG admin_status so replay does not enqueue ACTION_POWER_ON. Non-liquid OFFLINE boot checks get_switch_host_admin_status() and skips power_on unless admin is up.

#### Additional Information (Optional)
New unit tests cover CONFIG replay dedup after seed, HOST_STATE init before event thread, non-liquid skip when admin_status=down, and non-liquid power_on when admin_status=up. Nokia H6-128 BMC verified: first-install CLI shutdown/startup works without pmon restart; BMC reboot with admin down leaves Switch-Host powered off.
