### PR TITLE
[thermalctld] Use monotonic time for determining sensor updates and rate-limiting

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -656,7 +656,7 @@ class LiquidCoolingUpdater(threading.Thread, logger.Logger):
             sensor_is_leak = sensor.is_leak()
             sensor_leak_severity = sensor.get_leak_severity()
 
-            now = datetime.now()
+            now = time.monotonic()
 
             if not sensor_is_ok:
                 if sensor_name not in self.faulty_sensors:
@@ -680,8 +680,7 @@ class LiquidCoolingUpdater(threading.Thread, logger.Logger):
                         profile = sensor.get_leak_profile()
                         max_minor_secs = profile.get_leak_max_minor_duration_sec() if profile else inf
                         if max_minor_secs < inf:
-                            max_minor = leak_start_time + timedelta(seconds=max_minor_secs)
-                            if max_minor <= now:
+                            if leak_start_time + max_minor_secs <= now:
                                 sensor_leak_severity = LeakSeverity.CRITICAL
                                 escalated_to_critical = True
 
@@ -1049,7 +1048,7 @@ class TemperatureUpdater(logger.Logger):
         if interval is None:
             return True
         if now is None:
-            now = time.time()
+            now = time.monotonic()
         last = self._last_thermal_update_times.get(name, 0)
         if now - last >= interval:
             self._last_thermal_update_times[name] = now
@@ -1084,7 +1083,7 @@ class TemperatureUpdater(logger.Logger):
         """
         self.log_debug("Start temperature updating")
         if now is None:
-            now = time.time()
+            now = time.monotonic()
         available_thermals = set()
 
         if not self._collect_thermals(available_thermals, CHASSIS_INFO_KEY, self.chassis.get_all_thermals(), now=now):
@@ -1378,7 +1377,7 @@ class ThermalMonitor(ThreadTaskBase):
             del self._switch_host_thermal_state[stale]
 
     def main(self):
-        begin = time.time()
+        begin = time.monotonic()
 
         if self._fan_update_interval is None or (begin - self._last_fan_update) >= self._fan_update_interval:
             self.fan_updater.update()
@@ -1386,7 +1385,7 @@ class ThermalMonitor(ThreadTaskBase):
 
         self.temperature_updater.update(now=begin)
         self._check_switch_host_thermals()
-        elapsed = time.time() - begin
+        elapsed = time.monotonic() - begin
         if elapsed < self.update_interval:
             self.wait_time = self.update_interval - elapsed
         else:
@@ -1543,7 +1542,7 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
             # We received a fatal signal
             return False
 
-        begin = time.time()
+        begin = time.monotonic()
         try:
             if self.thermal_manager:
                 self.thermal_manager.run_policy(self.chassis)
@@ -1551,7 +1550,7 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
             self.log_error('Caught exception while running thermal policy - {}'.format(repr(e)))
 
         interval = self.thermal_manager.get_interval() if self.thermal_manager else self.INTERVAL
-        elapsed = time.time() - begin
+        elapsed = time.monotonic() - begin
         if elapsed < interval:
             self.wait_time = interval - elapsed
         else:

--- a/sonic-thermalctld/tests/conftest.py
+++ b/sonic-thermalctld/tests/conftest.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import importlib.util
+import importlib.machinery
+from mock import MagicMock
+import logging
+import logging.handlers
+class DummySysLogHandler(logging.Handler):
+    priority_map = {}
+    LOG_USER = 8
+    LOG_DAEMON = 24
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+    def emit(self, record):
+        pass
+logging.handlers.SysLogHandler = DummySysLogHandler
+sys.modules['fcntl'] = MagicMock()
+
+tests_path = os.path.dirname(os.path.abspath(__file__))
+
+# Add mocked_libs path so that the file under test can load mocked modules from there
+mocked_libs_path = os.path.join(tests_path, "mocked_libs")
+sys.path.insert(0, mocked_libs_path)
+sys.path.insert(0, r"c:\Users\ayushraj\Important\lfx 2026\sonic-platform-common")
+
+# Mock syslog since it is not available on Windows
+class MockSyslog:
+    LOG_EMERG = 0
+    LOG_ALERT = 1
+    LOG_CRIT = 2
+    LOG_ERR = 3
+    LOG_WARNING = 4
+    LOG_NOTICE = 5
+    LOG_INFO = 6
+    LOG_DEBUG = 7
+    LOG_DAEMON = 24
+    LOG_USER = 8
+    LOG_NDELAY = 8
+    LOG_PID = 1
+
+    def openlog(self, *args, **kwargs): pass
+    def closelog(self, *args, **kwargs): pass
+    def syslog(self, *args, **kwargs): pass
+
+sys.modules['syslog'] = MockSyslog()
+
+# Mock SIGHUP, SIGUSR1, and signal.signal on Windows
+import signal
+import _signal
+if sys.platform == "win32":
+    signal.signal = MagicMock()
+    _signal.signal = MagicMock()
+if not hasattr(signal, 'SIGHUP'):
+    signal.SIGHUP = 1
+if not hasattr(signal, 'SIGUSR1'):
+    signal.SIGUSR1 = 10
+
+# Mock swsscommon using the local mock_swsscommon if not already mocked by sys.path
+# Note: tests/test_thermalctld.py manually inserts mocked_libs and imports swsscommon.
+# But we can also set it up here.
+# Mock swsscommon using local mocks if needed, but let test_thermalctld.py load it from mocked_libs.
+
+from sonic_py_common import daemon_base
+daemon_base.db_connect = MagicMock()

--- a/sonic-thermalctld/tests/mock_swsscommon.py
+++ b/sonic-thermalctld/tests/mock_swsscommon.py
@@ -35,3 +35,17 @@ class FieldValuePairs:
     def __init__(self, fvs):
         self.fv_dict = dict(fvs)
         pass
+
+class ConfigDBConnector:
+    def __init__(self, *args, **kwargs):
+        pass
+    def connect(self, *args, **kwargs):
+        pass
+    def get_table(self, *args, **kwargs):
+        return {}
+
+class SonicV2Connector:
+    def __init__(self, *args, **kwargs):
+        pass
+    def connect(self, *args, **kwargs):
+        pass

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -1703,7 +1703,7 @@ class TestShouldUpdateThermal(object):
         updater = thermalctld.TemperatureUpdater(
             chassis, threading.Event(), default_interval=1)
         updater._should_update_thermal('Unknown Thermal')
-        updater._last_thermal_update_times['Unknown Thermal'] = time.time() - 2
+        updater._last_thermal_update_times['Unknown Thermal'] = time.monotonic() - 2
         assert updater._should_update_thermal('Unknown Thermal') is True
 
     def test_true_on_first_call(self):
@@ -1725,7 +1725,7 @@ class TestShouldUpdateThermal(object):
             chassis, threading.Event(), thermal_intervals={'CPU Temp': 1})
         updater._should_update_thermal('CPU Temp')
         # Fake that last update was 2 seconds ago
-        updater._last_thermal_update_times['CPU Temp'] = time.time() - 2
+        updater._last_thermal_update_times['CPU Temp'] = time.monotonic() - 2
         assert updater._should_update_thermal('CPU Temp') is True
 
     def test_explicit_interval_overrides_default(self):
@@ -1735,7 +1735,7 @@ class TestShouldUpdateThermal(object):
             thermal_intervals={'CPU Temp': 5}, default_interval=60)
         updater._should_update_thermal('CPU Temp')
         # CPU Temp uses explicit 5s, not default 60s
-        updater._last_thermal_update_times['CPU Temp'] = time.time() - 6
+        updater._last_thermal_update_times['CPU Temp'] = time.monotonic() - 6
         assert updater._should_update_thermal('CPU Temp') is True
 
 
@@ -1780,7 +1780,7 @@ class TestPsuIntervalGating(object):
         updater._refresh_temperature_status.reset_mock()
 
         # Fake that last PSU update was 2 seconds ago
-        updater._last_psu_thermal_update = time.time() - 2
+        updater._last_psu_thermal_update = time.monotonic() - 2
         updater.update()
         assert updater._refresh_temperature_status.call_count > 0
 
@@ -1869,7 +1869,7 @@ class TestThermalMonitorPollingIntervals(object):
         monitor.fan_updater.update.reset_mock()
 
         # Fake that last fan update was 2 seconds ago
-        monitor._last_fan_update = time.time() - 2
+        monitor._last_fan_update = time.monotonic() - 2
         monitor.main()
         assert monitor.fan_updater.update.call_count == 1
 
@@ -1890,7 +1890,7 @@ class TestThermalMonitorPollingIntervals(object):
         assert monitor.fan_updater.update.call_count == 0
 
         # After interval elapses, should update again
-        monitor._last_fan_update = time.time() - 61
+        monitor._last_fan_update = time.monotonic() - 61
         monitor.main()
         assert monitor.fan_updater.update.call_count == 1
 
@@ -2246,4 +2246,11 @@ class TestThermalMonitorSwitchHostCritical(object):
             assert 'CRITICAL chassis thermal: Thermal X' in contents
             assert '110.0' in contents
         finally:
-            os.unlink(tmp_log)
+            if hasattr(tm, '_sw_host_thermal_event_logger') and tm._sw_host_thermal_event_logger:
+                for h in list(tm._sw_host_thermal_event_logger._file_logger.handlers):
+                    h.close()
+                    tm._sw_host_thermal_event_logger._file_logger.removeHandler(h)
+            try:
+                os.unlink(tmp_log)
+            except OSError:
+                pass


### PR DESCRIPTION
#### Description
Currently, `thermalctld` relies on standard clock time (`time.time()`, `datetime.now()`) to calculate elapsed time for temperature updates, track leak/fault durations, and schedule policy execution. This makes the daemon vulnerable to system clock drift, manual time adjustments, or NTP synchronization jumps, which can cause sensor updates to hang, schedule tasks incorrectly, or trigger false state changes.

This PR switches `thermalctld` to use `time.monotonic()` for all timing checks, duration tracking, and rate-limiting, ensuring consistent behavior regardless of system time adjustments.

#### Changes Made
*   **Monotonic Clock Migration:**
    *   Updated `_refresh_leak_status()` to track leak durations and faulty periods using `time.monotonic()` instead of `datetime.now()`.
    *   Updated `_should_update_thermal()`, `update()`, `main()`, and `run()` to use `time.monotonic()` instead of `time.time()` for checking polling intervals and tracking elapsed run time.
*   **Unit Tests & Windows Mocking Support:**
    *   Updated the timing offsets in `test_thermalctld.py` to use `time.monotonic()` to align with the new daemon logic.
    *   Added a proper `conftest.py` setup to mock Unix signals (`SIGHUP`, `SIGUSR1`, `signal.signal`) and `logging.handlers.SysLogHandler` to allow the test suite to run and pass cleanly on Windows environments.
    *   Fixed temporary file cleanup locking to avoid `PermissionError` when deleting test logs.

#### Verification
*   Ran all unit tests under `sonic-thermalctld`: **All 116 tests are fully passing.**
```bash
======================= 116 passed, 1 warning in 5.34s ========================