### PR TITLE
Updated STATE_DB tables for c-cmis pm

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1386,7 +1386,11 @@ class TestXcvrdScript(object):
                                                                               'prefec_ber_max': '0.0006833674050752236',
                                                                               'uncorr_frames_avg': '0.0',
                                                                               'uncorr_frames_min': '0.0',
-                                                                              'uncorr_frames_max': '0.0', }))
+                                                                              'uncorr_frames_max': '0.0',
+                                                                              'rx_bits_pm': '1000000',
+                                                                              'rx_corr_bits_pm': '1000',
+                                                                              'tx_bits_pm': '2000000',
+                                                                              'tx_frames_pm': '20000', }))
     def test_post_port_pm_info_to_db(self):
         logical_port_name = "Ethernet0"
         port_mapping = PortMapping()
@@ -1395,9 +1399,14 @@ class TestXcvrdScript(object):
         mock_cmis_manager = MagicMock()
         dom_info_update = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, mock_sfp_obj_dict, stop_event, mock_cmis_manager)
         pm_tbl = Table("STATE_DB", TRANSCEIVER_PM_TABLE)
+        pm_counters_tbl = Table("STATE_DB", TRANSCEIVER_PM_COUNTERS_TABLE)
         assert pm_tbl.get_size() == 0
-        dom_info_update.post_port_pm_info_to_db(logical_port_name, port_mapping, pm_tbl, stop_event)
+        assert pm_counters_tbl.get_size() == 0
+        dom_info_update.post_port_pm_info_to_db(logical_port_name, port_mapping, pm_tbl, pm_counters_tbl, stop_event)
+        # Non-counter fields (6 preFEC ratios) go to TRANSCEIVER_PM.
         assert pm_tbl.get_size_for_key(logical_port_name) == 6
+        # Raw FEC counters (2 rx + 2 tx) go to TRANSCEIVER_PM_COUNTERS.
+        assert pm_counters_tbl.get_size_for_key(logical_port_name) == 4
 
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd_utilities.common._wrapper_get_presence', MagicMock(return_value=True))

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1403,9 +1403,10 @@ class TestXcvrdScript(object):
         assert pm_tbl.get_size() == 0
         assert pm_counters_tbl.get_size() == 0
         dom_info_update.post_port_pm_info_to_db(logical_port_name, port_mapping, pm_tbl, pm_counters_tbl, stop_event)
-        # Non-counter fields (6 preFEC ratios) go to TRANSCEIVER_PM.
-        assert pm_tbl.get_size_for_key(logical_port_name) == 6
-        # Raw FEC counters (2 rx + 2 tx) go to TRANSCEIVER_PM_COUNTERS.
+        # All fields (6 preFEC ratios + 4 raw FEC counters) go to TRANSCEIVER_PM
+        # for backward compatibility with existing streaming telemetry consumers.
+        assert pm_tbl.get_size_for_key(logical_port_name) == 10
+        # Raw FEC counters (2 rx + 2 tx) are additionally posted to TRANSCEIVER_PM_COUNTERS.
         assert pm_counters_tbl.get_size_for_key(logical_port_name) == 4
 
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -1417,9 +1418,11 @@ class TestXcvrdScript(object):
         dom_threshold_tbl = Table("STATE_DB", TRANSCEIVER_DOM_THRESHOLD_TABLE)
         init_tbl = Table("STATE_DB", TRANSCEIVER_INFO_TABLE)
         pm_tbl = Table("STATE_DB", TRANSCEIVER_PM_TABLE)
+        pm_counters_tbl = Table("STATE_DB", TRANSCEIVER_PM_COUNTERS_TABLE)
         firmware_info_tbl = Table("STATE_DB", TRANSCEIVER_FIRMWARE_INFO_TABLE)
-        common.del_port_sfp_dom_info_from_db(logical_port_name, port_mapping, [init_tbl, dom_tbl, dom_threshold_tbl, pm_tbl, firmware_info_tbl])
+        common.del_port_sfp_dom_info_from_db(logical_port_name, port_mapping, [init_tbl, dom_tbl, dom_threshold_tbl, pm_tbl, pm_counters_tbl, firmware_info_tbl])
         assert dom_tbl.get_size() == 0
+        assert pm_counters_tbl.get_size() == 0
 
     @pytest.mark.parametrize("mock_found, mock_state, expected_cmis_state", [
         (True, CMIS_STATE_INSERTED, CMIS_STATE_INSERTED),

--- a/sonic-xcvrd/xcvrd/dom/dom_mgr.py
+++ b/sonic-xcvrd/xcvrd/dom/dom_mgr.py
@@ -36,6 +36,23 @@ SYSLOG_IDENTIFIER_DOMINFOUPDATETASK = "DomInfoUpdateTask"
 PORT_UPDATE_EVENT_SELECT_TIMEOUT_MSECS = 1000
 PORT_UPDATE_EVENT_SELECT_TIMEOUT_FAST_MSECS = 10
 
+# Raw FEC counter fields from get_transceiver_pm() that are published to the
+# TRANSCEIVER_PM_COUNTERS table instead of TRANSCEIVER_PM. This is a positive list:
+# any field not named here (calculated ratios, optical metrics) stays in TRANSCEIVER_PM.
+PM_COUNTER_FIELDS = frozenset({
+    # media (page 34h) RX FEC counters
+    'rx_bits_pm', 'rx_bits_subint_pm', 'rx_corr_bits_pm',
+    'rx_min_corr_bits_subint_pm', 'rx_max_corr_bits_subint_pm',
+    'rx_frames_pm', 'rx_frames_subint_pm', 'rx_frames_uncorr_err_pm',
+    'rx_min_frames_uncorr_err_subint_pm', 'rx_max_frames_uncorr_err_subint_pm',
+    # host (page 3Ah) TX FEC counters
+    'tx_bits_pm', 'tx_bits_subint_pm', 'tx_corr_bits_pm',
+    'tx_min_corr_bits_subint_pm', 'tx_max_corr_bits_subint_pm',
+    'tx_frames_pm', 'tx_frames_subint_pm', 'tx_frames_uncorr_err_pm',
+    'tx_min_frames_uncorr_err_subint_pm', 'tx_max_frames_uncorr_err_subint_pm',
+    'tx_corrected_frames_pm', 'tx_corrected_frames_subint_pm',
+})
+
 class DomInfoUpdateBase(threading.Thread):
 
     name = ''
@@ -235,7 +252,7 @@ class DomInfoUpdateTask(DomInfoUpdateBase):
                 sys.exit(xcvrd.NOT_IMPLEMENTED_ERROR)
 
     # Update port pm info in db
-    def post_port_pm_info_to_db(self, logical_port_name, port_mapping, table, stop_event=threading.Event(), pm_info_cache=None):
+    def post_port_pm_info_to_db(self, logical_port_name, port_mapping, pm_table, pm_counters_table, stop_event=threading.Event(), pm_info_cache=None):
         for physical_port, physical_port_name in common.get_physical_port_name_dict(logical_port_name, port_mapping).items():
             if stop_event.is_set():
                 break
@@ -259,8 +276,14 @@ class DomInfoUpdateTask(DomInfoUpdateBase):
                 if not pm_info_dict:
                     continue
                 self.db_utils.beautify_info_dict(pm_info_dict)
-                fvs = swsscommon.FieldValuePairs([(k, v) for k, v in pm_info_dict.items()])
-                table.set(physical_port_name, fvs)
+                # Route raw FEC counters to TRANSCEIVER_PM_COUNTERS; everything else
+                # (calculated ratios, optical metrics) stays in TRANSCEIVER_PM.
+                pm_dict = {k: v for k, v in pm_info_dict.items() if k not in PM_COUNTER_FIELDS}
+                pm_counters_dict = {k: v for k, v in pm_info_dict.items() if k in PM_COUNTER_FIELDS}
+                if pm_dict:
+                    pm_table.set(physical_port_name, swsscommon.FieldValuePairs(list(pm_dict.items())))
+                if pm_counters_dict:
+                    pm_counters_table.set(physical_port_name, swsscommon.FieldValuePairs(list(pm_counters_dict.items())))
             else:
                 return xcvrd.SFP_EEPROM_NOT_READY
 
@@ -395,7 +418,7 @@ class DomInfoUpdateTask(DomInfoUpdateBase):
                                     except (KeyError, TypeError) as e:
                                         self.log_warning("Got exception {} while processing vdm statistic values for port {}, ignored".format(repr(e), logical_port_name))
                                     try:
-                                        self.post_port_pm_info_to_db(logical_port_name, self.port_mapping, self.xcvr_table_helper.get_pm_tbl(asic_index), self.task_stopping_event)
+                                        self.post_port_pm_info_to_db(logical_port_name, self.port_mapping, self.xcvr_table_helper.get_pm_tbl(asic_index), self.xcvr_table_helper.get_pm_counters_tbl(asic_index), self.task_stopping_event)
                                     except (KeyError, TypeError) as e:
                                         self.log_warning("Got exception {} while posting pm info to DB for port {}, ignored".format(repr(e), logical_port_name))
 
@@ -520,6 +543,7 @@ class DomInfoUpdateTask(DomInfoUpdateBase):
                                       self.xcvr_table_helper.get_status_flag_set_time_tbl(port_change_event.asic_id),
                                       self.xcvr_table_helper.get_status_flag_clear_time_tbl(port_change_event.asic_id),
                                       self.xcvr_table_helper.get_pm_tbl(port_change_event.asic_id),
+                                      self.xcvr_table_helper.get_pm_counters_tbl(port_change_event.asic_id),
                                       self.xcvr_table_helper.get_firmware_info_tbl(port_change_event.asic_id)
                                       ])
 

--- a/sonic-xcvrd/xcvrd/dom/dom_mgr.py
+++ b/sonic-xcvrd/xcvrd/dom/dom_mgr.py
@@ -37,8 +37,8 @@ PORT_UPDATE_EVENT_SELECT_TIMEOUT_MSECS = 1000
 PORT_UPDATE_EVENT_SELECT_TIMEOUT_FAST_MSECS = 10
 
 # Raw FEC counter fields from get_transceiver_pm() that are published to the
-# TRANSCEIVER_PM_COUNTERS table instead of TRANSCEIVER_PM. This is a positive list:
-# any field not named here (calculated ratios, optical metrics) stays in TRANSCEIVER_PM.
+# TRANSCEIVER_PM_COUNTERS table. This is a positive list: any field not named 
+# here (calculated ratios, optical metrics) stays in TRANSCEIVER_PM.
 PM_COUNTER_FIELDS = frozenset({
     # media (page 34h) RX FEC counters
     'rx_bits_pm', 'rx_bits_subint_pm', 'rx_corr_bits_pm',
@@ -252,10 +252,11 @@ class DomInfoUpdateTask(DomInfoUpdateBase):
                 sys.exit(xcvrd.NOT_IMPLEMENTED_ERROR)
 
     # Update port pm info in db
-    def post_port_pm_info_to_db(self, logical_port_name, port_mapping, pm_table, pm_counters_table, stop_event=threading.Event(), pm_info_cache=None):
+    def post_port_pm_info_to_db(self, logical_port_name, port_mapping, pm_table, pm_counters_table, stop_event=None, pm_info_cache=None):
+        if stop_event is None:
+            stop_event = threading.Event()
+
         for physical_port, physical_port_name in common.get_physical_port_name_dict(logical_port_name, port_mapping).items():
-            if stop_event.is_set():
-                break
 
             if not common._wrapper_get_presence(physical_port):
                 continue
@@ -276,12 +277,11 @@ class DomInfoUpdateTask(DomInfoUpdateBase):
                 if not pm_info_dict:
                     continue
                 self.db_utils.beautify_info_dict(pm_info_dict)
-                # Route raw FEC counters to TRANSCEIVER_PM_COUNTERS; everything else
-                # (calculated ratios, optical metrics) stays in TRANSCEIVER_PM.
-                pm_dict = {k: v for k, v in pm_info_dict.items() if k not in PM_COUNTER_FIELDS}
+                # Publish all PM fields and counters to TRANSCEIVER_PM.
+                # Additionally publish the raw FEC counters to TRANSCEIVER_PM_COUNTERS.
                 pm_counters_dict = {k: v for k, v in pm_info_dict.items() if k in PM_COUNTER_FIELDS}
-                if pm_dict:
-                    pm_table.set(physical_port_name, swsscommon.FieldValuePairs(list(pm_dict.items())))
+                if pm_info_dict:
+                    pm_table.set(physical_port_name, swsscommon.FieldValuePairs(list(pm_info_dict.items())))
                 if pm_counters_dict:
                     pm_counters_table.set(physical_port_name, swsscommon.FieldValuePairs(list(pm_counters_dict.items())))
             else:
@@ -521,9 +521,10 @@ class DomInfoUpdateTask(DomInfoUpdateBase):
         Args:
             port_change_event (object): port change event
         """
-        # To avoid race condition, remove the entry TRANSCEIVER_FIRMWARE_INFO, TRANSCEIVER_DOM_SENSOR, TRANSCEIVER_PM and HW section of TRANSCEIVER_STATUS table.
-        # This thread only updates TRANSCEIVER_FIRMWARE_INFO, TRANSCEIVER_DOM_SENSOR, TRANSCEIVER_PM and HW section of TRANSCEIVER_STATUS table,
-        # so we don't have to remove entries from TRANSCEIVER_INFO, TRANSCEIVER_DOM_THRESHOLD and VDM threshold value tables.
+        # To avoid race condition, remove the entry TRANSCEIVER_FIRMWARE_INFO, TRANSCEIVER_DOM_SENSOR, TRANSCEIVER_PM, TRANSCEIVER_PM_COUNTERS, 
+        # and HW section of TRANSCEIVER_STATUS table. This thread only updates TRANSCEIVER_FIRMWARE_INFO, TRANSCEIVER_DOM_SENSOR, TRANSCEIVER_PM,
+        # TRANSCEIVER_PM_COUNTERS and HW section of TRANSCEIVER_STATUS table, so we don't have to remove entries from TRANSCEIVER_INFO, 
+        # TRANSCEIVER_DOM_THRESHOLD and VDM threshold value tables.
         common.del_port_sfp_dom_info_from_db(port_change_event.port_name,
                                       self.port_mapping,
                                       [self.xcvr_table_helper.get_dom_tbl(port_change_event.asic_id),

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvr_table_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvr_table_helper.py
@@ -45,6 +45,11 @@ TRANSCEIVER_VDM_LALARM_FLAG_CLEAR_TIME = 'TRANSCEIVER_VDM_LALARM_FLAG_CLEAR_TIME
 TRANSCEIVER_VDM_HWARN_FLAG_CLEAR_TIME = 'TRANSCEIVER_VDM_HWARN_FLAG_CLEAR_TIME'
 TRANSCEIVER_VDM_LWARN_FLAG_CLEAR_TIME = 'TRANSCEIVER_VDM_LWARN_FLAG_CLEAR_TIME'
 TRANSCEIVER_PM_TABLE = 'TRANSCEIVER_PM'
+<<<<<<< HEAD
+=======
+TRANSCEIVER_PM_COUNTERS_TABLE = 'TRANSCEIVER_PM_COUNTERS'
+TRANSCEIVER_CMIS_STATE_TIMESTAMPS_TABLE = 'TRANSCEIVER_CMIS_STATE_TIMESTAMPS'
+>>>>>>> b3e8fd9 (NOS-11257: Updated STATE_DB tables for C-CMIS PM pages 34h, 35h, 3Ah (#208))
 
 NPU_SI_SETTINGS_SYNC_STATUS_KEY = 'NPU_SI_SETTINGS_SYNC_STATUS'
 NPU_SI_SETTINGS_DEFAULT_VALUE = 'NPU_SI_SETTINGS_DEFAULT'
@@ -69,6 +74,11 @@ class XcvrTableHelper:
         self.status_flag_set_time_tbl = {}
         self.status_flag_clear_time_tbl = {}
         self.status_sw_tbl = {}
+<<<<<<< HEAD
+=======
+        self.cmis_state_timestamps_tbl = {}
+        self.pm_counters_tbl = {}
+>>>>>>> b3e8fd9 (NOS-11257: Updated STATE_DB tables for C-CMIS PM pages 34h, 35h, 3Ah (#208))
         self.vdm_real_value_tbl = {}
         VDM_THRESHOLD_TYPES = ['halarm', 'lalarm', 'hwarn', 'lwarn']
         self.vdm_threshold_tbl = {f'vdm_{t}_threshold_tbl': {} for t in VDM_THRESHOLD_TYPES}
@@ -94,6 +104,7 @@ class XcvrTableHelper:
             self.status_flag_clear_time_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], TRANSCEIVER_STATUS_FLAG_CLEAR_TIME_TABLE)
             self.status_sw_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], TRANSCEIVER_STATUS_SW_TABLE)
             self.pm_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], TRANSCEIVER_PM_TABLE)
+            self.pm_counters_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], TRANSCEIVER_PM_COUNTERS_TABLE)
             self.firmware_info_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], TRANSCEIVER_FIRMWARE_INFO_TABLE)
             self.state_port_tbl[asic_id] = swsscommon.Table(self.state_db[asic_id], swsscommon.STATE_PORT_TABLE_NAME)
             self.appl_db[asic_id] = daemon_base.db_connect("APPL_DB", namespace)
@@ -170,6 +181,9 @@ class XcvrTableHelper:
 
     def get_pm_tbl(self, asic_id):
         return self.pm_tbl[asic_id]
+
+    def get_pm_counters_tbl(self, asic_id):
+        return self.pm_counters_tbl[asic_id]
 
     def get_firmware_info_tbl(self, asic_id):
         return self.firmware_info_tbl[asic_id]

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvr_table_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvr_table_helper.py
@@ -45,11 +45,8 @@ TRANSCEIVER_VDM_LALARM_FLAG_CLEAR_TIME = 'TRANSCEIVER_VDM_LALARM_FLAG_CLEAR_TIME
 TRANSCEIVER_VDM_HWARN_FLAG_CLEAR_TIME = 'TRANSCEIVER_VDM_HWARN_FLAG_CLEAR_TIME'
 TRANSCEIVER_VDM_LWARN_FLAG_CLEAR_TIME = 'TRANSCEIVER_VDM_LWARN_FLAG_CLEAR_TIME'
 TRANSCEIVER_PM_TABLE = 'TRANSCEIVER_PM'
-<<<<<<< HEAD
-=======
 TRANSCEIVER_PM_COUNTERS_TABLE = 'TRANSCEIVER_PM_COUNTERS'
 TRANSCEIVER_CMIS_STATE_TIMESTAMPS_TABLE = 'TRANSCEIVER_CMIS_STATE_TIMESTAMPS'
->>>>>>> b3e8fd9 (NOS-11257: Updated STATE_DB tables for C-CMIS PM pages 34h, 35h, 3Ah (#208))
 
 NPU_SI_SETTINGS_SYNC_STATUS_KEY = 'NPU_SI_SETTINGS_SYNC_STATUS'
 NPU_SI_SETTINGS_DEFAULT_VALUE = 'NPU_SI_SETTINGS_DEFAULT'
@@ -74,11 +71,8 @@ class XcvrTableHelper:
         self.status_flag_set_time_tbl = {}
         self.status_flag_clear_time_tbl = {}
         self.status_sw_tbl = {}
-<<<<<<< HEAD
-=======
         self.cmis_state_timestamps_tbl = {}
         self.pm_counters_tbl = {}
->>>>>>> b3e8fd9 (NOS-11257: Updated STATE_DB tables for C-CMIS PM pages 34h, 35h, 3Ah (#208))
         self.vdm_real_value_tbl = {}
         VDM_THRESHOLD_TYPES = ['halarm', 'lalarm', 'hwarn', 'lwarn']
         self.vdm_threshold_tbl = {f'vdm_{t}_threshold_tbl': {} for t in VDM_THRESHOLD_TYPES}

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvr_table_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/xcvr_table_helper.py
@@ -46,7 +46,6 @@ TRANSCEIVER_VDM_HWARN_FLAG_CLEAR_TIME = 'TRANSCEIVER_VDM_HWARN_FLAG_CLEAR_TIME'
 TRANSCEIVER_VDM_LWARN_FLAG_CLEAR_TIME = 'TRANSCEIVER_VDM_LWARN_FLAG_CLEAR_TIME'
 TRANSCEIVER_PM_TABLE = 'TRANSCEIVER_PM'
 TRANSCEIVER_PM_COUNTERS_TABLE = 'TRANSCEIVER_PM_COUNTERS'
-TRANSCEIVER_CMIS_STATE_TIMESTAMPS_TABLE = 'TRANSCEIVER_CMIS_STATE_TIMESTAMPS'
 
 NPU_SI_SETTINGS_SYNC_STATUS_KEY = 'NPU_SI_SETTINGS_SYNC_STATUS'
 NPU_SI_SETTINGS_DEFAULT_VALUE = 'NPU_SI_SETTINGS_DEFAULT'
@@ -71,7 +70,6 @@ class XcvrTableHelper:
         self.status_flag_set_time_tbl = {}
         self.status_flag_clear_time_tbl = {}
         self.status_sw_tbl = {}
-        self.cmis_state_timestamps_tbl = {}
         self.pm_counters_tbl = {}
         self.vdm_real_value_tbl = {}
         VDM_THRESHOLD_TYPES = ['halarm', 'lalarm', 'hwarn', 'lwarn']


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
- Adds a new `TRANSCEIVER_PM_COUNTERS` STATE_DB table and routes raw FEC counter fields (page 34h counters and page 3Ah counters) from `get_transceiver_pm()` into it, while calculated ratios and metrics stay in `TRANSCEIVER_PM`.
- Adds the table constant, per-asic Table handle, and accessor to `xcvr_table_helper.py`.
- Splits the PM dict by a `PM_COUNTER_FIELDS` set in `post_port_pm_info_to_db` (`dom_mgr.py`), updates the caller to pass both table handles, and adds cleanup of the new table on logical port removal.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
`TRANSCEIVER_PM` was only accumulating derived analog PM metrics (BER ratios, optical power/OSNR/etc.) from page 34h counters. Adding raw counters into their own table gives consumers a distinction between processed diagnostics and raw counters. Also, the new table gives a location for the new host counters from [C-CMIS 1.4](https://www.oiforum.com/wp-content/uploads/OIF-C-CMIS-01.4.pdf) page 3Ah.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
- Ran the xcvrd unit tests (`tests/test_xcvrd.py`), focusing on `test_post_port_pm_info_to_db` (asserts non-counter fields land in `TRANSCEIVER_PM` and counter fields land in `TRANSCEIVER_PM_COUNTERS`).
- Verified on a DUT with changes from following PRS: [C-CMIS PM API/Memory Maps](https://github.com/sonic-net/sonic-platform-common/pull/719), [C-CMIS PM STATE_DB](https://github.com/sonic-net/sonic-platform-daemons/pull/856),  [C-CMIS PM CLI](https://github.com/sonic-net/sonic-utilities/pull/4699).