### PR TITLE
[ci] replace python3-pip with uv in pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,12 +135,12 @@ jobs:
 
     - script: |
         set -xe
-        sudo pip3 install swsssdk-2.0.1-py3-none-any.whl
-        sudo pip3 install sonic_py_common-1.0-py3-none-any.whl
-        sudo pip3 install sonic_yang_mgmt-1.0-py3-none-any.whl
-        sudo pip3 install sonic_yang_models-1.0-py3-none-any.whl
-        sudo pip3 install sonic_config_engine-1.0-py3-none-any.whl
-        sudo pip3 install sonic_platform_common-1.0-py3-none-any.whl
+        uv pip install --system swsssdk-2.0.1-py3-none-any.whl
+        uv pip install --system sonic_py_common-1.0-py3-none-any.whl
+        uv pip install --system sonic_yang_mgmt-1.0-py3-none-any.whl
+        uv pip install --system sonic_yang_models-1.0-py3-none-any.whl
+        uv pip install --system sonic_config_engine-1.0-py3-none-any.whl
+        uv pip install --system sonic_platform_common-1.0-py3-none-any.whl
       workingDirectory: $(Build.ArtifactStagingDirectory)/download/target/python-wheels/trixie/
       displayName: 'Install Python dependencies'
 
@@ -169,8 +169,8 @@ jobs:
                   exit 1
                 fi
             fi
-            pip3 install ".[testing]"
-            pip3 uninstall --yes sonic-platform-daemons
+            uv pip install --system ".[testing]"
+            uv pip uninstall --system --yes sonic-platform-daemons
             pytest
           workingDirectory: ${{ project.root_dir }}
           displayName: '${{ project.name }}(Py3) Test'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description

Replace `pip3` (`python3-pip`) with `uv pip` in the CI pipeline for installing and uninstalling Python packages.

#### Motivation and Context

`python3-pip` has been removed from the CI agent (`sonic-slave-trixie`) due to security alerts. `uv` is provided as its replacement. This change updates all `pip3 install` / `pip3 uninstall` calls to the equivalent `uv pip install --system` / `uv pip uninstall --system --yes` commands.

Note: `python3 -m build -n` is left unchanged — `python3-build` is installed as a separate Debian package in `sonic-slave-trixie` and is not affected by the removal of `python3-pip`.

#### How Has This Been Tested?

CI pipeline run triggered on this PR.

#### Additional Information (Optional)