### PR TITLE
[xcvrd] Verify that the module activated the requested CMIS application

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -3800,6 +3800,57 @@ class TestXcvrdScript(object):
 
         assert task.is_cmis_application_update_required(mock_xcvr_api, app_new, host_lanes_mask) == expected
 
+    @pytest.mark.parametrize("appl, host_lanes_mask, active_apsel, expected", [
+        # The module activated the desired application
+        (1, 0x0F, {'ActiveAppSelLane1': 1, 'ActiveAppSelLane2': 1,
+                   'ActiveAppSelLane3': 1, 'ActiveAppSelLane4': 1}, True),
+        # The module is running a different application than the desired one
+        (12, 0x0F, {'ActiveAppSelLane1': 4, 'ActiveAppSelLane2': 4,
+                    'ActiveAppSelLane3': 4, 'ActiveAppSelLane4': 4}, False),
+        # Only a subset of the host lanes failed to activate the desired application
+        (12, 0x0F, {'ActiveAppSelLane1': 12, 'ActiveAppSelLane2': 12,
+                    'ActiveAppSelLane3': 12, 'ActiveAppSelLane4': 4}, False),
+        # Host lanes outside of the mask are ignored
+        (12, 0x03, {'ActiveAppSelLane1': 12, 'ActiveAppSelLane2': 12,
+                    'ActiveAppSelLane3': 4, 'ActiveAppSelLane4': 4}, True),
+        # The active application code is not readable
+        (12, 0x0F, {'ActiveAppSelLane1': 'N/A', 'ActiveAppSelLane2': 'N/A',
+                    'ActiveAppSelLane3': 'N/A', 'ActiveAppSelLane4': 'N/A'}, True),
+        (12, 0x0F, {}, True),
+    ])
+    def test_CmisManagerTask_is_active_apsel_matching_desired(self, appl, host_lanes_mask, active_apsel, expected):
+        mock_xcvr_api = MagicMock()
+        mock_xcvr_api.get_active_apsel_hostlane = MagicMock(return_value=active_apsel)
+
+        port_mapping = PortMapping()
+        stop_event = threading.Event()
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event, platform_chassis=MagicMock())
+
+        assert task.is_active_apsel_matching_desired(mock_xcvr_api, appl, host_lanes_mask) == expected
+
+    def test_CmisManagerTask_is_cmis_application_update_required_active_apsel_mismatch(self):
+        """
+        A module can accept the staged application and report ConfigSuccess without
+        ever updating the Active Control Set. The staged application then matches the
+        desired one and the datapath looks healthy, while the module keeps running the
+        previous application, so an update still has to be forced.
+        """
+        mock_xcvr_api = MagicMock()
+        mock_xcvr_api.is_flat_memory = MagicMock(return_value=False)
+        mock_xcvr_api.get_application = MagicMock(return_value=12)
+        mock_xcvr_api.get_datapath_state = MagicMock(return_value=self.DEFAULT_DP_STATE)
+        mock_xcvr_api.get_config_datapath_hostlane_status = MagicMock(return_value=self.DEFAULT_CONFIG_STATUS)
+        mock_xcvr_api.get_active_apsel_hostlane = MagicMock(return_value={
+            'ActiveAppSelLane1': 4, 'ActiveAppSelLane2': 4,
+            'ActiveAppSelLane3': 4, 'ActiveAppSelLane4': 4
+        })
+
+        port_mapping = PortMapping()
+        stop_event = threading.Event()
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event, platform_chassis=MagicMock())
+
+        assert task.is_cmis_application_update_required(mock_xcvr_api, 12, 0x0F) == True
+
     @pytest.mark.parametrize("ifname, expected", [
         ('1.6TBASE-CR8 (Clause179)', 1600000),
         ('1.6TAUI-8 (Annex176E)', 1600000),

--- a/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
+++ b/sonic-xcvrd/xcvrd/cmis/cmis_manager_task.py
@@ -572,7 +572,56 @@ class CmisManagerTask(threading.Thread):
                 if conf_state[name] != 'ConfigSuccess':
                     skip = False
                     break
+            if skip and not self.is_active_apsel_matching_desired(api, app_new, host_lanes_mask):
+                self.log_notice("Forcing application update since the module has not "
+                                "activated the desired application {}...".format(app_new))
+                skip = False
             return (not skip)
+        return True
+
+    def is_active_apsel_matching_desired(self, api, appl, host_lanes_mask):
+        """
+        Check whether the module has actually activated the desired application.
+
+        get_application() reads the staged control set, which reflects what was
+        requested rather than what the module is running. A module can accept a
+        staged application and report ConfigSuccess while leaving the Active
+        Control Set unchanged, in which case the media side keeps running the
+        previous application. Comparing against the active application select
+        code detects that case.
+
+        Args:
+            api:
+                XcvrApi object
+            appl:
+                Integer, the desired transceiver-specific application code
+            host_lanes_mask:
+                Integer, a bitmask of the lanes on the host side
+                e.g. 0x5 for lane 0 and lane 2.
+
+        Returns:
+            Boolean, true if the active application matches the desired one on
+            every host lane of the mask, or if the active application code
+            cannot be read.
+        """
+        active_apsel = api.get_active_apsel_hostlane()
+        if not active_apsel:
+            return True
+
+        for lane in range(self.CMIS_MAX_HOST_LANES):
+            if ((1 << lane) & host_lanes_mask) == 0:
+                continue
+            active = active_apsel.get("ActiveAppSelLane{}".format(lane + 1))
+            # The active application code is not always readable, e.g. on flat
+            # memory modules it is reported as 'N/A'. Skip the check instead of
+            # forcing a needless datapath reinitialization.
+            if not isinstance(active, int):
+                return True
+            if active != appl:
+                self.log_error("Active application {} on host lane {} does not match "
+                               "the desired application {}".format(active, lane + 1, appl))
+                return False
+
         return True
 
     def force_cmis_reinit(self, lport, retries=0):
@@ -1238,6 +1287,15 @@ class CmisManagerTask(threading.Thread):
                     if self.is_timer_expired(expired):
                         self.log_notice("{}: timeout for 'DataPathActivated'".format(lport))
                         self.force_cmis_reinit(lport, retries + 1)
+                    return
+
+                # A module can report ConfigSuccess and activate its datapath while
+                # still running a different application than the one requested. Verify
+                # the active application before declaring the port ready, otherwise the
+                # module silently stays on the wrong media interface.
+                if not self.is_active_apsel_matching_desired(api, appl, host_lanes_mask):
+                    self.log_error("{}: module did not activate application {}".format(lport, appl))
+                    self.force_cmis_reinit(lport, retries + 1)
                     return
 
                 self.log_notice("{}: READY".format(lport))


### PR DESCRIPTION
### Why I did it

`is_cmis_application_update_required()` compares the desired application against `get_application()`, which reads the **staged** control set. The staged value reflects what xcvrd requested, not what the module is actually running.

A module can accept a staged application, return success from `ApplyDataPathInit`, report `ConfigSuccess` on every lane and activate its datapath, while leaving the **Active Control Set** unchanged. xcvrd then sees a staged application equal to the desired one plus a healthy datapath, logs `no CMIS application update required...READY`, and marks the port READY.

The module keeps running its previous application on the media side, so the link never comes up. Nothing in the logs or in `TRANSCEIVER_STATUS` indicates why, because every value xcvrd inspects looks correct. The only sign is that `active_apsel_hostlane*` in `TRANSCEIVER_INFO` differs from the application xcvrd asked for.

This was hit on a 100G port where xcvrd correctly selected the `CAUI-4 C2M` / `100G PSM4` application, but the module stayed on a `400GBASE-DR4` application. The optical power was healthy in both directions while the media side ran the wrong modulation, so the port reported READY and never linked.

### How I did it

Added `is_active_apsel_matching_desired()`, which compares the desired application against `get_active_apsel_hostlane()` (the Active Control Set) for every host lane in the mask.

It is used in two places:

- `is_cmis_application_update_required()`: when the staged application matches and the datapath looks healthy, the active application is checked before the update is skipped. This covers xcvrd restarts, where the CMIS state is preserved.
- The `CMIS_STATE_DP_ACTIVATE` to `CMIS_STATE_READY` transition: the active application is verified before the port is declared READY.

On mismatch the datapath is reinitialized through the existing retry path. Once `CMIS_MAX_RETRIES` is exhausted the port transitions to `CMIS_STATE_FAILED`, which surfaces the problem instead of leaving the port silently on the wrong application.

The check is skipped when the active application code is not readable, for example the `'N/A'` reported for flat memory modules, so modules that do not expose it keep the current behaviour. On a compliant module the staged and active codes match after activation, so this is a no-op.

### How to verify it

Unit tests:

```
cd sonic-xcvrd && python3 -m pytest tests/test_xcvrd.py -k "is_active_apsel_matching_desired or is_cmis_application_update_required"
```

Added `test_CmisManagerTask_is_active_apsel_matching_desired`, covering a matching active application, a full mismatch, a partial per-lane mismatch, lanes outside the host lane mask, an unreadable `'N/A'` active code, and an empty result. Added `test_CmisManagerTask_is_cmis_application_update_required_active_apsel_mismatch`, which reproduces the reported case: staged application matches, `DataPathActivated` plus `ConfigSuccess` on all lanes, active application different, update still required.

On hardware, compare `active_apsel_hostlane*` in `TRANSCEIVER_INFO` against the application xcvrd selected. A module that fails to activate it now retries and ends in `CMIS_STATE_FAILED` with an explicit log, instead of reporting READY.

### Description for the changelog

Detect CMIS modules that fail to activate the requested application instead of reporting the port as READY.