### PR TITLE
[chassisd]: Replay saved module admin down state on boot in chassisd

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -410,6 +410,13 @@ class ModuleUpdater(logger.Logger):
             return fvs.get(CHASSIS_MODULE_INFO_OPERSTATUS_FIELD, ModuleBase.MODULE_STATUS_EMPTY)
         return ModuleBase.MODULE_STATUS_EMPTY
 
+    def get_module_current_presence(self, key):
+        fvs = self.module_table.get(key)
+        if isinstance(fvs, list) and fvs[0] is True:
+            fvs = dict(fvs[-1])
+            return fvs.get(CHASSIS_MODULE_INFO_PRESENCE_FIELD, 'False')
+        return None
+
     def get_module_admin_status(self, chassis_module_name):
         config_db = daemon_base.db_connect("CONFIG_DB")
         vtable = swsscommon.Table(config_db, CHASSIS_CFG_TABLE)
@@ -419,6 +426,23 @@ class ModuleUpdater(logger.Logger):
             return fvs[CHASSIS_MODULE_ADMIN_STATUS]
         else:
             return 'up'
+
+    def replay_saved_module_admin_down(self, module_index, module_name):
+        """Apply persisted admin down from CONFIG_DB to a present fabric/line module."""
+        if not (module_name.startswith(ModuleBase.MODULE_TYPE_FABRIC) or
+                module_name.startswith(ModuleBase.MODULE_TYPE_LINE)):
+            return False
+
+        if self.get_module_admin_status(module_name) != 'down':
+            return False
+
+        module = self.chassis.get_module(module_index)
+        if not try_get(module.get_presence, default=False):
+            return False
+
+        self.log_info("Replaying admin down state for module {}".format(module_name))
+        try_get(module.set_admin_state, MODULE_ADMIN_DOWN, default=False)
+        return True
 
     def module_db_update(self):
         notOnlineModules = []
@@ -453,9 +477,15 @@ class ModuleUpdater(logger.Logger):
 
 
                 prev_status = self.get_module_current_status(key)
+                prev_presence = self.get_module_current_presence(key)
                 self.module_table.set(key, fvs)
 
-                if module_info_dict[CHASSIS_MODULE_INFO_PRESENCE_FIELD].lower() == "true":
+                new_presence = module_info_dict[CHASSIS_MODULE_INFO_PRESENCE_FIELD].lower() == "true"
+                prev_was_absent = (prev_presence is None or prev_presence.lower() == 'false')
+                if self._is_supervisor() and prev_was_absent and new_presence:
+                    self.replay_saved_module_admin_down(module_index, key)
+
+                if new_presence:
                     update_entity_info(self.phy_entity_table,
                                        "chassis {}".format(1),
                                        key,
@@ -1894,21 +1924,8 @@ class ChassisdDaemon(daemon_base.DaemonBase):
         """Replay saved admin down state for fabric/line modules after reboot."""
         for module_index in range(0, self.module_updater.num_modules):
             try:
-                module = self.platform_chassis.get_module(module_index)
-                module_name = module.get_name()
-
-                if not (module_name.startswith(ModuleBase.MODULE_TYPE_FABRIC) or
-                        module_name.startswith(ModuleBase.MODULE_TYPE_LINE)):
-                    continue
-
-                if self.module_updater.get_module_admin_status(module_name) != 'down':
-                    continue
-
-                if not try_get(module.get_presence, default=False):
-                    continue
-
-                self.log_info("Replaying admin down state for module {} at boot".format(module_name))
-                try_get(module.set_admin_state, MODULE_ADMIN_DOWN, default=False)
+                module_name = self.platform_chassis.get_module(module_index).get_name()
+                self.module_updater.replay_saved_module_admin_down(module_index, module_name)
             except Exception as e:
                 self.log_error("Error replaying admin state for module index {}: {}".format(
                     module_index, str(e)))

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -1890,6 +1890,29 @@ class ChassisdDaemon(daemon_base.DaemonBase):
         for thread in threads:
             thread.join()
 
+    def set_initial_module_admin_state(self):
+        """Replay saved admin down state for fabric/line modules after reboot."""
+        for module_index in range(0, self.module_updater.num_modules):
+            try:
+                module = self.platform_chassis.get_module(module_index)
+                module_name = module.get_name()
+
+                if not (module_name.startswith(ModuleBase.MODULE_TYPE_FABRIC) or
+                        module_name.startswith(ModuleBase.MODULE_TYPE_LINE)):
+                    continue
+
+                if self.module_updater.get_module_admin_status(module_name) != 'down':
+                    continue
+
+                if not try_get(module.get_presence, default=False):
+                    continue
+
+                self.log_info("Replaying admin down state for module {} at boot".format(module_name))
+                try_get(module.set_admin_state, MODULE_ADMIN_DOWN, default=False)
+            except Exception as e:
+                self.log_error("Error replaying admin state for module index {}: {}".format(
+                    module_index, str(e)))
+
     # Run daemon
     def run(self):
         self.log_info("Starting up...")
@@ -1924,6 +1947,11 @@ class ChassisdDaemon(daemon_base.DaemonBase):
                 self.config_manager.task_run()
             else:
                 self.config_manager = None
+
+            # Replay saved admin down state for modular chassis supervisor on boot
+            if (not self.smartswitch and self.config_manager is not None and
+                    self.module_updater.supervisor_slot == self.module_updater.my_slot):
+                self.set_initial_module_admin_state()
 
             # Start main loop
             self.log_info("Start daemon main loop")

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -2043,6 +2043,7 @@ def test_submit_dpu_callback():
         daemon_chassisd.submit_dpu_callback(index, MODULE_ADMIN_DOWN)
         mock_set_admin_state_gracefully.assert_called_once_with(MODULE_ADMIN_DOWN)
 
+
 def test_chassis_daemon_assertion():
     chassis = MockChassis()
 
@@ -2071,6 +2072,7 @@ def test_chassis_daemon_assertion():
         time.sleep(1)
     else:
         assert False, "config_manager thread never died"
+
 
 def test_set_initial_module_admin_state_down():
     """Replay admin down for present fabric/line modules at boot."""
@@ -2141,3 +2143,51 @@ def test_set_initial_module_admin_state_up():
         mock_fabric_up.assert_not_called()
         mock_fabric_absent.assert_not_called()
         mock_supervisor.assert_not_called()
+
+
+def test_module_db_update_replays_admin_down_on_presence():
+    """Replay saved admin down when an absent fabric module becomes present."""
+    sup_slot = 16
+    module = MockModule(0, "FABRIC-CARD1", "Fabric card", ModuleBase.MODULE_TYPE_FABRIC,
+                        10, "FC1000101")
+    module.set_presence(False)
+    module.set_oper_status(ModuleBase.MODULE_STATUS_OFFLINE)
+
+    chassis = MockChassis()
+    chassis.get_supervisor_slot = Mock(return_value=sup_slot)
+    chassis.get_my_slot = Mock(return_value=sup_slot)
+    chassis.module_list.append(module)
+
+    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, sup_slot, sup_slot)
+    module_updater.modules_num_update()
+    module_updater.module_db_update()
+
+    module.set_presence(True)
+    with patch.object(module_updater, 'get_module_admin_status', return_value='down'), \
+         patch.object(module, 'set_admin_state') as mock_set_admin_state:
+        module_updater.module_db_update()
+
+    mock_set_admin_state.assert_called_once_with(MODULE_ADMIN_DOWN)
+
+
+def test_module_db_update_replays_admin_down_on_first_presence():
+    """Replay saved admin down when module is present on first STATE_DB update."""
+    sup_slot = 16
+    module = MockModule(0, "FABRIC-CARD1", "Fabric card", ModuleBase.MODULE_TYPE_FABRIC,
+                        10, "FC1000101")
+    module.set_presence(True)
+    module.set_oper_status(ModuleBase.MODULE_STATUS_OFFLINE)
+
+    chassis = MockChassis()
+    chassis.get_supervisor_slot = Mock(return_value=sup_slot)
+    chassis.get_my_slot = Mock(return_value=sup_slot)
+    chassis.module_list.append(module)
+
+    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, sup_slot, sup_slot)
+    module_updater.modules_num_update()
+
+    with patch.object(module_updater, 'get_module_admin_status', return_value='down'), \
+         patch.object(module, 'set_admin_state') as mock_set_admin_state:
+        module_updater.module_db_update()
+
+    mock_set_admin_state.assert_called_once_with(MODULE_ADMIN_DOWN)

--- a/sonic-chassisd/tests/test_chassisd.py
+++ b/sonic-chassisd/tests/test_chassisd.py
@@ -2071,3 +2071,73 @@ def test_chassis_daemon_assertion():
         time.sleep(1)
     else:
         assert False, "config_manager thread never died"
+
+def test_set_initial_module_admin_state_down():
+    """Replay admin down for present fabric/line modules at boot."""
+    fabric = MockModule(0, "FABRIC-CARD1", "Fabric card", ModuleBase.MODULE_TYPE_FABRIC,
+                        10, "FC1000101")
+    fabric.set_presence(True)
+    line = MockModule(1, "LINE-CARD0", "Line card", ModuleBase.MODULE_TYPE_LINE,
+                      1, "LC1000101")
+    line.set_presence(True)
+
+    chassis = MockChassis()
+    chassis.get_supervisor_slot = Mock(return_value=16)
+    chassis.get_my_slot = Mock(return_value=16)
+    chassis.module_list.extend([fabric, line])
+
+    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, 16, 16)
+    module_updater.modules_num_update()
+
+    daemon_chassisd = ChassisdDaemon(SYSLOG_IDENTIFIER, chassis)
+    daemon_chassisd.module_updater = module_updater
+    daemon_chassisd.platform_chassis = chassis
+    daemon_chassisd.smartswitch = False
+
+    with patch.object(module_updater, 'get_module_admin_status', return_value='down'), \
+         patch.object(fabric, 'set_admin_state') as mock_fabric_set_admin_state, \
+         patch.object(line, 'set_admin_state') as mock_line_set_admin_state:
+        daemon_chassisd.set_initial_module_admin_state()
+
+        mock_fabric_set_admin_state.assert_called_once_with(MODULE_ADMIN_DOWN)
+        mock_line_set_admin_state.assert_called_once_with(MODULE_ADMIN_DOWN)
+
+
+def test_set_initial_module_admin_state_up():
+    """Skip replay for up, absent, and non fabric/line modules."""
+    fabric_up = MockModule(0, "FABRIC-CARD1", "Fabric card", ModuleBase.MODULE_TYPE_FABRIC,
+                           10, "FC1000101")
+    fabric_up.set_presence(True)
+    fabric_absent = MockModule(1, "FABRIC-CARD2", "Fabric card", ModuleBase.MODULE_TYPE_FABRIC,
+                               11, "FC1000102")
+    fabric_absent.set_presence(False)
+    supervisor = MockModule(2, "SUPERVISOR0", "Supervisor", ModuleBase.MODULE_TYPE_SUPERVISOR,
+                            16, "RP1000101")
+    supervisor.set_presence(True)
+
+    chassis = MockChassis()
+    chassis.get_supervisor_slot = Mock(return_value=16)
+    chassis.get_my_slot = Mock(return_value=16)
+    chassis.module_list.extend([fabric_up, fabric_absent, supervisor])
+
+    module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, chassis, 16, 16)
+    module_updater.modules_num_update()
+
+    daemon_chassisd = ChassisdDaemon(SYSLOG_IDENTIFIER, chassis)
+    daemon_chassisd.module_updater = module_updater
+    daemon_chassisd.platform_chassis = chassis
+    daemon_chassisd.smartswitch = False
+
+    def admin_status_side_effect(module_name):
+        return 'up' if module_name == "FABRIC-CARD1" else 'down'
+
+    with patch.object(module_updater, 'get_module_admin_status',
+                      side_effect=admin_status_side_effect), \
+         patch.object(fabric_up, 'set_admin_state') as mock_fabric_up, \
+         patch.object(fabric_absent, 'set_admin_state') as mock_fabric_absent, \
+         patch.object(supervisor, 'set_admin_state') as mock_supervisor:
+        daemon_chassisd.set_initial_module_admin_state()
+
+        mock_fabric_up.assert_not_called()
+        mock_fabric_absent.assert_not_called()
+        mock_supervisor.assert_not_called()


### PR DESCRIPTION
Issue: https://github.com/sonic-net/sonic-platform-daemons/issues/868

<!-- Provide a general summary of your changes in the Title above -->

## Summary
- Add `set_initial_module_admin_state()` to replay persisted `admin_status: down` from CONFIG_DB at chassisd startup on modular chassis supervisors (8808 RP).
- For each present fabric/line module with saved admin down, call `set_admin_state(MODULE_ADMIN_DOWN)` so hardware shutdown is applied after reboot without a new config event.

#### Motivation and Context
After reboot, a module can remain `admin_status: down` in CONFIG_DB while oper stays Online because chassisd never replays the hardware shutdown. Z rails stay powered until a new shutdown config event is applied. This change replays the saved admin-down state once at supervisor boot, after config_manager starts and before the main loop.

#### How Has This Been Tested?
- DUT 8808 RP: config chassis modules shutdown FABRIC-CARD1 → sudo config save -y → reboot
- After pmon/chassisd up: FC1 admin=down, oper=Offline, rails off, no swss@2/3