### PR TITLE
[CPO] Add library functions that expose a mapping of CPO topology

### DIFF
--- a/sonic-xcvrd/tests/test_cpo.py
+++ b/sonic-xcvrd/tests/test_cpo.py
@@ -1,5 +1,8 @@
+import contextlib
+
 from unittest.mock import MagicMock, patch
 
+from sonic_py_common import device_info
 from xcvrd.xcvrd_utilities import common
 
 
@@ -100,3 +103,76 @@ class TestObjDictAccessors:
              patch.object(common, 'get_port_device', side_effect=mock_get_port_device):
             pluggable = common.get_pluggable_obj_dict(self._make_port_mapping())
         assert set(pluggable.keys()) == {0, 1}
+
+
+# Ethernet0 and Ethernet8 share OE1, while ELS1 is shared by all three interfaces
+CPO_DATA = {
+    'devices': {
+        'OE1': {'device_type': 'optical_engine', 'max_banks': 2},
+        'OE2': {'device_type': 'optical_engine', 'max_banks': 1},
+        'ELS1': {'device_type': 'external_laser_source', 'max_banks': 3, 'lasers': 8},
+    },
+    'interfaces': {
+        'Ethernet0': {'associated_devices': [{'device_id': 'OE1', 'bank': 0},
+                                             {'device_id': 'ELS1', 'bank': 0}]},
+        'Ethernet8': {'associated_devices': [{'device_id': 'OE1', 'bank': 1},
+                                             {'device_id': 'ELS1', 'bank': 1}]},
+        'Ethernet16': {'associated_devices': [{'device_id': 'OE2', 'bank': 0},
+                                              {'device_id': 'ELS1', 'bank': 2}]},
+    },
+}
+
+PLATFORM_DATA = {
+    'interfaces': {
+        'Ethernet0': {'index': '1,1,1,1,1,1,1,1'},
+        'Ethernet8': {'index': '2,2,2,2,2,2,2,2'},
+        'Ethernet16': {'index': '3,3,3,3,3,3,3,3'},
+    },
+}
+
+
+@contextlib.contextmanager
+def patched_topology(cpo_data=CPO_DATA, platform_data=PLATFORM_DATA):
+    """Serve the given platform topology, with the memoized topology cleared."""
+    common._build_cpo_topology.cache_clear()
+    try:
+        with patch.object(device_info, 'get_cpo_data', return_value=cpo_data, create=True) as mock_get_cpo_data, \
+             patch.object(device_info, 'get_platform_json_data', return_value=platform_data):
+            yield mock_get_cpo_data
+    finally:
+        common._build_cpo_topology.cache_clear()
+
+
+class TestCpoTopology:
+    def test_devices_of_pport_are_grouped_per_device(self):
+        with patched_topology():
+            assert common.get_cpo_devices_of_pport(1, common.CPO_DEVICE_TYPE_OE) == {'OE1': {1, 2}}
+            assert common.get_cpo_devices_of_pport(3, common.CPO_DEVICE_TYPE_OE) == {'OE2': {3}}
+            assert common.get_cpo_devices_of_pport(1, common.CPO_DEVICE_TYPE_ELSFP) == {'ELS1': {1, 2, 3}}
+
+            # No device of the requested type, and no device at all
+            assert common.get_cpo_devices_of_pport(1, 'no_such_device_type') == {}
+            assert common.get_cpo_devices_of_pport(99, common.CPO_DEVICE_TYPE_OE) == {}
+
+    def test_sibling_pports_grouped_per_device(self):
+        with patched_topology():
+            # OE1 drives physical ports 1 and 2, OE2 drives physical port 3
+            assert common.get_oe_sibling_pports(1) == {1, 2}
+            assert common.get_oe_sibling_pports(2) == {1, 2}
+            assert common.get_oe_sibling_pports(3) == {3}
+
+            # ELS1 provides the lasers for all three physical ports
+            assert common.get_elsfp_sibling_pports(1) == {1, 2, 3}
+            assert common.get_elsfp_sibling_pports(3) == {1, 2, 3}
+
+    def test_topology_is_memoized(self):
+        with patched_topology() as mock_get_cpo_data:
+            common.get_oe_sibling_pports(1)
+            common.get_elsfp_sibling_pports(1)
+            assert mock_get_cpo_data.call_count == 1
+
+    def test_only_self_returned_without_cpo_data(self):
+        with patched_topology(cpo_data=None):
+            assert common.get_oe_sibling_pports(1) == {1}
+            assert common.get_elsfp_sibling_pports(1) == {1}
+

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/common.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/common.py
@@ -13,7 +13,7 @@ try:
     import threading
     from dataclasses import dataclass
     from types import MappingProxyType
-    from typing import Any, Callable, Dict, FrozenSet, Mapping
+    from typing import Any, Callable, Dict, FrozenSet, Mapping, Set
     from swsscommon import swsscommon
     from sonic_py_common import syslogger, daemon_base, device_info, multi_asic
     from . import sfp_status_helper
@@ -207,10 +207,24 @@ def _build_cpo_topology() -> CpoTopology:
     Returns:
         CpoTopology: The platform topology, empty if cpo.json is not available.
     """
+    def freeze_topology(pports_by_device: Dict[str, Dict[str, Set[int]]],
+                        devices_by_pport: Dict[int, Set[str]]) -> CpoTopology:
+        """Convert the mutable topology accumulators into an immutable CpoTopology."""
+        frozen_pports_by_device = {}
+        for device_type, devices_of_type in pports_by_device.items():
+            frozen_devices_of_type = {device_id: frozenset(pports)
+                                      for device_id, pports in devices_of_type.items()}
+            frozen_pports_by_device[device_type] = MappingProxyType(frozen_devices_of_type)
+
+        frozen_devices_by_pport = {pport: frozenset(device_ids)
+                                   for pport, device_ids in devices_by_pport.items()}
+        return CpoTopology(MappingProxyType(frozen_pports_by_device),
+                           MappingProxyType(frozen_devices_by_pport))
+
     cpo_data = device_info.get_cpo_data()
     if not cpo_data:
         helper_logger.log_notice("CPO TOPOLOGY: no cpo.json data available")
-        return CpoTopology(MappingProxyType({}), MappingProxyType({}))
+        return freeze_topology({}, {})
 
     pports_by_device = {}
     devices_by_pport = {}
@@ -227,13 +241,7 @@ def _build_cpo_topology() -> CpoTopology:
             pports.setdefault(device_id, set()).add(pport)
             devices_by_pport.setdefault(pport, set()).add(device_id)
 
-    return CpoTopology(
-        pports_by_device=MappingProxyType({
-            device_type: MappingProxyType({device_id: frozenset(pports)
-                                           for device_id, pports in devices_of_type.items()})
-            for device_type, devices_of_type in pports_by_device.items()}),
-        devices_by_pport=MappingProxyType({pport: frozenset(device_ids)
-                                           for pport, device_ids in devices_by_pport.items()}))
+    return freeze_topology(pports_by_device, devices_by_pport)
 
 def get_cpo_devices_of_pport(physical_port: int, device_type: str) -> Dict[str, FrozenSet[int]]:
     """

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/common.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/common.py
@@ -7,12 +7,15 @@
 
 try:
     import sys
+    import functools
     import subprocess
     import traceback
     import threading
-    from typing import Callable, Dict
+    from dataclasses import dataclass
+    from types import MappingProxyType
+    from typing import Any, Callable, Dict, FrozenSet, Mapping
     from swsscommon import swsscommon
-    from sonic_py_common import syslogger, daemon_base, multi_asic
+    from sonic_py_common import syslogger, daemon_base, device_info, multi_asic
     from . import sfp_status_helper
     from .port_event_helper import PortMapping
     from sonic_platform_base.sonic_xcvr.api.public.c_cmis import CmisApi
@@ -46,6 +49,11 @@ platform_sfputil = None
 
 # Cache for thread-specific loggers to avoid creating multiple loggers for the same thread
 thread_loggers = {}
+
+# Useful constants for interpreting the contents of cpo.json
+CPO_DEVICE_TYPE_OE = 'optical_engine'
+CPO_DEVICE_TYPE_ELSFP = 'external_laser_source'
+
 
 def get_syslog_identifier_common():
     """Get syslog identifier based on current thread name, fallback to 'xcvrd_common'"""
@@ -114,7 +122,7 @@ def update_port_transceiver_status_table_sw(logical_port_name, status_sw_tbl, st
     fvs = swsscommon.FieldValuePairs([('status', status), ('error', error_descriptions)])
     status_sw_tbl.set(logical_port_name, fvs)
 
-def get_port_device(physical_port):
+def get_port_device(physical_port: int) -> Any:
     if platform_chassis is None:
         return None
     try:
@@ -128,7 +136,7 @@ def get_port_device(physical_port):
     except (NotImplementedError, AttributeError, IndexError):
         return None
 
-def is_cpo_port(physical_port):
+def is_cpo_port(physical_port: int) -> bool:
     if platform_chassis is None:
         return False
     try:
@@ -136,11 +144,11 @@ def is_cpo_port(physical_port):
     except (NotImplementedError, AttributeError, IndexError):
         return False
 
-def is_pluggable_port(physical_port):
+def is_pluggable_port(physical_port: int) -> bool:
     return not is_cpo_port(physical_port)
 
 def _get_port_obj_dict(port_mapping_data: PortMapping | None,
-                       port_filter: Callable[[int], bool]) -> Dict[int, object]:
+                       port_filter: Callable[[int], bool]) -> Dict[int, Any]:
     """
     Create a dictionary mapping physical ports to their corresponding device objects,
     restricted to the ports accepted by port_filter.
@@ -150,7 +158,7 @@ def _get_port_obj_dict(port_mapping_data: PortMapping | None,
         port_filter (Callable[[int], bool]): Predicate selecting the physical ports to include.
 
     Returns:
-        Dict[int, object]: A dictionary mapping physical ports to device objects.
+        Dict[int, Any]: A dictionary mapping physical ports to device objects.
     """
     if port_mapping_data is None or port_mapping_data.physical_to_logical is None:
         helper_logger.log_error("PORT OBJ INIT: Failed to get port mapping data")
@@ -166,13 +174,116 @@ def _get_port_obj_dict(port_mapping_data: PortMapping | None,
 
     return obj_dict
 
-def get_cpo_obj_dict(port_mapping_data):
+def get_cpo_obj_dict(port_mapping_data: PortMapping | None) -> Dict[int, Any]:
     """Create a dictionary mapping physical ports to their corresponding CPO objects."""
     return _get_port_obj_dict(port_mapping_data, is_cpo_port)
 
-def get_pluggable_obj_dict(port_mapping_data):
+def get_pluggable_obj_dict(port_mapping_data: PortMapping | None) -> Dict[int, Any]:
     """Create a dictionary mapping physical ports to their corresponding SFP objects."""
     return _get_port_obj_dict(port_mapping_data, is_pluggable_port)
+
+@dataclass(frozen=True)
+class CpoTopology:
+    """
+    The CPO devices of a platform and the physical ports they drive.
+
+    Attributes:
+        pports_by_device: {device type: {device id: physical ports the device drives}}
+        devices_by_pport: {physical port: ids of the devices driving the port}
+    """
+    pports_by_device: Mapping[str, Mapping[str, FrozenSet[int]]]
+    devices_by_pport: Mapping[int, FrozenSet[str]]
+
+@functools.cache
+def _build_cpo_topology() -> CpoTopology:
+    """
+    Build the CPO device topology of the platform.
+
+    The topology is described by cpo.json, which associates each platform.json
+    interface with the devices driving it, and platform.json, which maps
+    each of those interfaces to a physical port index. Both describe static
+    platform data, so the result is memoized for the lifetime of the process.
+
+    Returns:
+        CpoTopology: The platform topology, empty if cpo.json is not available.
+    """
+    cpo_data = device_info.get_cpo_data()
+    if not cpo_data:
+        helper_logger.log_notice("CPO TOPOLOGY: no cpo.json data available")
+        return CpoTopology(MappingProxyType({}), MappingProxyType({}))
+
+    pports_by_device = {}
+    devices_by_pport = {}
+
+    platform_interfaces = (device_info.get_platform_json_data() or {}).get('interfaces', {})
+    devices = cpo_data.get('devices') or {}
+
+    for ifname, if_data in (cpo_data.get('interfaces') or {}).items():
+        pport = int(str(platform_interfaces[ifname]['index']).split(',')[0].strip())
+
+        for associated_device in (if_data or {}).get('associated_devices') or []:
+            device_id = associated_device['device_id']
+            pports = pports_by_device.setdefault(devices[device_id]['device_type'], {})
+            pports.setdefault(device_id, set()).add(pport)
+            devices_by_pport.setdefault(pport, set()).add(device_id)
+
+    return CpoTopology(
+        pports_by_device=MappingProxyType({
+            device_type: MappingProxyType({device_id: frozenset(pports)
+                                           for device_id, pports in devices_of_type.items()})
+            for device_type, devices_of_type in pports_by_device.items()}),
+        devices_by_pport=MappingProxyType({pport: frozenset(device_ids)
+                                           for pport, device_ids in devices_by_pport.items()}))
+
+def get_cpo_devices_of_pport(physical_port: int, device_type: str) -> Dict[str, FrozenSet[int]]:
+    """
+    Get the CPO devices of the given type driving physical_port.
+
+    Args:
+        physical_port (int): Physical port index
+        device_type (str): cpo.json device type
+
+    Returns:
+        Dict[str, FrozenSet[int]]: {device id: all physical ports the device drives}, taken
+        straight from the immutable platform topology. Empty if the topology is not
+        available or no such device drives physical_port.
+    """
+    topology = _build_cpo_topology()
+    pports_by_device = topology.pports_by_device.get(device_type) or {}
+    return {device_id: pports_by_device[device_id]
+            for device_id in topology.devices_by_pport.get(physical_port, ())
+            if device_id in pports_by_device}
+
+def _get_sibling_pports(physical_port: int, device_type: str) -> FrozenSet[int]:
+    """
+    Get all physical ports sharing the given type of CPO device with physical_port.
+
+    Args:
+        physical_port (int): Physical port index
+        device_type (str): cpo.json device type
+
+    Returns:
+        FrozenSet[int]: Physical port indexes, always including physical_port itself.
+        Only physical_port is returned if the platform topology is not available.
+    """
+    siblings = {physical_port}
+    for pports in get_cpo_devices_of_pport(physical_port, device_type).values():
+        siblings.update(pports)
+    return frozenset(siblings)
+
+def get_oe_sibling_pports(physical_port: int) -> FrozenSet[int]:
+    """
+    Get all physical ports sharing an optical engine with physical_port, including
+    physical_port itself.
+    """
+    return _get_sibling_pports(physical_port, CPO_DEVICE_TYPE_OE)
+
+def get_elsfp_sibling_pports(physical_port: int) -> FrozenSet[int]:
+    """
+    Get all physical ports sharing an ELSFP with physical_port, including
+    physical_port itself.
+    """
+    return _get_sibling_pports(physical_port, CPO_DEVICE_TYPE_ELSFP)
 
 def is_copper(physical_port):
     """Check if the transceiver on the given physical port is copper"""


### PR DESCRIPTION
#### Description
This PR adds a set of functions that reads `cpo.json` and constructs a CPO device topology mapping for `xcvrd` to conveniently understand how optical engines and ELSFPs map to physical ports (and vice-versa) when dealing with CPO hardware.

#### Motivation and Context
Various parts of `xcvrd` need to be aware of the CPO device topology of a hardware platform in order to correctly function. For instance: the DOM task needs to avoid reading non-banked or clear-on-read information from the same device multiple times, even though that device may be shared across multiple logical interfaces and physical ports.

#### How Has This Been Tested?
This has been tested via newly added unit-tests.
