### PR TITLE
bmcctld: stop teeing routine logs to /var/log/syslog

### DIFF
--- a/sonic-bmcctld/scripts/bmcctld
+++ b/sonic-bmcctld/scripts/bmcctld
@@ -14,7 +14,8 @@
       - Operator admin up/down                  (STATE_DB: CHASSIS_MODULE)
 
     Classes:
-      EventLogger            Dual-output logger: syslog + /host/bmc/event.log.
+      EventLogger            Syslog logger that optionally tees to a file
+                             (/host/bmc/event.log for critical events).
                              All daemon classes inherit from this.
       ActionItem             Data class carrying a pending power action from the
                              event thread to the main thread via action_queue.
@@ -60,26 +61,37 @@ except ImportError as e:
     raise ImportError(str(e) + " - required module not found")
 
 
-DEFAULT_LOG_FILE = "/var/log/syslog"
 CRITICAL_EVENT_LOG_FILE = "/host/bmc/event.log"
 
 
 # This class could be moved to sonic-py-common, the log file name can be passed as input.
 class EventLogger(logger.Logger):
     """
-    Extends sonic_py_common Logger to tee every log call to a local file in
-    addition to syslog.  All bmcctld classes inherit from this so that
-    power-state transitions and event handling are recorded in a dedicated
-    log file that survives syslog rotation and is easy to grep offline.
+    Extends sonic_py_common Logger to optionally tee log calls to a local file
+    in addition to syslog.  A file is used only for critical power/leak/alert
+    events, which must survive syslog rotation and be easy to grep offline.
+
+    When log_file is None the instance logs to syslog only.  Container-local
+    files are not rotated by the host logrotate, so a file target must live on
+    a host-visible path that logrotate covers.
     """
 
-    def __init__(self, syslog_identifier, log_file=DEFAULT_LOG_FILE):
+    def __init__(self, syslog_identifier, log_file=None):
         super(EventLogger, self).__init__(syslog_identifier)
         # Derive a unique Python logger name per log file so instances writing
-        # to different files do not share handlers.
-        py_name = "{}.{}".format(syslog_identifier,
-                                 os.path.basename(log_file).replace(".", "_"))
+        # to different files do not share handlers.  Syslog-only instances
+        # share a single inert logger.
+        py_name = "{}.{}".format(
+            syslog_identifier,
+            os.path.basename(log_file).replace(".", "_") if log_file else "syslog_only")
         self._file_logger = logging.getLogger(py_name)
+        if log_file is None:
+            # Keep the logger inert so records are neither emitted nor
+            # propagated to the root logger.
+            self._file_logger.propagate = False
+            if not self._file_logger.handlers:
+                self._file_logger.addHandler(logging.NullHandler())
+            return
         if not self._file_logger.handlers and os.getenv("BMCCTLD_UNIT_TESTING") != "1":
             try:
                 handler = logging.FileHandler(log_file)
@@ -268,9 +280,9 @@ exit_code = 1
 CHASSIS_LOAD_ERROR = 1
 
 # Two global logger instances — initialised once and shared across the module.
-# Use _daemon_logger for routine operational messages (DEFAULT_LOG_FILE).
+# Use _daemon_logger for routine operational messages (syslog only).
 # Use _event_logger for critical power/leak/alert events (CRITICAL_EVENT_LOG_FILE).
-_daemon_logger = EventLogger(SYSLOG_IDENTIFIER, DEFAULT_LOG_FILE)
+_daemon_logger = EventLogger(SYSLOG_IDENTIFIER)
 _event_logger = EventLogger(SYSLOG_IDENTIFIER, CRITICAL_EVENT_LOG_FILE)
 
 # ============================================================
@@ -554,7 +566,7 @@ class PolicyReader(EventLogger):
     """Reads bmcctld timing and leak policy configuration from CONFIG_DB."""
 
     def __init__(self):
-        super(PolicyReader, self).__init__(SYSLOG_IDENTIFIER, DEFAULT_LOG_FILE)
+        super(PolicyReader, self).__init__(SYSLOG_IDENTIFIER)
         self.config_db = daemon_base.db_connect("CONFIG_DB")
 
     def _get_chassis_module_entry(self):
@@ -690,7 +702,7 @@ class GracefulShutdownHandler(EventLogger):
     """
 
     def __init__(self, controller, policy_reader):
-        super(GracefulShutdownHandler, self).__init__(SYSLOG_IDENTIFIER, DEFAULT_LOG_FILE)
+        super(GracefulShutdownHandler, self).__init__(SYSLOG_IDENTIFIER)
         self._event_log = _event_logger  # for critical leak / alert events only
         self.controller = controller
         self.policy_reader = policy_reader
@@ -808,7 +820,7 @@ class BmcEventHandler(EventLogger):
 
     def __init__(self, action_queue, policy_reader, critical_event_checker, stop_event,
                  controller):
-        super(BmcEventHandler, self).__init__(SYSLOG_IDENTIFIER, DEFAULT_LOG_FILE)
+        super(BmcEventHandler, self).__init__(SYSLOG_IDENTIFIER)
         self._event_log = _event_logger  # for critical leak / alert events only
         self.action_queue = action_queue
         self.policy_reader = policy_reader

--- a/sonic-bmcctld/tests/test_bmcctld.py
+++ b/sonic-bmcctld/tests/test_bmcctld.py
@@ -1575,3 +1575,40 @@ class TestChassisModuleInfo:
         cfg = dict(result[1])
         assert cfg[bmcctld.CHASSIS_MODULE_INFO_ADMIN_STATUS_FIELD] == bmcctld.ADMIN_DOWN
 
+
+# --------------------------------------------------------------------------
+# Tests: EventLogger file target
+# --------------------------------------------------------------------------
+
+class TestEventLogger:
+    """EventLogger must not tee to a container-local, unrotated file."""
+
+    def test_no_default_log_file_constant(self):
+        """The /var/log/syslog tee target is gone."""
+        assert not hasattr(bmcctld, 'DEFAULT_LOG_FILE')
+        assert bmcctld.CRITICAL_EVENT_LOG_FILE == "/host/bmc/event.log"
+
+    def test_syslog_only_logger_has_no_file_handler(self):
+        """Omitting log_file leaves a non-propagating logger with no file target.
+
+        Only handlers[0] is inspected: pytest's logging plugin appends its own
+        capture handlers to every logger.
+        """
+        import logging as _logging
+        el = bmcctld.EventLogger(bmcctld.SYSLOG_IDENTIFIER)
+        assert el._file_logger.propagate is False
+        assert isinstance(el._file_logger.handlers[0], _logging.NullHandler)
+
+    def test_syslog_only_logger_still_logs(self):
+        """Log calls on a syslog-only instance do not raise."""
+        el = bmcctld.EventLogger(bmcctld.SYSLOG_IDENTIFIER)
+        el.log_debug("d")
+        el.log_info("i")
+        el.log_notice("n")
+        el.log_warning("w")
+        el.log_error("e")
+
+    def test_module_loggers_target_expected_files(self):
+        """_daemon_logger is syslog-only; _event_logger keeps the host file."""
+        assert bmcctld._daemon_logger._file_logger.name.endswith("syslog_only")
+        assert bmcctld._event_logger._file_logger.name.endswith("event_log")


### PR DESCRIPTION
### Why i did it?
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/28982
Fixes: https://github.com/sonic-net/sonic-platform-daemons/issues/872

> - bmcctld FileHandler currently has no log rotation mechanism, making it the only unrotated writer to syslog within PMON. The write volume is low, but the log is effectively bounded only by the event rate.
> - EventLogger tees every log call to DEFAULT_LOG_FILE = "/var/log/syslog" using a plain logging.FileHandler, without any maxBytes or backupCount. This path lives in PMON’s writable overlay, so the host’s logrotate cannot manage it, and PMON does not have a cron-based rotation mechanism. As a result, it is the only file in the container without any form of rotation. Since the file is append-only and persists across reboots, it can grow monotonically over the lifetime of the device.

### How i did it ?

> remove the tee to /var/log/syslog rather than adding a RotatingFileHandler. EventLogger already invokes the base class before touching the file on every logging method, so the messages are already handled through the normal logging path, which would avoid maintaining a separate unrotated file

### How to verify?
```
docker exec pmon ls -la /var/log/syslog
```

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
